### PR TITLE
feat: Launch the local master in a subprocess if standalone.

### DIFF
--- a/dlrover/python/brain/client.py
+++ b/dlrover/python/brain/client.py
@@ -268,7 +268,7 @@ def build_brain_client():
         client = build_brain_client()
         ```
     """
-    brain_addr = os.getenv(_ENV_BRAIN_ADDR_KEY, _DEFAULT_BRAIN_ADDR)
+    brain_addr = os.getenv(_ENV_BRAIN_ADDR_KEY, "")
     channel = build_channel(brain_addr)
     if channel and grpc_server_ready(channel):
         return BrainClient(channel)

--- a/dlrover/trainer/tests/torch/elastic_run_test.py
+++ b/dlrover/trainer/tests/torch/elastic_run_test.py
@@ -12,7 +12,11 @@
 # limitations under the License.
 
 import unittest
-from dlrover.trainer.torch.elastic_run import _launch_dlrover_local_master, _check_dlrover_master_available
+
+from dlrover.trainer.torch.elastic_run import (
+    _check_dlrover_master_available,
+    _launch_dlrover_local_master,
+)
 
 
 class ElasticRunTest(unittest.TestCase):
@@ -21,4 +25,3 @@ class ElasticRunTest(unittest.TestCase):
         available = _check_dlrover_master_available(addr)
         self.assertTrue(available)
         handler.close()
-        

--- a/dlrover/trainer/tests/torch/elastic_run_test.py
+++ b/dlrover/trainer/tests/torch/elastic_run_test.py
@@ -1,0 +1,24 @@
+# Copyright 2023 The DLRover Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from dlrover.trainer.torch.elastic_run import _launch_dlrover_local_master, _check_dlrover_master_available
+
+
+class ElasticRunTest(unittest.TestCase):
+    def test_launch_local_master(self):
+        handler, addr = _launch_dlrover_local_master()
+        available = _check_dlrover_master_available(addr)
+        self.assertTrue(available)
+        handler.close()
+        

--- a/dlrover/trainer/torch/elastic_run.py
+++ b/dlrover/trainer/torch/elastic_run.py
@@ -107,7 +107,7 @@ class elastic_launch:
             )
 
 
-def launch_dlrover_local_master():
+def _launch_dlrover_local_master():
     """Launch a subprocess to run the DLrover master."""
     cmd = os.getenv("PYTHON_EXEC", sys.executable)
     host = "127.0.0.1"
@@ -136,7 +136,7 @@ def launch_dlrover_local_master():
 def _check_dlrover_master_available(addr, timeout=60):
     """Check whether the master grpc servicer is available."""
     host = addr.split(":")[0]
-    port = int(addr.split(":"))[1]
+    port = int(addr.split(":")[1])
     start_time = time.time()
     while True:
         try:
@@ -154,7 +154,7 @@ def run(args):
     dmaster_addr = os.getenv("DLROVER_MASTER_ADDR", "")
     use_dlrover_launch = False
     if args.standalone:
-        master_handler, dmaster_addr = launch_dlrover_local_master()
+        master_handler, dmaster_addr = _launch_dlrover_local_master()
     if _check_dlrover_master_available():
         GlobalMasterClient.MASTER_CLIENT = build_master_client(dmaster_addr)
         use_dlrover_launch = True

--- a/dlrover/trainer/torch/elastic_run.py
+++ b/dlrover/trainer/torch/elastic_run.py
@@ -32,9 +32,7 @@ from dlrover.python.elastic_agent.master_client import (
     GlobalMasterClient,
     build_master_client,
 )
-from dlrover.python.elastic_agent.torch.training import (
-    launch_agent as dlrover_launch_agent,
-)
+from dlrover.python.elastic_agent.torch.training import launch_agent
 
 
 def parse_args(args):
@@ -98,9 +96,7 @@ class elastic_launch:
 
     def __call__(self, *args):
         if self._use_dlrover_launch:
-            return dlrover_launch_agent(
-                self._config, self._entrypoint, list(args)
-            )
+            return launch_agent(self._config, self._entrypoint, list(args))
         else:
             return torch_launch_agent(
                 self._config, self._entrypoint, list(args)

--- a/dlrover/trainer/torch/elastic_run.py
+++ b/dlrover/trainer/torch/elastic_run.py
@@ -97,30 +97,25 @@ class elastic_launch:
 def launch_dlrover_local_master():
     """Launch a subprocess to run the DLrover master."""
     cmd = os.getenv("PYTHON_EXEC", sys.executable)
+    host = "127.0.0.1"
     port = find_free_port()
     log_dir = tempfile.mkdtemp(prefix="dlrover_master_")
     job_name = log_dir.split("_")[-1]
     stdout = os.path.join(log_dir, "stdout.log")
     stderr = os.path.join(log_dir, "stderror.log")
     logger.info(f"The master log file:\n stdout: {stdout} \n stderr: {stderr}")
-    handler = SubprocessHandler(
-        cmd,
-        (
-            "-u",
-            "-m",
-            "dlrover.python.master.main",
-            "--port",
-            f"{port}",
-            "--job_name",
-            f"standalone-{job_name}",
-            "--platform",
-            "local",
-        ),
-        {},
-        stdout,
-        stderr,
+    args = (
+        "-u",
+        "-m",
+        "dlrover.python.master.main",
+        "--port",
+        f"{port}",
+        "--job_name",
+        f"standalone-{job_name}",
+        "--platform",
+        "local",
     )
-    host = "127.0.0.1"
+    handler = SubprocessHandler(cmd, args, {}, stdout, stderr)
     dlrover_master_addr = f"{host}:{port}"
     while True:
         try:


### PR DESCRIPTION
### What changes were proposed in this pull request?

Launch the local master in a subprocess if standalone.

### Why are the changes needed?

Support executing dlrover-run in a single node.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

```
dlrover-run --standalone \
                  --nproc_per_node=2 --max_restarts=3  \
                  model_zoo/pytorch/mnist_cnn.py --num_epochs 2 \
                  --training_data /data/mnist_png/training/ \
                  --validation_data /data/mnist_png/testing/
```
