### PR TITLE
The sampler restores the completed number of sample in the epoch.

### DIFF
--- a/dlrover/examples/torch_nanogpt_job.yaml
+++ b/dlrover/examples/torch_nanogpt_job.yaml
@@ -15,7 +15,7 @@ spec:
           containers:
             - name: main
               # yamllint disable-line rule:line-length
-              image: registry.cn-hangzhou.aliyuncs.com/easydl/dlrover-train:nanogpt-test
+              image: registry.cn-hangzhou.aliyuncs.com/intell-ai/dlrover:nanogpt-test
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/bash

--- a/dlrover/trainer/tests/torch/elastic_sampler_test.py
+++ b/dlrover/trainer/tests/torch/elastic_sampler_test.py
@@ -52,3 +52,9 @@ class ElasticDistributedSamplerTest(unittest.TestCase):
         sampler.load_state_dict(sampler_state)
         val = next(iter(sampler))
         self.assertEqual(val, 64)
+
+        for i in sampler:
+            pass
+        sampler.set_epoch(1)
+        val = next(iter(sampler))
+        self.assertEqual(val, 0)

--- a/model_zoo/pytorch/nanogpt/train.py
+++ b/model_zoo/pytorch/nanogpt/train.py
@@ -139,7 +139,7 @@ def get_lr(it, args):
 
 
 def log_rank0(msg):
-    local_rank = int(os.environ.get("LOCAL_RANK", 0))
+    local_rank = int(os.getenv("LOCAL_RANK", 0))
     if local_rank == 0:
         print(msg)
 
@@ -153,7 +153,7 @@ def setup(args):
     else:
         dist.init_process_group("gloo", timeout=timedelta(seconds=120))
     rank = dist.get_rank()
-    local_rank = int(os.environ["LOCAL_RANK"])
+    local_rank = int(os.getenv("LOCAL_RANK", 0))
     print(f"rank {rank} is initialized local_rank = {local_rank}")
     # This process will do logging, checkpointing etc.
     master_process = rank == 0
@@ -172,7 +172,7 @@ def train():
 
     args = arg_parser()
     setup(args)
-    world_size = int(os.environ["WORLD_SIZE"])
+    world_size = int(os.getenv("WORLD_SIZE", 1))
     gradient_accumulation_steps = args.gradient_accumulation_steps
     batch_size = args.batch_size
     block_size = args.block_size
@@ -218,7 +218,6 @@ def train():
     model = model.to(device)
     # Device
     if torch.cuda.is_available() and device_type == "cuda":
-        local_rank = int(os.environ["LOCAL_RANK"])
         # Create model and move it to GPU with id rank
         model = model.to(local_rank)
         if use_fsdp:
@@ -230,7 +229,6 @@ def train():
             print(f"Model device {model.device}")
 
     else:
-        local_rank = int(os.environ["LOCAL_RANK"])
         print(f"Running basic CPU example on device {device}.")
         model = model.to(device)
         model = DDP(model)


### PR DESCRIPTION
### What changes were proposed in this pull request?

`ElasticDistributedSampler` only restore the completed number of sample of the epoch in the checkpoint. For other epoch, the start index should be 0.

### Why are the changes needed?

Bug fix.

### Does this PR introduce any user-facing change?

No

### How was this patch tested?

Unit test.