### PR TITLE
1/3 feat(elastic_agent) add GPU statistic fetching to resource monitor. 

### DIFF
--- a/dlrover/python/elastic_agent/monitor/metrics.py
+++ b/dlrover/python/elastic_agent/monitor/metrics.py
@@ -1,0 +1,9 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class GPUMetric:
+    index: int
+    total_memory_mb: int
+    used_memory_mb: int
+    gpu_utilization: float

--- a/dlrover/python/elastic_agent/monitor/metrics.py
+++ b/dlrover/python/elastic_agent/monitor/metrics.py
@@ -1,3 +1,16 @@
+# Copyright 2023 The DLRover Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from dataclasses import dataclass
 
 

--- a/dlrover/python/elastic_agent/monitor/resource.py
+++ b/dlrover/python/elastic_agent/monitor/resource.py
@@ -55,11 +55,13 @@ def get_used_memory():
     return int(mem.used / 1024 / 1024)
 
 
-def get_gpu_stats():
+def get_gpu_stats(gpus=[]):
     """ "Get the used gpu info of the container"""
-    device_count = pynvml.nvmlDeviceGetCount()
+    if not gpus:
+        device_count = pynvml.nvmlDeviceGetCount()
+        gpus = list(range(device_count))
     gpu_stats_list = []
-    for i in range(device_count):
+    for i in gpus:
         handle = pynvml.nvmlDeviceGetHandleByIndex(i)
         memory_info = pynvml.nvmlDeviceGetMemoryInfo(handle)
         total_memory = memory_info.total / (1024**2)

--- a/dlrover/python/elastic_agent/monitor/resource.py
+++ b/dlrover/python/elastic_agent/monitor/resource.py
@@ -22,6 +22,7 @@ from dlrover.python.common.constants import NodeEnv
 from dlrover.python.common.log import default_logger as logger
 from dlrover.python.common.singleton import singleton
 from dlrover.python.elastic_agent.master_client import GlobalMasterClient
+from dlrover.python.elastic_agent.monitor.metrics import GPUMetric
 
 
 def get_process_cpu_percent():
@@ -69,19 +70,19 @@ def get_gpu_stats():
         gpu_utilization = utilization.gpu
 
         gpu_stats_list.append(
-            {
-                "index": i,
-                "total_memory_mb": total_memory,
-                "used_memory_mb": used_memory,
-                "gpu_utilization": gpu_utilization,
-            }
+            GPUMetric(
+                index=i,
+                total_memory_mb=total_memory,
+                used_memory_mb=used_memory,
+                gpu_utilization=gpu_utilization
+            )
         )
     for info in gpu_stats_list:
         logger.debug(
-            f"GPU {info['index']}: "
-            f"Total Memory: {info['total_memory_mb']} MB, "
-            f"Used Memory: {info['used_memory_mb']} MB, "
-            f"GPU Utilization: {info['gpu_utilization']}%"
+            f"GPU {info.index}: "
+            f"Total Memory: {info.total_memory_mb} MB, "
+            f"Used Memory: {info.used_memory_mb} MB, "
+            f"GPU Utilization: {info.gpu_utilization}%"
         )
     return gpu_stats_list
 

