### PR TITLE
fix dependency conflicts caused by auto best match during "python setup.py install"

### DIFF
--- a/dlrover/requirements.txt
+++ b/dlrover/requirements.txt
@@ -1,6 +1,7 @@
 grpcio==1.34.1
 grpcio-tools==1.34.1
-protobuf>=3.12.0
+protobuf>=3.15.3,<4.0dev
 psutil
+urllib3<1.27,>=1.21.1
 kubernetes
 ray


### PR DESCRIPTION
python env : conda virtual env python 3.8
During running python setup.py install
![image](https://user-images.githubusercontent.com/67818399/227703159-91f25a0c-6362-4d19-8b3b-f81ddc39cb64.png)
Because the kubernetes requires a urllib3 verision >=1.24.2, the auto best match version could be 2.0.0a. Here comes the conflict.
![image](https://user-images.githubusercontent.com/67818399/227703424-3affaf6e-b25e-4d89-b663-454c6adc4c18.png)
I modified the requirement.txt to avoid the conflicts.
