### PR TITLE
Add tutorial to enable GPU support on minikube cluster.

### DIFF
--- a/dlrover/examples/torch_mnist_master_backend_job.yaml
+++ b/dlrover/examples/torch_mnist_master_backend_job.yaml
@@ -17,6 +17,11 @@ spec:
               # yamllint disable-line rule:line-length
               image: registry.cn-hangzhou.aliyuncs.com/intell-ai/dlrover:torch113-mnist
               imagePullPolicy: Always
+              resources:
+                requests:
+                  nvidia.com/gpu: 1 
+                limits:
+                  nvidia.com/gpu: 1 # requesting 1 GPU
               command:
                 - /bin/bash
                 - -c
@@ -26,6 +31,10 @@ spec:
                 model_zoo/pytorch/mnist_cnn.py \
                 --training_data /data/mnist_png/training/elastic_ds.txt \
                 --validation_data /data/mnist_png/testing/elastic_ds.txt"
+          tolerations:
+          - key: nvidia.com/gpu
+            operator: Exists
+            effect: NoSchedule
     dlrover-master:
       template:
         spec:

--- a/dlrover/examples/torch_mnist_master_backend_job.yaml
+++ b/dlrover/examples/torch_mnist_master_backend_job.yaml
@@ -31,10 +31,15 @@ spec:
                 model_zoo/pytorch/mnist_cnn.py \
                 --training_data /data/mnist_png/training/elastic_ds.txt \
                 --validation_data /data/mnist_png/testing/elastic_ds.txt"
-          tolerations:
-          - key: nvidia.com/gpu
-            operator: Exists
-            effect: NoSchedule
+              resources:
+                limits:
+                  cpu: "1"
+                  memory: 2Gi
+                  nvidia.com/gpu: 1
+                requests:
+                  cpu: "1"
+                  memory: 2Gi
+                  nvidia.com/gpu: 1
     dlrover-master:
       template:
         spec:

--- a/dlrover/examples/torch_mnist_master_backend_job.yaml
+++ b/dlrover/examples/torch_mnist_master_backend_job.yaml
@@ -17,20 +17,15 @@ spec:
               # yamllint disable-line rule:line-length
               image: registry.cn-hangzhou.aliyuncs.com/intell-ai/dlrover:torch113-mnist
               imagePullPolicy: Always
-              resources:
-                requests:
-                  nvidia.com/gpu: 1 
-                limits:
-                  nvidia.com/gpu: 1 # requesting 1 GPU
               command:
                 - /bin/bash
                 - -c
                 - "python -m dlrover.python.elastic_agent.torch.prepare \
-                && torchrun --nnodes=1:$WORKER_NUM --nproc_per_node=1
-                --max_restarts=3 --rdzv_backend=dlrover-master \
-                model_zoo/pytorch/mnist_cnn.py \
-                --training_data /data/mnist_png/training/elastic_ds.txt \
-                --validation_data /data/mnist_png/testing/elastic_ds.txt"
+                  && torchrun --nnodes=1:$WORKER_NUM --nproc_per_node=1
+                  --max_restarts=3 --rdzv_backend=dlrover-master \
+                  model_zoo/pytorch/mnist_cnn.py \
+                  --training_data /data/mnist_png/training/elastic_ds.txt \
+                  --validation_data /data/mnist_png/testing/elastic_ds.txt"
               resources:
                 limits:
                   cpu: "1"

--- a/dlrover/examples/torch_mnist_master_backend_job.yaml
+++ b/dlrover/examples/torch_mnist_master_backend_job.yaml
@@ -30,11 +30,9 @@ spec:
                 limits:
                   cpu: "1"
                   memory: 2Gi
-                  nvidia.com/gpu: 1
                 requests:
                   cpu: "1"
                   memory: 2Gi
-                  nvidia.com/gpu: 1
     dlrover-master:
       template:
         spec:

