### PR TITLE
fix(docs): update pytorch training tutorial doc

### DIFF
--- a/docs/tutorial/pytorch_training.md
+++ b/docs/tutorial/pytorch_training.md
@@ -12,22 +12,6 @@ Using elastic training of DLRover, users only need to set the
 `ElasticDistributedSampler` into their training `DataLoader`
 and checkpoint the sampler when checkpointing the model.
 
-### Setup the Environment Using ElasticTrainer
-
-Users need to set up the environment through `setup_master_addr`
-because the pod with rank-0 in an elastic training job may
-changes.
-
-The `setup_master_addr` will mark the rank-0 node as PyTorch MASTER
-and the node's IP as `MASTER_ADDR`. Note that, the ranks of all nodes
-are not fixed during elasticity and the rank-0 node is always marked as MASTER.
-
-```python
-from dlrover.trainer.torch.elastic import setup_master_addr
-
-setup_master_addr()
-```
-
 ### Setup ElasticDistributedSampler into the Dataloader.
 
 


### PR DESCRIPTION
```
from dlrover.trainer.torch.elastic import setup_master_addr

setup_master_addr()
```
The above syntax has been deprecated.