### PR TITLE
[#538]Add device_type function and warning messages

### DIFF
--- a/model_zoo/pytorch/nanogpt/train.py
+++ b/model_zoo/pytorch/nanogpt/train.py
@@ -14,7 +14,6 @@
 
 import argparse
 import contextlib
-import logging
 import math
 import os
 import pickle
@@ -319,15 +318,13 @@ def train():
         # Termination conditions
         if iter_num > max_iters:
             break
-
+        
 # Determine the device type based on the input string.
 def device_type(string):
-    logging.basicConfig(level=logging.WARNING)
-    
     lower_string = string.lower()
     if "gpu" in lower_string or "cuda" in lower_string:
         if lower_string != "cuda":
-            logging.warning(
+            log_rank0(
                 "It seems you are trying to use a cuda device."
                 "The correct argument should be \"cuda\"."
                 "Automatically using the cuda device."
@@ -335,12 +332,12 @@ def device_type(string):
         return "cuda"
     else:
         if lower_string != "cpu":
-            logging.warning(
+            log_rank0(
                 f"Unrecognized device type argument \"{lower_string}\"."
                 "Defaulting to use the cpu device."
             )
         return "cpu"
-        
+
 def arg_parser():
     parser = argparse.ArgumentParser(description="Process training parameters")
 

--- a/model_zoo/pytorch/nanogpt/train.py
+++ b/model_zoo/pytorch/nanogpt/train.py
@@ -319,7 +319,24 @@ def train():
         if iter_num > max_iters:
             break
 
-
+def device_type(string):
+    lower_string = string.lower()
+    if "gpu" in lower_string or "cuda" in lower_string:
+        if lower_string != "cuda":
+            print(
+                "Warning: It seems you are trying to use a cuda device."
+                "The correct argument should be \"cuda\"."
+                "Automatically using the cuda device."
+            )
+        return "cuda"
+    else:
+        if lower_string != "cpu":
+            print(
+                f"Warning: Unrecognized device type argument \"{lower_string}\"."
+                "Defaulting to use the cpu device."
+            )
+        return "cpu"
+        
 def arg_parser():
     parser = argparse.ArgumentParser(description="Process training parameters")
 
@@ -369,7 +386,7 @@ def arg_parser():
     parser.add_argument("--min_lr", type=float, default=6e-5, required=False)
 
     # System settings
-    parser.add_argument("--device", type=str, default="cpu", required=False)
+    parser.add_argument("--device", type=device_type, default="cpu", required=False)
     parser.add_argument("--compile", type=str, default="False", required=False)
 
     args = parser.parse_args()

--- a/model_zoo/pytorch/nanogpt/train.py
+++ b/model_zoo/pytorch/nanogpt/train.py
@@ -14,6 +14,7 @@
 
 import argparse
 import contextlib
+import logging
 import math
 import os
 import pickle
@@ -319,20 +320,23 @@ def train():
         if iter_num > max_iters:
             break
 
+# Determine the device type based on the input string.
 def device_type(string):
+    logging.basicConfig(level=logging.WARNING)
+    
     lower_string = string.lower()
     if "gpu" in lower_string or "cuda" in lower_string:
         if lower_string != "cuda":
-            print(
-                "Warning: It seems you are trying to use a cuda device."
+            logging.warning(
+                "It seems you are trying to use a cuda device."
                 "The correct argument should be \"cuda\"."
                 "Automatically using the cuda device."
             )
         return "cuda"
     else:
         if lower_string != "cpu":
-            print(
-                f"Warning: Unrecognized device type argument \"{lower_string}\"."
+            logging.warning(
+                f"Unrecognized device type argument \"{lower_string}\"."
                 "Defaulting to use the cpu device."
             )
         return "cpu"

--- a/model_zoo/pytorch/nanogpt/train.py
+++ b/model_zoo/pytorch/nanogpt/train.py
@@ -386,7 +386,14 @@ def arg_parser():
     parser.add_argument("--min_lr", type=float, default=6e-5, required=False)
 
     # System settings
-    parser.add_argument("--device", type=device_type, default="cpu", required=False)
+    parser.add_argument(
+                        "--device", type=device_type, default="cpu", required=False,
+                        help="""
+                        The device to use for computation. 
+                        Choose from 'cuda' or 'cpu'. 
+                        Defaults to 'cpu' if not specified.
+                        """
+    )
     parser.add_argument("--compile", type=str, default="False", required=False)
 
     args = parser.parse_args()


### PR DESCRIPTION
To improve the extensibility of parameters, this PR adds the device_type function that can recognize various input device types such as "gpu", "GPU0", "GPU1", "cuda01", etc., and automatically uses the "cuda" device. If the input device type is not recognized, it defaults to using the "cpu" device.
This change provides a better user experience.