### PR TITLE
Fix num_nodes_waiting function argument issue.

### DIFF
--- a/dlrover/python/elastic_agent/master_client.py
+++ b/dlrover/python/elastic_agent/master_client.py
@@ -567,7 +567,7 @@ class LocalMasterClient(object):
     def report_used_resource(self, memory, cpu):
         return empty_pb2.Empty()
 
-    def num_nodes_waiting(self):
+    def num_nodes_waiting(self, rdzv_name=""):
         return 0
 
     def join_rendezvous(


### PR DESCRIPTION
Fix #505.
`Log after fixing`:
```log
WARNING:torch.distributed.run:
*****************************************
Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
*****************************************
[2023-07-18 14:31:22,175] [INFO] [training.py:436:launch_agent] Starting elastic_operator with launch configs:
  entrypoint       : model_zoo/pytorch/mnist_cnn.py
  min_nodes        : 1
  max_nodes        : 1
  nproc_per_node   : 2
  run_id           : none
  rdzv_backend     : static
  rdzv_endpoint    : 127.0.0.1:29500
  rdzv_configs     : {'rank': 0, 'timeout': 900, 'node_unit': 1}
  max_restarts     : 3
  monitor_interval : 5
  log_dir          : None
  metrics_cfg      : {}

[2023-07-18 14:31:22,177] [INFO] [training.py:336:_invoke_run] [default] starting workers for entrypoint: python
[2023-07-18 14:31:22,177] [INFO] [training.py:123:next_rendezvous] The node node_name attempts to join the next round of the rendezvous 'elastic' with timeout 600.
[2023-07-18 14:31:22,177] [INFO] [training.py:138:next_rendezvous] The node has joined round 0 of the elastic rendezvous as rank 0 in a world of size 1.
[2023-07-18 14:31:22,178] [INFO] [master_client.py:595:kv_store_set] {'elastic/torch.rendezvous.elastic.0.0/MASTER_ADDR': b'127.0.1.1'}
[2023-07-18 14:31:22,178] [INFO] [master_client.py:595:kv_store_set] {'elastic/torch.rendezvous.elastic.0.0/MASTER_ADDR': b'127.0.1.1', 'elastic/torch.rendezvous.elastic.0.0/MASTER_PORT': b'56315'}
[2023-07-18 14:31:22,178] [INFO] [training.py:245:_rendezvous] [default] Rendezvous complete for workers. Result:
  restart_count=0
  master_addr=127.0.1.1
  master_port=56315
  group_rank=0
  group_world_size=1
  local_ranks=[0, 1]
  role_ranks=[0, 1]
  global_ranks=[0, 1]
  role_world_sizes=[2, 2]
  global_world_sizes=[2, 2]

rank 0 is initialized local_rank = 0
rank 1 is initialized local_rank = 1
Running basic DDP example on local rank 1.
Running basic DDP example on local rank 0.
Model device cuda:0Model device cuda:1

[2023-07-18 14:31:25,673] [INFO] [elastic_sampler.py:112:load_state_dict] Load epoch = 1, completed num = 51200, num_samples = 4400
[2023-07-18 14:31:26,245] [INFO] [elastic_sampler.py:112:load_state_dict] Load epoch = 1, completed num = 51200, num_samples = 4400
[2023-07-18 14:31:27,200] [INFO] [training.py:151:num_nodes_waiting] self_name:elastic
[2023-07-18 14:31:27,201] [INFO] [training.py:153:num_nodes_waiting] self_name_type:<class 'str'>
loss = 0.08425028622150421, step = 0
loss = 0.034735605120658875, step = 20
loss = 0.08101857453584671, step = 40
loss = 0.2105797976255417, step = 60
loss = 0.08669748157262802, step = 80
loss = 0.054297395050525665, step = 100
loss = 0.020621852949261665, step = 120
Test model after epoch 1
Test the model ...
[2023-07-18 14:31:32,206] [INFO] [training.py:151:num_nodes_waiting] self_name:elastic
[2023-07-18 14:31:32,206] [INFO] [training.py:153:num_nodes_waiting] self_name_type:<class 'str'>
[2023-07-18 14:31:37,211] [INFO] [training.py:151:num_nodes_waiting] self_name:elastic
[2023-07-18 14:31:37,211] [INFO] [training.py:153:num_nodes_waiting] self_name_type:<class 'str'>

Test set: Average loss: 0.0452, Accuracy: 59162/60000 (99%)

[2023-07-18 14:31:42,217] [INFO] [training.py:358:_invoke_run] [default] worker group successfully finished. Waiting 300 seconds for other agents to finish.
[2023-07-18 14:31:42,218] [INFO] [master_client.py:595:kv_store_set] {'elastic/torch.rendezvous.elastic.0.0/MASTER_ADDR': b'127.0.1.1', 'elastic/torch.rendezvous.elastic.0.0/MASTER_PORT': b'56315', 'elastic/torch.rendezvous.elastic.0.0/torchelastic/agent/terminal_state0': b'0'}
[2023-07-18 14:31:42,218] [INFO] [master_client.py:595:kv_store_set] {'elastic/torch.rendezvous.elastic.0.0/MASTER_ADDR': b'127.0.1.1', 'elastic/torch.rendezvous.elastic.0.0/MASTER_PORT': b'56315', 'elastic/torch.rendezvous.elastic.0.0/torchelastic/agent/terminal_state0': b'0', 'elastic/torch.rendezvous.elastic.0.0/torchelastic/agent/terminal_state0.FIN': b'FIN'}
```

`UT result`:
```
======================= 98 passed, 3 warnings in 45.25s ========================
```

3 warnings are mentioned in #506. And they are not relative with this PR.

`Job Test result`:
It is a local version of master_client, no job submission is needed.
