### PR TITLE
Fix generating model directory error for tensorflow estimator.

### DIFF
--- a/dlrover/trainer/tensorflow/executor/estimator_executor.py
+++ b/dlrover/trainer/tensorflow/executor/estimator_executor.py
@@ -65,10 +65,12 @@ class EstimatorExecutor(BaseExecutor):
         self._prepare_estimator_class()
         self._prepare_estimator()
 
-
     def gen_model_dir(self):
         self._model_dir = self._task_conf.get(TFConstants.ModelDir.name)
-        if not os.path.exists(self._model_dir) and self.task_type==TFConstants.Chief():
+        if (
+            not os.path.exists(self._model_dir)
+            and self.task_type == TFConstants.Chief()
+        ):
             os.makedirs(self._model_dir)
 
     def _initialize_estimator_related(self):


### PR DESCRIPTION
The error is 
![image](https://user-images.githubusercontent.com/107838921/217693033-07612774-c796-4f08-9f03-78e1a38c56ec.png)

When preparing estimator, model_dir for checkpoints and saved models needed to be generated. Only chief worker checks whether model_dir exists or not. If model_dir doesn't, chief worker creates the model dir.
