### PR TITLE
Exclude grpc.py for black and isort.

### DIFF
--- a/atorch/.pre-commit-config.yaml
+++ b/atorch/.pre-commit-config.yaml
@@ -4,11 +4,13 @@ repos:
     rev: v5.10.1
     hooks:
       - id: isort
+        exclude: _pb2.py|_pb2_grpc.py
         args: [--settings-path, atorch/]
   - repo: https://github.com/psf/black
     rev: 22.6.0
     hooks:
       - id: black
+        exclude: _pb2.py|_pb2_grpc.py
         args: [--line-length=120]
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.4.0

--- a/atorch/.pre-commit-config.yaml
+++ b/atorch/.pre-commit-config.yaml
@@ -18,7 +18,8 @@ repos:
       - id: flake8
         exclude: __init__.py|_pb2.py|_pb2_grpc.py
         args: [
-          "--max-line-length=120", 
+          "--max-line-length=120",
+          "--ignore=E721",
         ]
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.900

--- a/atorch/.pre-commit-config.yaml
+++ b/atorch/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
         exclude: __init__.py|_pb2.py|_pb2_grpc.py
         args: [
           "--max-line-length=120",
-          "--ignore=E721",
+          "--ignore=E721,W503",
         ]
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.900


### PR DESCRIPTION
### What changes were proposed in this pull request?

The black and isort hook excludes *._pb_grpc.py

