### PR TITLE
Fix tutorial yaml file naming.

### DIFF
--- a/docs/deployment/controller.md
+++ b/docs/deployment/controller.md
@@ -36,7 +36,7 @@ pod/dlrover-controller-manager-7dccdf6c4d-grmks   2/2     Running   0          6
 ## 4. Test Your Controller by Submitting A Mnist Training Job
 
 ```bash
-kubectl -n dlrover apply -f dlrover/examples/torch_mnist.yaml
+kubectl -n dlrover apply -f dlrover/examples/torch_mnist_job.yaml
 ```
 
 Check traning nodes.

--- a/docs/tutorial/torch_allreduce_on_cloud.md
+++ b/docs/tutorial/torch_allreduce_on_cloud.md
@@ -28,7 +28,7 @@ kubectl -n dlrover apply -f dlrover/go/operator/config/rbac/default_role.yaml
 - Submit a job to train a CNN model with MNIST dataset.
 
 ```bash
-kubectl -n dlrover apply -f dlrover/examples/torch_mnist.yaml
+kubectl -n dlrover apply -f dlrover/examples/torch_mnist_job.yaml
 ```
 
 - Check the job status


### PR DESCRIPTION
Name in the tutorial mismatch the file name.
![image](https://github.com/intelligent-machine-learning/dlrover/assets/67818399/789200e7-9505-4482-bdb9-2edf3a721c98)