--- a/dlrover/go/operator/config/gpu/nvidia-device-plugin-gpu-shared.yaml
+++ b/dlrover/go/operator/config/gpu/nvidia-device-plugin-gpu-shared.yaml
@@ -1,0 +1,6 @@
+version: v1
+sharing:
+  timeSlicing:
+    resources:
+    - name: nvidia.com/gpu
+      replicas: 2

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -47,9 +47,20 @@ Install [minikube](https://kubernetes.io/docs/tasks/tools/) on your loptop.
 
 #### Minikube with GPU Support
 
-To enable GPU support follow the doc to install [containerd](https://github.com/containerd/containerd/blob/main/docs/getting-started.md) and [NVIDIA Container Toolkit](https://github.com/NVIDIA/nvidia-docker) then enable [k8s-device-plugin](https://github.com/NVIDIA/k8s-device-plugin#preparing-your-gpu-nodes) and test your GPU by the official [gpu-pod](https://github.com/NVIDIA/k8s-device-plugin#running-gpu-jobs)
+To enable GPU support, follow the doc as follows:
 
-It is highly recommended to have more than one GPU resource in your workspace. However, there is still a workaround to divide your singie GPU resource into multiple ones. For this, enable [shared-access-to-gpus with CUDA Time-Slicing](https://github.com/NVIDIA/k8s-device-plugin#shared-access-to-gpus-with-cuda-time-slicing) to get more GPU resources.
+- install [containerd](https://github.com/containerd/containerd/blob/main/docs/getting-started.md)
+and [NVIDIA Container Toolkit](https://github.com/NVIDIA/nvidia-docker)
+- Enable [k8s-device-plugin](https://github.com/NVIDIA/k8s-device-plugin#preparing-your-gpu-nodes)
+
+- Test your GPU by the official [gpu-pod](https://github.com/NVIDIA/k8s-device-plugin#running-gpu-jobs)
+
+It is highly recommended to have more than one GPU resource in your workspace.
+
+However, there is still a workaround to divide your singie GPU resource into multiple ones.
+
+For this, enable [shared-access-to-gpus with CUDA Time-Slicing](https://github.com/NVIDIA/k8s-device-plugin#shared-access-to-gpus-with-cuda-time-slicing) to get more GPU resources.
+
 Check the doc and modify your ``nvidia-k8s-device-plugin`` or simply update the plugin by ``helm`` with the command
 
 ```bash

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -49,7 +49,18 @@ Install [minikube](https://kubernetes.io/docs/tasks/tools/) on your loptop.
 
 To enable GPU support follow the doc to install [containerd](https://github.com/containerd/containerd/blob/main/docs/getting-started.md) and [NVIDIA Container Toolkit](https://github.com/NVIDIA/nvidia-docker) then enable [k8s-device-plugin](https://github.com/NVIDIA/k8s-device-plugin#preparing-your-gpu-nodes) and test your GPU by the official [gpu-pod](https://github.com/NVIDIA/k8s-device-plugin#running-gpu-jobs)
 
-It is highly recommended to have more than one GPU resource in your workspace. However, there is still a workaround to divide your singie GPU resource into multiple ones. For this, enable [shared-access-to-gpus with CUDA Time-Slicing](https://github.com/NVIDIA/k8s-device-plugin#shared-access-to-gpus-with-cuda-time-slicing) to get more GPU resources. Then test your GPU resources by
+It is highly recommended to have more than one GPU resource in your workspace. However, there is still a workaround to divide your singie GPU resource into multiple ones. For this, enable [shared-access-to-gpus with CUDA Time-Slicing](https://github.com/NVIDIA/k8s-device-plugin#shared-access-to-gpus-with-cuda-time-slicing) to get more GPU resources.
+Check the doc and modify your ``nvidia-k8s-device-plugin`` or simply update the plugin by ``helm`` with the command
+
+```bash
+$ helm upgrade -i nvdp nvdp/nvidia-device-plugin \
+    --version=0.13.0 \
+    --namespace nvidia-device-plugin \
+    --create-namespace \
+    --set-file config.map.config=./dlrover/go/operator/config/gpu
+```
+
+Then test your GPU resources by
 
 ```bash
 $ kubectl get nodes -ojson | jq .items[].status.capacity

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -36,15 +36,22 @@ go mod vendor
 ```
 
 ## Running the Operator Locally
+
 Running the operator locally (as opposed to deploying it on a K8s cluster) is convenient for debugging/development.
 
 ### 1. Preliminary
 
 Install [minikube](https://kubernetes.io/docs/tasks/tools/) on your loptop.
-And you can start minikube by the command
+(To enable GPU support follow the doc to install [containerd](https://github.com/containerd/containerd/blob/main/docs/getting-started.md) and [NVIDIA Container Toolkit](https://github.com/NVIDIA/nvidia-docker) then enable [k8s-device-plugin](https://github.com/NVIDIA/k8s-device-plugin#preparing-your-gpu-nodes) and test your GPU by the official [gpu-pod](https://github.com/NVIDIA/k8s-device-plugin#running-gpu-jobs))
+
+After preparing your minikube cluster you can start minikube with the command:
 
 ```bash
 minikube start --vm-driver=docker --cpus 6 --memory 6144
+
+# If you wish to run minikube with GPUs, recommended commands are as follows.(root privilege requried)
+
+minikube start --driver=none --container-runtime='containerd' --apiserver-ips 127.0.0.1 --apiserver-name localhost --cpus 6 --memory 6144
 ```
 
 ### Configure KUBECONFIG and KUBEFLOW_NAMESPACE
@@ -58,7 +65,6 @@ export KUBEFLOW_NAMESPACE=$(your_namespace)
 ```
 
 - KUBEFLOW_NAMESPACE is used when deployed on Kubernetes, we use this variable to create other resources (e.g. the resource lock) internal in the same namespace. It is optional, use `default` namespace if not set.
-
 
 ### 2. Run ElasticJob Controller
 
@@ -114,6 +120,7 @@ elasticjob-sample-edljob-worker-1     1/1     Running   0          2m42s
 ```
 
 ### 6. Create a release
+
 Change pip version and docker image tag when creating a new release.
 
 ## Go version


### PR DESCRIPTION
Enabling GPU support on the minikube cluster is meaningful for personal developers without access to a bare-metal K8s cluster.
So the tutorial was added.