### PR TITLE
Fix mypy's version in pre-commit.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     hooks:
       - id: flake8
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.701
+    rev: v1.2.0
     hooks:
       - id: mypy
         args: [--ignore-missing-imports, --follow-imports=skip]


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix deprecated mypy version in pre-commit yaml.

### Why are the changes needed?

Developers may meet failing in `pre-commit run -a` . 

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

Test by running `pre-commit run -a` in CI docker successfully. 
