### PR TITLE
2/3 feat(elastic_agent) add GPU statistic report to resource monitor.

### DIFF
--- a/dlrover/proto/elastic_training.proto
+++ b/dlrover/proto/elastic_training.proto
@@ -95,10 +95,10 @@ message ReportUsedResourceRequest {
   float cpu = 2;
   int32 node_id = 3;
   string node_type = 4;
-  map<int32, GPUStats> gpu_stats = 5;
+  repeated GPUMetric gpu_stats = 5;
 }
 
-message GPUStats {
+message GPUMetric {
   int32 index = 1;
   float total_memory_mb = 2;
   float used_memory_mb = 3;

--- a/dlrover/proto/elastic_training.proto
+++ b/dlrover/proto/elastic_training.proto
@@ -95,6 +95,14 @@ message ReportUsedResourceRequest {
   float cpu = 2;
   int32 node_id = 3;
   string node_type = 4;
+  map<int32, GPUStats> gpu_stats = 5;
+}
+
+message GPUStats {
+  int32 index = 1;
+  float total_memory_mb = 2;
+  float used_memory_mb = 3;
+  float gpu_utilization = 4;
 }
 
 message TensorStats {

--- a/dlrover/python/elastic_agent/master_client.py
+++ b/dlrover/python/elastic_agent/master_client.py
@@ -194,12 +194,19 @@ class MasterClient(object):
         return self._stub.report_shard_checkpoint(request)
 
     @retry_grpc_request
-    def report_used_resource(self, memory, cpu):
+    def report_used_resource(self, memory, cpu, gpu_stats):
         request = elastic_training_pb2.ReportUsedResourceRequest()
         request.memory = memory
         request.cpu = cpu
+        for gpu in gpu_stats:
+            gpu_stats_message = request.gpu_stats[gpu["index"]]
+            gpu_stats_message.index = gpu["index"]
+            gpu_stats_message.total_memory_mb = gpu["total_memory_mb"]
+            gpu_stats_message.used_memory_mb = gpu["used_memory_mb"]
+            gpu_stats_message.gpu_utilization = gpu["gpu_utilization"]
         request.node_id = self._node_id
         request.node_type = self._node_type
+        logger.info("report used resource request: {}".format(request))
         return self._stub.report_used_resource(request)
 
     @retry_grpc_request

--- a/dlrover/python/elastic_agent/master_client.py
+++ b/dlrover/python/elastic_agent/master_client.py
@@ -199,11 +199,11 @@ class MasterClient(object):
         request.memory = memory
         request.cpu = cpu
         for gpu in gpu_stats:
-            gpu_stats_message = request.gpu_stats[gpu["index"]]
-            gpu_stats_message.index = gpu["index"]
-            gpu_stats_message.total_memory_mb = gpu["total_memory_mb"]
-            gpu_stats_message.used_memory_mb = gpu["used_memory_mb"]
-            gpu_stats_message.gpu_utilization = gpu["gpu_utilization"]
+            gpu_stats_message = request.gpu_stats.add()
+            gpu_stats_message.index = gpu.index
+            gpu_stats_message.total_memory_mb = gpu.total_memory_mb
+            gpu_stats_message.used_memory_mb = gpu.used_memory_mb
+            gpu_stats_message.gpu_utilization = gpu.gpu_utilization
         request.node_id = self._node_id
         request.node_type = self._node_type
         logger.info("report used resource request: {}".format(request))

--- a/dlrover/python/elastic_agent/monitor/resource.py
+++ b/dlrover/python/elastic_agent/monitor/resource.py
@@ -60,7 +60,7 @@ def get_gpu_stats(gpus=[]):
     if not gpus:
         device_count = pynvml.nvmlDeviceGetCount()
         gpus = list(range(device_count))
-    gpu_stats_list = []
+    gpu_stats_list: list[GPUMetric] = []
     for i in gpus:
         handle = pynvml.nvmlDeviceGetHandleByIndex(i)
         memory_info = pynvml.nvmlDeviceGetMemoryInfo(handle)
@@ -102,6 +102,7 @@ class ResourceMonitor(object):
         ):
             return
 
+        print("Start to monitor resource usage")
         self.init_gpu_monitor()
         logger.info("Resource Monitor Initializing ...")
 
@@ -164,8 +165,10 @@ class ResourceMonitor(object):
         try:
             used_mem = get_used_memory()
             cpu_percent = get_process_cpu_percent()
+            print(f"_gpu_enabled: {self._gpu_enabled}")
             if self._gpu_enabled:
                 self._gpu_stats = get_gpu_stats()
+            print(f"gpus: {self._gpu_stats}")
             current_cpu = round(cpu_percent * self._total_cpu, 2)
             GlobalMasterClient.MASTER_CLIENT.report_used_resource(
                 used_mem, current_cpu, self._gpu_stats

--- a/dlrover/python/elastic_agent/monitor/resource.py
+++ b/dlrover/python/elastic_agent/monitor/resource.py
@@ -102,7 +102,6 @@ class ResourceMonitor(object):
         ):
             return
 
-        print("Start to monitor resource usage")
         self.init_gpu_monitor()
         logger.info("Resource Monitor Initializing ...")
 
@@ -165,10 +164,8 @@ class ResourceMonitor(object):
         try:
             used_mem = get_used_memory()
             cpu_percent = get_process_cpu_percent()
-            print(f"_gpu_enabled: {self._gpu_enabled}")
             if self._gpu_enabled:
                 self._gpu_stats = get_gpu_stats()
-            print(f"gpus: {self._gpu_stats}")
             current_cpu = round(cpu_percent * self._total_cpu, 2)
             GlobalMasterClient.MASTER_CLIENT.report_used_resource(
                 used_mem, current_cpu, self._gpu_stats

--- a/dlrover/python/elastic_agent/monitor/resource.py
+++ b/dlrover/python/elastic_agent/monitor/resource.py
@@ -133,7 +133,7 @@ class ResourceMonitor(object):
             pynvml.nvmlInit()
             self._gpu_enabled = True
         except pynvml.NVMLError_LibraryNotFound:
-            logger.error(
+            logger.warn(
                 "NVIDIA NVML library not found. "
                 "GPU monitoring features will be disabled."
             )

--- a/dlrover/python/elastic_agent/monitor/resource.py
+++ b/dlrover/python/elastic_agent/monitor/resource.py
@@ -60,7 +60,7 @@ def get_gpu_stats(gpus=[]):
     if not gpus:
         device_count = pynvml.nvmlDeviceGetCount()
         gpus = list(range(device_count))
-    gpu_stats_list: list[GPUMetric] = []
+    gpu_stats: list[GPUMetric] = []
     for i in gpus:
         handle = pynvml.nvmlDeviceGetHandleByIndex(i)
         memory_info = pynvml.nvmlDeviceGetMemoryInfo(handle)
@@ -71,7 +71,7 @@ def get_gpu_stats(gpus=[]):
         utilization = pynvml.nvmlDeviceGetUtilizationRates(handle)
         gpu_utilization = utilization.gpu
 
-        gpu_stats_list.append(
+        gpu_stats.append(
             GPUMetric(
                 index=i,
                 total_memory_mb=total_memory,
@@ -79,9 +79,7 @@ def get_gpu_stats(gpus=[]):
                 gpu_utilization=gpu_utilization,
             )
         )
-    for gpu_stats in gpu_stats_list:
-        logger.debug(f"GPU metric {gpu_stats}")
-    return gpu_stats_list
+    return gpu_stats
 
 
 @singleton

--- a/dlrover/python/tests/test_agent_monitor.py
+++ b/dlrover/python/tests/test_agent_monitor.py
@@ -15,6 +15,7 @@ import json
 import os
 import time
 import unittest
+from unittest.mock import patch
 
 from dlrover.python.elastic_agent.monitor.resource import ResourceMonitor
 from dlrover.python.elastic_agent.monitor.training import (
@@ -25,10 +26,24 @@ from dlrover.python.elastic_agent.monitor.training import (
 
 class ResourceMonitorTest(unittest.TestCase):
     def test_resource_monitor(self):
-        resource_monitor = ResourceMonitor()
-        time.sleep(0.3)
-        resource_monitor.report_resource()
-        self.assertTrue(resource_monitor._total_cpu >= 0.0)
+        gpu_stats = [
+            {
+                "index": 0,
+                "total_memory_mb": 24000,
+                "used_memory_mb": 4000,
+                "gpu_utilization": 55.5,
+            }
+        ]
+        # mock get_gpu_stats
+        with patch(
+            "dlrover.python.elastic_agent.monitor.resource.get_gpu_stats",
+            return_value=gpu_stats,
+        ):
+            resource_monitor = ResourceMonitor()
+            time.sleep(0.3)
+            resource_monitor.report_resource()
+            self.assertTrue(resource_monitor._total_cpu >= 0.0)
+            self.assertTrue(resource_monitor._gpu_stats == gpu_stats)
 
     def test_training_reporter(self):
         TF_CONFIG = {

--- a/dlrover/python/tests/test_agent_monitor.py
+++ b/dlrover/python/tests/test_agent_monitor.py
@@ -51,9 +51,7 @@ class ResourceMonitorTest(unittest.TestCase):
                 "dlrover.python.elastic_agent.monitor.resource.get_gpu_stats",
                 return_value=gpu_stats,
             ):
-                with patch(
-                    "dlrover.python.elastic_agent.monitor.resource.ResourceMonitor.init_gpu_monitor"  # noqa: E501
-                ):
+                with patch("pynvml.nvmlInit"):
                     resource_monitor = ResourceMonitor()
                     resource_monitor.start()
                     time.sleep(0.3)

--- a/dlrover/python/tests/test_agent_monitor.py
+++ b/dlrover/python/tests/test_agent_monitor.py
@@ -51,12 +51,15 @@ class ResourceMonitorTest(unittest.TestCase):
                 "dlrover.python.elastic_agent.monitor.resource.get_gpu_stats",
                 return_value=gpu_stats,
             ):
-                resource_monitor = ResourceMonitor()
-                resource_monitor.start()
-                time.sleep(0.3)
-                resource_monitor.report_resource()
-                self.assertTrue(resource_monitor._total_cpu >= 0.0)
-                self.assertTrue(resource_monitor._gpu_stats == gpu_stats)
+                with patch(
+                    "dlrover.python.elastic_agent.monitor.resource.ResourceMonitor.init_gpu_monitor"  # noqa: E501
+                ):
+                    resource_monitor = ResourceMonitor()
+                    resource_monitor.start()
+                    time.sleep(0.3)
+                    resource_monitor.report_resource()
+                    self.assertTrue(resource_monitor._total_cpu >= 0.0)
+                    self.assertTrue(resource_monitor._gpu_stats == gpu_stats)
 
     def test_training_reporter(self):
         TF_CONFIG = {

--- a/dlrover/python/tests/test_agent_monitor.py
+++ b/dlrover/python/tests/test_agent_monitor.py
@@ -17,13 +17,13 @@ import time
 import unittest
 from unittest.mock import patch
 
+from dlrover.python.common.constants import NodeEnv
+from dlrover.python.elastic_agent.monitor.metrics import GPUMetric
 from dlrover.python.elastic_agent.monitor.resource import ResourceMonitor
 from dlrover.python.elastic_agent.monitor.training import (
     TrainingProcessReporter,
     is_tf_chief,
 )
-from dlrover.python.elastic_agent.monitor.metrics import GPUMetric
-from dlrover.python.common.constants import NodeEnv
 
 
 class ResourceMonitorTest(unittest.TestCase):
@@ -43,7 +43,8 @@ class ResourceMonitorTest(unittest.TestCase):
 
         with patch.dict("os.environ", mock_env):
             result = not os.getenv(NodeEnv.DLROVER_MASTER_ADDR, "") or not (
-                os.getenv(NodeEnv.AUTO_MONITOR_WORKLOAD, "") == "true")
+                os.getenv(NodeEnv.AUTO_MONITOR_WORKLOAD, "") == "true"
+            )
             self.assertFalse(result)
             # mock get_gpu_stats
             with patch(

--- a/dlrover/python/tests/test_agent_monitor.py
+++ b/dlrover/python/tests/test_agent_monitor.py
@@ -22,28 +22,40 @@ from dlrover.python.elastic_agent.monitor.training import (
     TrainingProcessReporter,
     is_tf_chief,
 )
+from dlrover.python.elastic_agent.monitor.metrics import GPUMetric
+from dlrover.python.common.constants import NodeEnv
 
 
 class ResourceMonitorTest(unittest.TestCase):
     def test_resource_monitor(self):
-        gpu_stats = [
-            {
-                "index": 0,
-                "total_memory_mb": 24000,
-                "used_memory_mb": 4000,
-                "gpu_utilization": 55.5,
-            }
+        gpu_stats: list[GPUMetric] = [
+            GPUMetric(
+                index=0,
+                total_memory_mb=24000,
+                used_memory_mb=4000,
+                gpu_utilization=55.5,
+            )
         ]
-        # mock get_gpu_stats
-        with patch(
-            "dlrover.python.elastic_agent.monitor.resource.get_gpu_stats",
-            return_value=gpu_stats,
-        ):
-            resource_monitor = ResourceMonitor()
-            time.sleep(0.3)
-            resource_monitor.report_resource()
-            self.assertTrue(resource_monitor._total_cpu >= 0.0)
-            self.assertTrue(resource_monitor._gpu_stats == gpu_stats)
+        mock_env = {
+            NodeEnv.DLROVER_MASTER_ADDR: "127.0.0.1:12345",
+            NodeEnv.AUTO_MONITOR_WORKLOAD: "true",
+        }
+
+        with patch.dict("os.environ", mock_env):
+            result = not os.getenv(NodeEnv.DLROVER_MASTER_ADDR, "") or not (
+                os.getenv(NodeEnv.AUTO_MONITOR_WORKLOAD, "") == "true")
+            self.assertFalse(result)
+            # mock get_gpu_stats
+            with patch(
+                "dlrover.python.elastic_agent.monitor.resource.get_gpu_stats",
+                return_value=gpu_stats,
+            ):
+                resource_monitor = ResourceMonitor()
+                resource_monitor.start()
+                time.sleep(0.3)
+                resource_monitor.report_resource()
+                self.assertTrue(resource_monitor._total_cpu >= 0.0)
+                self.assertTrue(resource_monitor._gpu_stats == gpu_stats)
 
     def test_training_reporter(self):
         TF_CONFIG = {

--- a/dlrover/python/tests/test_master_client.py
+++ b/dlrover/python/tests/test_master_client.py
@@ -13,11 +13,12 @@
 
 import unittest
 
+from google.protobuf.empty_pb2 import Empty
+
 from dlrover.python.common.constants import TrainingMsgLevel
 from dlrover.python.elastic_agent.master_client import build_master_client
-from dlrover.python.tests.test_utils import start_local_master
 from dlrover.python.elastic_agent.monitor.metrics import GPUMetric
-from google.protobuf.empty_pb2 import Empty
+from dlrover.python.tests.test_utils import start_local_master
 
 
 class MasterClientTest(unittest.TestCase):
@@ -37,11 +38,8 @@ class MasterClientTest(unittest.TestCase):
                 gpu_utilization=55.5,
             )
         ]
-        result = self._master_client.report_used_resource(
-                1024, 10, gpu_stats)
+        result = self._master_client.report_used_resource(1024, 10, gpu_stats)
         self.assertIsInstance(result, Empty)
-
-
 
     def test_report_failures(self):
         res = self._master_client.report_failures(

--- a/dlrover/python/tests/test_master_client.py
+++ b/dlrover/python/tests/test_master_client.py
@@ -13,9 +13,11 @@
 
 import unittest
 
-from dlrover.python.common.constants import NodeType, TrainingMsgLevel
+from dlrover.python.common.constants import TrainingMsgLevel
 from dlrover.python.elastic_agent.master_client import build_master_client
 from dlrover.python.tests.test_utils import start_local_master
+from dlrover.python.elastic_agent.monitor.metrics import GPUMetric
+from google.protobuf.empty_pb2 import Empty
 
 
 class MasterClientTest(unittest.TestCase):
@@ -27,10 +29,19 @@ class MasterClientTest(unittest.TestCase):
         self._master.stop()
 
     def test_report_used_resource(self):
-        self._master_client.report_used_resource(1024, 10)
-        node = self._master.job_manager._job_nodes[NodeType.WORKER][0]
-        self.assertEqual(node.used_resource.cpu, 10)
-        self.assertEqual(node.used_resource.memory, 1024)
+        gpu_stats: list[GPUMetric] = [
+            GPUMetric(
+                index=0,
+                total_memory_mb=24000,
+                used_memory_mb=4000,
+                gpu_utilization=55.5,
+            )
+        ]
+        result = self._master_client.report_used_resource(
+                1024, 10, gpu_stats)
+        self.assertIsInstance(result, Empty)
+
+
 
     def test_report_failures(self):
         res = self._master_client.report_failures(


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add GPU statistic report to resource monitor by modifying report_resource.

### Why are the changes needed?

We need to report GPU statistics by grpc request to pass training statistics to master.

### Does this PR introduce any user-facing change?

NO.

### How was this patch tested?

Tests are performed using the included unit test code.