--- a/dlrover/python/elastic_agent/monitor/resource.py
+++ b/dlrover/python/elastic_agent/monitor/resource.py
@@ -95,16 +95,23 @@ class ResourceMonitor(object):
         """
         self._total_cpu = psutil.cpu_count(logical=True)
         self.init_gpu_monitor()
-        logger.info("Resource Monitor Init")
+        logger.info("Resource Monitor Initializing ...")
         if (
             os.getenv(NodeEnv.DLROVER_MASTER_ADDR, "")
             and os.getenv(NodeEnv.AUTO_MONITOR_WORKLOAD, "") == "true"
         ):
-            threading.Thread(
-                target=self._monitor_resource,
-                name="monitor_resource",
-                daemon=True,
-            ).start()
+            try:
+                thread = threading.Thread(
+                    target=self._monitor_resource,
+                    name="monitor_resource",
+                    daemon=True,
+                )
+                thread.start()
+                if thread.is_alive():
+                    logger.info("Resource Monitor initialized successfully")
+            except Exception as e:
+                logger.error(
+                    f"Failed to start the monitor resource thread. Error: {e}")
 
     def __del__(self):
         self.shutdown_gpu_monitor()

--- a/dlrover/python/elastic_agent/monitor/resource.py
+++ b/dlrover/python/elastic_agent/monitor/resource.py
@@ -76,7 +76,7 @@ def get_gpu_stats(gpus=[]):
                 index=i,
                 total_memory_mb=total_memory,
                 used_memory_mb=used_memory,
-                gpu_utilization=gpu_utilization
+                gpu_utilization=gpu_utilization,
             )
         )
     for gpu_stats in gpu_stats_list:
@@ -109,7 +109,8 @@ class ResourceMonitor(object):
                     logger.info("Resource Monitor initialized successfully")
             except Exception as e:
                 logger.error(
-                    f"Failed to start the monitor resource thread. Error: {e}")
+                    f"Failed to start the monitor resource thread. Error: {e}"
+                )
 
     def __del__(self):
         self.shutdown_gpu_monitor()
@@ -124,20 +125,24 @@ class ResourceMonitor(object):
             )
         except pynvml.NVMLError as e:
             logger.error(
-                f"An error occurred while initializing NVIDIA NVML: {e}")
+                f"An error occurred while initializing NVIDIA NVML: {e}"
+            )
         except Exception as e:
             logger.exception(
-                f"An unexpected error occurred during NVML shutdown: {e}")
+                f"An unexpected error occurred during NVML shutdown: {e}"
+            )
 
     def shutdown_gpu_monitor(self):
         try:
             pynvml.nvmlShutdown()
         except pynvml.NVMLError as e:
             logger.error(
-                f"An error occurred while shutting down NVIDIA NVML: {e}")
+                f"An error occurred while shutting down NVIDIA NVML: {e}"
+            )
         except Exception as e:
             logger.exception(
-                f"An unexpected error occurred during NVML shutdown: {e}")
+                f"An unexpected error occurred during NVML shutdown: {e}"
+            )
 
     def start_monitor_cpu(self):
         get_process_cpu_percent()

--- a/dlrover/python/elastic_agent/monitor/resource.py
+++ b/dlrover/python/elastic_agent/monitor/resource.py
@@ -79,13 +79,8 @@ def get_gpu_stats(gpus=[]):
                 gpu_utilization=gpu_utilization
             )
         )
-    for info in gpu_stats_list:
-        logger.debug(
-            f"GPU {info.index}: "
-            f"Total Memory: {info.total_memory_mb} MB, "
-            f"Used Memory: {info.used_memory_mb} MB, "
-            f"GPU Utilization: {info.gpu_utilization}%"
-        )
+    for gpu_stats in gpu_stats_list:
+        logger.debug(f"GPU metric {gpu_stats}")
     return gpu_stats_list
 
 

--- a/dlrover/python/elastic_agent/torch/training.py
+++ b/dlrover/python/elastic_agent/torch/training.py
@@ -58,6 +58,7 @@ from dlrover.python.common.constants import (
 )
 from dlrover.python.common.log import default_logger as logger
 from dlrover.python.elastic_agent.master_client import GlobalMasterClient
+from dlrover.python.elastic_agent.monitor.resource import ResourceMonitor
 from dlrover.python.elastic_agent.torch.master_kv_store import MasterKVStore
 
 __all__ = ["launch_agent"]
@@ -485,6 +486,8 @@ def launch_agent(
         f"  metrics_cfg      : {config.metrics_cfg}\n"
     )
 
+    ResourceMonitor()
+    logger.info("Elastic agent is imported ResourceMonitor")
     rdzv_parameters = RendezvousParameters(
         backend=config.rdzv_backend,
         endpoint=config.rdzv_endpoint,

--- a/dlrover/python/elastic_agent/torch/training.py
+++ b/dlrover/python/elastic_agent/torch/training.py
@@ -487,7 +487,6 @@ def launch_agent(
     )
 
     ResourceMonitor()
-    logger.info("Elastic agent is imported ResourceMonitor")
     rdzv_parameters = RendezvousParameters(
         backend=config.rdzv_backend,
         endpoint=config.rdzv_endpoint,

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ install_requires = [
     "grpcio-tools==1.34.1",
     "protobuf>=3.15.3,<4.0dev",
     "psutil",
+    "pynvml",
     "urllib3<1.27,>=1.21.1",
 ]
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add GPU statistic fetching to resource monitor in elastic agent.

### Why are the changes needed?

We need to collect GPU info first to update node resource info.

### Does this PR introduce any user-facing change?

NO.

### How was this patch tested?

Tested by locally running get_gpu_stats (both with K8s & without K8s).
