### PR TITLE
Refactor: move the method to convert k8s resource to kubernetes.py.

### DIFF
--- a/dlrover/python/common/node.py
+++ b/dlrover/python/common/node.py
@@ -22,11 +22,6 @@ from dlrover.python.common.constants import (
 )
 from dlrover.python.common.serialize import JsonSerializable
 
-try:
-    from kubernetes.utils.quantity import parse_quantity
-except ImportError:
-    pass
-
 
 def _is_float_str(str_number):
     if not str_number:
@@ -93,18 +88,6 @@ class NodeResource(JsonSerializable):
                 gpu_type = key
                 gpu_num = int(resource[key])
         return NodeResource(cpu, memory, gpu_type, gpu_num)
-
-    @classmethod
-    def convert_memory_to_mb(cls, memory: str):
-        return int(parse_quantity(memory) / 1024 / 1024)
-
-    @classmethod
-    def convert_memory_to_byte(cls, memory: str):
-        return parse_quantity(memory)
-
-    @classmethod
-    def convert_cpu_to_decimal(cls, cpu: str):
-        return round(float(parse_quantity(cpu)), 1)
 
 
 class NodeGroupResource(JsonSerializable):

--- a/dlrover/python/master/scaler/pod_scaler.py
+++ b/dlrover/python/master/scaler/pod_scaler.py
@@ -33,6 +33,8 @@ from dlrover.python.common.node import Node, NodeResource
 from dlrover.python.master.scaler.base_scaler import ScalePlan, Scaler
 from dlrover.python.scheduler.kubernetes import (
     NODE_SERVICE_PORTS,
+    convert_cpu_to_decimal,
+    convert_memory_to_mb,
     get_pod_name,
     k8sClient,
 )
@@ -226,13 +228,9 @@ class PodScaler(Scaler):
 
     def _get_pod_resource(self, pod):
         resources = pod.spec.containers[0].resources
-        cpu = NodeResource.convert_cpu_to_decimal(
-            resources.requests.get("cpu", "0")
-        )
+        cpu = convert_cpu_to_decimal(resources.requests.get("cpu", "0"))
         if "memory" in resources.requests:
-            memory = NodeResource.convert_memory_to_mb(
-                resources.requests["memory"]
-            )
+            memory = convert_memory_to_mb(resources.requests["memory"])
         else:
             memory = 0
         return NodeResource(cpu, memory)

--- a/dlrover/python/master/watcher/k8s_watcher.py
+++ b/dlrover/python/master/watcher/k8s_watcher.py
@@ -28,7 +28,11 @@ from dlrover.python.common.log import default_logger as logger
 from dlrover.python.common.node import Node, NodeGroupResource, NodeResource
 from dlrover.python.master.resource.optimizer import ResourcePlan
 from dlrover.python.master.watcher.base_watcher import NodeEvent, NodeWatcher
-from dlrover.python.scheduler.kubernetes import k8sClient
+from dlrover.python.scheduler.kubernetes import (
+    convert_cpu_to_decimal,
+    convert_memory_to_mb,
+    k8sClient,
+)
 
 
 def _get_start_timestamp(pod_status_obj):
@@ -118,12 +122,8 @@ def _convert_pod_event_to_node_event(event):
 
 
 def _parse_container_resource(container):
-    cpu = NodeResource.convert_cpu_to_decimal(
-        container.resources.requests["cpu"]
-    )
-    memory = NodeResource.convert_memory_to_mb(
-        container.resources.requests["memory"]
-    )
+    cpu = convert_cpu_to_decimal(container.resources.requests["cpu"])
+    memory = convert_memory_to_mb(container.resources.requests["memory"])
     return NodeResource(cpu, memory)
 
 
@@ -247,10 +247,10 @@ class K8sScalePlanWatcher:
         for replica, spec in (
             scaler_crd["spec"].get("replicaResourceSpecs", {}).items()
         ):
