### PR TITLE
Parse PS memory from the PodResource of plan.

### DIFF
--- a/dlrover/python/master/resource/job.py
+++ b/dlrover/python/master/resource/job.py
@@ -351,7 +351,7 @@ class PSJobResourceOptimizer(JobResourceOptimizer):
         plan = self._resource_optimizer.generate_oom_recovery_plan(
             [node], JobOptStage.PS_INITIAL
         )
-        if plan and not plan.empty():
+        if plan and not plan.empty() and node.name in plan.node_resources:
             resource = plan.node_resources[node.name]
             self._ps_resource.node_resource.memory = max(
                 self._ps_resource.node_resource.memory,

--- a/dlrover/python/master/resource/job.py
+++ b/dlrover/python/master/resource/job.py
@@ -352,10 +352,10 @@ class PSJobResourceOptimizer(JobResourceOptimizer):
             [node], JobOptStage.PS_INITIAL
         )
         if plan and not plan.empty():
-            ps = plan.node_group_resources[NodeType.PS]
+            resource = plan.node_resources[node.name]
             self._ps_resource.node_resource.memory = max(
                 self._ps_resource.node_resource.memory,
-                ps.node_resource.memory,
+                resource.memory,
             )
         cur_mem = node.config_resource.memory
         cur_mem *= NodeResourceLimit.INCREMENTAL_MEMORY_FACTOR

--- a/dlrover/python/tests/test_resource_optimizer.py
+++ b/dlrover/python/tests/test_resource_optimizer.py
@@ -43,9 +43,8 @@ class MockStub(object):
     def optimize(self, request):
         res = brain_pb2.OptimizeResponse()
         res.job_optimize_plans.add()
-        group_resources = res.job_optimize_plans[
-            0
-        ].resource.task_group_resources
+        plan = res.job_optimize_plans[0]
+        group_resources = plan.resource.task_group_resources
         group_resources[NodeType.WORKER].count = 5
         group_resources[NodeType.WORKER].resource.memory = (
             _MEMORY * MemoryUnit.MB
@@ -55,6 +54,7 @@ class MockStub(object):
         group_resources[NodeType.PS].count = 2
         group_resources[NodeType.PS].resource.memory = _MEMORY * MemoryUnit.MB
         group_resources[NodeType.PS].resource.cpu = 16
+        plan.resource.pod_resources["ps-0"].memory = _MEMORY * MemoryUnit.MB
         return res
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

The brain set the resource of OOM PS into the plan.PodResource not plan.taskResource.

### Why are the changes needed?

Buf fix.

### Does this PR introduce any user-facing change?

No
### How was this patch tested?

UT