-            cpu = NodeResource.convert_cpu_to_decimal(
+            cpu = convert_cpu_to_decimal(
                 spec.get("resource", {}).get("cpu", "0")
             )
-            memory = NodeResource.convert_memory_to_mb(
+            memory = convert_memory_to_mb(
                 spec.get("resource", {}).get("memory", "0Mi")
             )
             resource_plan.node_group_resources[replica] = NodeGroupResource(
@@ -258,10 +258,10 @@ class K8sScalePlanWatcher:
             )
 
         for pod in scaler_crd["spec"].get("migratePods", []):
-            cpu = NodeResource.convert_cpu_to_decimal(
+            cpu = convert_cpu_to_decimal(
                 pod["resource"].get("cpu", "0"),
             )
-            memory = NodeResource.convert_memory_to_mb(
+            memory = convert_memory_to_mb(
                 pod["resource"].get("memory", "0Mi"),
             )
             resource_plan.node_resources[pod["name"]] = NodeResource(

--- a/dlrover/python/scheduler/kubernetes.py
+++ b/dlrover/python/scheduler/kubernetes.py
@@ -16,6 +16,7 @@ import threading
 import time
 
 from kubernetes import client, config
+from kubernetes.utils.quantity import parse_quantity
 
 from dlrover.python.common.constants import (
     DefaultResourceLimits,
@@ -36,6 +37,18 @@ NODE_SERVICE_PORTS = {
 }
 
 JOB_SUFFIX = "-edljob-"
+
+
+def convert_memory_to_mb(memory: str):
+    return int(parse_quantity(memory) / 1024 / 1024)
+
+
+def convert_memory_to_byte(memory: str):
+    return parse_quantity(memory)
+
+
+def convert_cpu_to_decimal(cpu: str):
+    return round(float(parse_quantity(cpu)), 1)
 
 
 def parse_bool(s: str):
@@ -310,10 +323,10 @@ class K8sJobArgs(JobArgs):
         if "distributionStrategy" in job["spec"]:
             self.distribution_strategy = job["spec"]["distributionStrategy"]
         limit_config = job["spec"].get("resourceLimits", {})
-        self.resource_limits.cpu = NodeResource.convert_cpu_to_decimal(
+        self.resource_limits.cpu = convert_cpu_to_decimal(
             limit_config.get("cpu", DefaultResourceLimits.CPU_LIMIT)
         )
-        self.resource_limits.memory = NodeResource.convert_memory_to_byte(
+        self.resource_limits.memory = convert_memory_to_byte(
             limit_config.get("memory", DefaultResourceLimits.MEMORY_LIMIT)
         )
         self.resource_limits.gpu_num = int(
@@ -331,9 +344,9 @@ class K8sJobArgs(JobArgs):
             container = spec["template"]["spec"]["containers"][0]
             resources = container.get("resources", {})
             requests = resources.get("requests", {})
-            cpu = NodeResource.convert_cpu_to_decimal(requests.get("cpu", 0))
+            cpu = convert_cpu_to_decimal(requests.get("cpu", 0))
             if "memory" in requests:
-                memory = NodeResource.convert_memory_to_mb(requests["memory"])
+                memory = convert_memory_to_mb(requests["memory"])
             else:
                 memory = 0
             gpu_type = None

--- a/dlrover/python/scheduler/ray.py
+++ b/dlrover/python/scheduler/ray.py
@@ -22,6 +22,10 @@ from dlrover.python.common.log import default_logger as logger
 from dlrover.python.common.node import NodeGroupResource, NodeResource
 from dlrover.python.master.stats.stats_backend import LocalFileStateBackend
 from dlrover.python.scheduler.job import ElasticJob, JobArgs, NodeArgs
+from dlrover.python.scheduler.kubernetes import (
+    convert_cpu_to_decimal,
+    convert_memory_to_mb,
+)
 from dlrover.python.util.actor_util.parse_actor import (
     parse_type_id_from_actor_name,
 )
@@ -177,9 +181,9 @@ class RayJobArgs(JobArgs):
         for replica, spec in job["spec"]["replicaSpecs"].items():
             num = int(spec.get("replicas", 0))
             requests = spec.get("resources", {})
-            cpu = NodeResource.convert_cpu_to_decimal(requests.get("cpu", 0))
+            cpu = convert_cpu_to_decimal(requests.get("cpu", 0))
             if "memory" in requests:
-                memory = NodeResource.convert_memory_to_mb(requests["memory"])
+                memory = convert_memory_to_mb(requests["memory"])
             else:
                 memory = 0
             gpu_type = None


### PR DESCRIPTION
### What changes were proposed in this pull request?

Move the methods to convert the k8s resource to kubernetes.py.

### Why are the changes needed?

We do not need to import k8s when we use`Node`. 

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

No.

