### PR TITLE
A local job manager manages the status of the job on a single node.

### DIFF
--- a/dlrover/python/master/dist_master.py
+++ b/dlrover/python/master/dist_master.py
@@ -32,12 +32,12 @@ from dlrover.python.master.elastic_training.rdzv_manager import (
 from dlrover.python.master.elastic_training.sync_service import SyncService
 from dlrover.python.master.master import JobMaster
 from dlrover.python.master.monitor.speed_monitor import SpeedMonitor
+from dlrover.python.master.node.dist_job_manager import create_job_manager
 from dlrover.python.master.node.event_callback import (
     AllReduceNodeHandlingCallback,
     TaskRescheduleCallback,
     TFPSNodeHandlingCallback,
 )
-from dlrover.python.master.node.job_manager import create_job_manager
 from dlrover.python.master.servicer import create_master_service
 from dlrover.python.master.shard.task_manager import TaskManager
 from dlrover.python.master.stats.job_collector import JobMetricCollector

--- a/dlrover/python/master/elastic_training/sync_service.py
+++ b/dlrover/python/master/elastic_training/sync_service.py
@@ -18,14 +18,14 @@ from typing import Dict, List, Set, Tuple
 
 from dlrover.python.common.log import default_logger as logger
 from dlrover.python.common.node import Node
-from dlrover.python.master.node.job_manager import JobManager
+from dlrover.python.master.node.dist_job_manager import DistributedJobManager
 
 _WAIT_SYNC_TINEOUT = 3600
 
 
 class SyncService(object):
     def __init__(self, job_manager):
-        self._job_manager: JobManager = job_manager
+        self._job_manager: DistributedJobManager = job_manager
         self._sync_objs_target: Dict[str, List[Tuple[str, int]]] = {}
         self._finished_barriers: Set[str] = set()
         self._lock = threading.Lock()

--- a/dlrover/python/master/local_master.py
+++ b/dlrover/python/master/local_master.py
@@ -27,6 +27,7 @@ from dlrover.python.master.elastic_training.rdzv_manager import (
 )
 from dlrover.python.master.master import JobMaster
 from dlrover.python.master.monitor.speed_monitor import SpeedMonitor
+from dlrover.python.master.node.local_job_manager import create_job_manager
 from dlrover.python.master.servicer import create_master_service
 from dlrover.python.master.shard.task_manager import TaskManager
 from dlrover.python.master.stats.job_collector import JobMetricCollector
@@ -37,6 +38,7 @@ class LocalJobMaster(JobMaster):
     def __init__(self, port, args: JobArgs):
         self.speed_monitor = SpeedMonitor()
         self.task_manager = TaskManager(0, self.speed_monitor)
+        self.job_manager = create_job_manager(args, self.speed_monitor)
         elastic_training = RendezvousName.ELASTIC_TRAINING
         self.rdzv_managers: Dict[str, RendezvousManager] = {
             elastic_training: ElasticTrainingRendezvousManager(),
@@ -52,7 +54,7 @@ class LocalJobMaster(JobMaster):
         return create_master_service(
             port,
             self.task_manager,
-            None,
+            self.job_manager,
             self.speed_monitor,
             self.rdzv_managers,
             self.job_metric_collector,

--- a/dlrover/python/master/node/dist_job_manager.py
+++ b/dlrover/python/master/node/dist_job_manager.py
@@ -1,0 +1,722 @@
+# Copyright 2022 The DLRover Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import copy
+import os
+import threading
+import time
+import traceback
+from typing import Dict, List
+
+from dlrover.python.common.constants import (
+    DistributionStrategy,
+    NodeEventType,
+    NodeExitReason,
+    NodeResourceLimit,
+    NodeStatus,
+    NodeType,
+)
+from dlrover.python.common.global_context import Context
+from dlrover.python.common.log import default_logger as logger
+from dlrover.python.common.node import Node, NodeGroupResource
+from dlrover.python.master.monitor.error_monitor import (
+    ErrorLogMonitor,
+    ErrorMonitor,
+)
+from dlrover.python.master.monitor.speed_monitor import SpeedMonitor
+from dlrover.python.master.node.event_callback import (
+    ClusterContext,
+    NodeEventCallback,
+)
+from dlrover.python.master.node.job_auto_scaler import (
+    JobAutoScaler,
+    new_job_auto_scaler,
+)
+from dlrover.python.master.node.job_manager import JobManager
+from dlrover.python.master.node.ps import ParameterServerManager
+from dlrover.python.master.node.status_flow import (
+    NodeStateFlow,
+    get_node_state_flow,
+)
+from dlrover.python.master.node.training_node import (
+    get_critical_worker_index,
+    set_critical_node,
+    update_nodes_priority,
+)
+from dlrover.python.master.node.worker import (
+    ChiefManager,
+    EvaluatorManager,
+    WorkerManager,
+)
+from dlrover.python.master.resource.job import (
+    AllreduceJobResourceOptimizer,
+    JobResource,
+    JobResourceOptimizer,
+    PSJobResourceOptimizer,
+)
+from dlrover.python.master.scaler.base_scaler import ScalePlan, Scaler
+from dlrover.python.master.scaler.factory import new_job_scaler
+from dlrover.python.master.watcher.base_watcher import NodeEvent
+from dlrover.python.master.watcher.factory import (
+    new_node_watcher,
+    new_scale_plan_watcher,
+)
+from dlrover.python.scheduler.factory import new_elastic_job
+from dlrover.python.scheduler.job import ElasticJob, JobArgs
+
+_dlrover_context = Context.singleton_instance()
+
+_MAX_POD_RELAUNCH_COUNT = 5
+
+
+class DistributedJobManager(JobManager):
+    """DistributedJobManager manages the nodes of a distributed job on
+    a k8s cluster. For a job, the manager will:
+    - create nodes on a cluster.
+    - monitor nodes on a cluster.
+    - scale up/down nodes on a cluster.
+    """
+
+    def __init__(
+        self,
+        job_args: JobArgs,
+        critical_worker_index={},
+        wait_pending_relaunch=False,
+        speed_monitor=None,
+        job=None,
+        node_watcher=None,
+        job_scaler=None,
+        error_monitor=None,
+    ):
+        self._job_resource = JobResource()
+        node_restart_count: Dict[str, int] = {}
+        for type, node_args in job_args.node_args.items():
+            self._job_resource.node_group_resources[
+                type
+            ] = node_args.group_resource
+            node_restart_count[type] = node_args.restart_count
+
+        self._job_args = job_args
+        self._ps_is_critical = False
+        if (
+            job_args.distribution_strategy == DistributionStrategy.PS
+            or job_args.distribution_strategy == DistributionStrategy.CUSTOM
+        ):
+            self._ps_is_critical = (
+                job_args.node_args[NodeType.PS].critical_nodes == "all"
+            )
+            self._job_optimizer: JobResourceOptimizer = PSJobResourceOptimizer(
+                self._job_resource.node_group_resources[NodeType.WORKER],
+                self._job_resource.node_group_resources[NodeType.PS],
+                job_args.optimize_mode,
+                job_args.job_uuid,
+                job_args.resource_limits,
+            )
+        elif job_args.distribution_strategy == DistributionStrategy.ALLREDUCE:
+            self._job_optimizer = AllreduceJobResourceOptimizer(
+                self._job_resource.node_group_resources[NodeType.WORKER],
+                job_args.job_uuid,
+            )
+        else:
+            raise ValueError(
+                f"Distribution strategy {job_args.distribution_strategy} "
+                "is not supported. You can specify it with "
+                "ParameterServerStrategy/AllreduceStrategy."
+            )
+        logger.info("New job optimizer : %s", self._job_optimizer.__class__)
+
+        worker_restart_count = node_restart_count.get(NodeType.WORKER, 0)
+        ps_restart_count = node_restart_count.get(NodeType.PS, 0)
+
+        self._relaunch_on_worker_failure = min(
+            worker_restart_count, _MAX_POD_RELAUNCH_COUNT
+        )
+        self._wait_pending_relaunch = wait_pending_relaunch
+        self._start_launch_waiting_workers_time = time.time()
+        self._critical_worker_index = critical_worker_index
+        self._ps_relaunch_max_num = min(
+            ps_restart_count, _MAX_POD_RELAUNCH_COUNT
+        )
+        self._node_event_callbacks: List[NodeEventCallback] = []
+        self._stop_monitor = False
+        self._speed_monitor: SpeedMonitor = speed_monitor
+        self._error_monitor: ErrorMonitor = error_monitor
+
+        # Protects followed variables, which are accessed from event_cb.
+        self._lock = threading.Lock()
+        self._job_nodes: Dict[str, Dict[int, Node]] = {}
+
+        self._elastic_job: ElasticJob = job
+        self._node_watcher = node_watcher
+
+        self._scaler_watcher = new_scale_plan_watcher(
+            job_args.platform,
+            job_args.job_name,
+            job_args.namespace,
+            job_args.job_uuid,
+        )
+        self._scaler: Scaler = job_scaler
+        self._init_training_node_manager()
+
+    def start(self):
+        self._job_optimizer.update_job_uuid(self._job_args.job_uuid)
+        self._job_optimizer.init_job_resource(self._job_resource)
+        self._adjust_worker_for_estimator()
+        self._init_nodes()
+        self._init_job_auto_scaler()
+        plan = self._create_initial_scale_plan()
+        self._scaler.scale(plan)
+        worker_num = 0
+        if NodeType.WORKER in plan.node_group_resources:
+            worker_num = plan.node_group_resources[NodeType.WORKER].count
+        if NodeType.CHIEF in plan.node_group_resources:
+            worker_num += plan.node_group_resources[NodeType.CHIEF].count
+        self._speed_monitor.set_target_worker_num(worker_num)
+        threading.Thread(
+            target=self._monitor_nodes, name="node_monitor", daemon=True
+        ).start()
+        if os.getenv("KUBERNETES_SERVICE_HOST"):
+            threading.Thread(
+                target=self._monitor_scale_plan_crd,
+                name="scaleplan_monitor",
+                daemon=True,
+            ).start()
+
+    def _adjust_worker_for_estimator(self):
+        if self._job_args.distribution_strategy == DistributionStrategy.PS:
+            self._job_resource.adjust_worker_for_estimator()
+
+    def _create_initial_scale_plan(self):
+        scale_plan = ScalePlan()
+        scale_plan.node_group_resources = copy.deepcopy(
+            self._job_resource.node_group_resources
+        )
+        scale_plan.ps_addrs = self._ps_manager.get_ps_addrs()
+        return scale_plan
+
+    def _init_training_node_manager(self):
+        self._ps_manager = ParameterServerManager(
+            self._job_nodes.get(NodeType.PS, {}),
+            self._job_resource,
+            self._ps_relaunch_max_num,
+            self._elastic_job.get_node_service_addr,
+            self._elastic_job.get_node_name,
+        )
+
+        chief_nodes = self._job_nodes.get(NodeType.CHIEF, {})
+        if not chief_nodes:
+            chief_nodes = self._job_nodes.get(NodeType.MASTER, {})
+        self._chief_manager = ChiefManager(
+            chief_nodes,
+            self._job_resource,
+            self._relaunch_on_worker_failure,
+            self._elastic_job.get_node_service_addr,
+            self._elastic_job.get_node_name,
+        )
+        self._worker_manager = WorkerManager(
+            self._job_nodes.get(NodeType.WORKER, {}),
+            self._job_resource,
+            self._relaunch_on_worker_failure,
+            self._elastic_job.get_node_service_addr,
+            self._elastic_job.get_node_name,
+        )
+        self._evaluator_manager = EvaluatorManager(
+            self._job_nodes.get(NodeType.EVALUATOR, {}),
+            self._job_resource,
+            self._relaunch_on_worker_failure,
+            self._elastic_job.get_node_service_addr,
+            self._elastic_job.get_node_name,
+        )
+
+    def add_node_event_callback(self, node_event_callback):
+        self._node_event_callbacks.append(node_event_callback)
+
+    def _init_nodes(self):
+        self._job_nodes = self._job_resource.init_job_node_meta(
+            self._relaunch_on_worker_failure,
+            self._elastic_job.get_node_service_addr,
+            self._elastic_job.get_node_name,
+        )
+
+        # worker and eval ids for nodes that should be created
+        # after all ps are running.
+        self._workers_waiting_ps_running = []
+
+        self._enable_relaunch_node = True
+        self._pending_relaunch_count = 0
+
+        set_critical_node(
+            self._job_nodes,
+            self._ps_is_critical,
+            self._ps_relaunch_max_num,
+            self._critical_worker_index,
+        )
+        update_nodes_priority(self._job_nodes)
+
+        self._ps_manager.update_nodes(self._job_nodes.get(NodeType.PS, {}))
+        self._chief_manager.update_nodes(
+            self._job_nodes.get(NodeType.CHIEF, {})
+        )
+        self._worker_manager.update_nodes(
+            self._job_nodes.get(NodeType.WORKER, {})
+        )
+        self._evaluator_manager.update_nodes(
+            self._job_nodes.get(NodeType.EVALUATOR, {})
+        )
+
+    def _init_job_auto_scaler(self):
+        self._job_autoscaler: JobAutoScaler = new_job_auto_scaler(
+            self._job_args.distribution_strategy,
+            self._job_resource,
+            self._job_nodes,
+            self._job_optimizer,
+            self._speed_monitor,
+            self._ps_manager,
+            self._worker_manager,
+            self._scaler,
+        )
+        logger.info(
+            "Create job autoscaler: %s", self._job_autoscaler.__class__
+        )
+
+    def _monitor_nodes(self):
+        logger.info("Start to monitor nodes")
+        while True:
+            nodes = self._node_watcher.list()
+            self._process_list_nodes(nodes)
+            try:
+                if self._stop_monitor:
+                    logger.info("Stop processing node events")
+                    break
+                for event in self._node_watcher.watch():
+                    try:
+                        self._process_event(event)
+                    except Exception as e:
+                        logger.warning(e)
+                        detail_trace_back = traceback.format_exc()
+                        logger.warning(detail_trace_back)
+            except Exception as e:
+                logger.warning(e)
+                time.sleep(30)
+
+    def _monitor_scale_plan_crd(self):
+        """Monitor the Scaler CRD from users to adjust the job resource"""
+        logger.info("Start to monitor Scaler CRD")
+        while True:
+            try:
+                if self._stop_monitor:
+                    logger.info("Stop monitoring Scaler CRDs")
+                    break
+                for plan in self._scaler_watcher.watch():
+                    try:
+                        self._job_autoscaler.execute_job_optimization_plan(
+                            plan
+                        )
+                    except Exception as e:
+                        logger.warning(e)
+                        detail_trace_back = traceback.format_exc()
+                        logger.warning(detail_trace_back)
+            except Exception as e:
+                logger.warning(e)
+                detail_trace_back = traceback.format_exc()
+                logger.warning(detail_trace_back)
+                time.sleep(5)
+
+    def _process_list_nodes(self, nodes: List[Node]):
+        """Callback with node list by the list api of k8s."""
+        if not nodes:
+            return
+        exist_nodes: Dict[str, List[int]] = {}
+        for node_type in self._job_nodes.keys():
+            exist_nodes[node_type] = []
+        for node in nodes:
+            exist_nodes[node.type].append(node.id)
+            if node.status == NodeStatus.DELETED:
+                type = NodeEventType.DELETED
+            else:
+                type = NodeEventType.MODIFIED
+            # Mock event to avoid missing events
+            event = NodeEvent(type, node)
+            self._process_event(event)
+
+        for node_type in self._job_nodes.keys():
+            for node_id, node in self._job_nodes[node_type].items():
+                if (
+                    node.status != NodeStatus.INITIAL
+                    and not node.is_released
+                    and node_id not in exist_nodes[node_type]
+                ):
+                    logger.info(
+                        "Node %s %s is deleted without the event",
+                        node_type,
+                        node_id,
+                    )
+                    node.is_released = True
+                    new_node = copy.deepcopy(node)
+                    new_node.status = NodeStatus.DELETED
+                    event = NodeEvent(NodeEventType.DELETED, new_node)
+                    self._process_event(event)
+
+    def close_job(self):
+        plan = ScalePlan()
+        ps_resource = NodeGroupResource.new_empty()
+        worker_reource = NodeGroupResource.new_empty()
+        plan.node_group_resources = {
+            "worker": worker_reource,
+            "ps": ps_resource,
+        }
+        self._scaler.scale(plan=plan)
+        os._exit(0)
+
+    def _process_event(self, event: NodeEvent):
+        node_type = event.node.type
+        node_id = event.node.id
+        if node_id not in self._job_nodes[node_type]:
+            self._job_nodes[node_type][node_id] = event.node
+            return
+        else:
+            cur_node = self._job_nodes[node_type][node_id]
+            cur_node.update_info(
+                name=event.node.name,
+                start_time=event.node.start_time,
+                create_time=event.node.create_time,
+                host_name=event.node.host_name,
+                host_ip=event.node.host_ip,
+            )
+
+        # For the given node id, check whether it meets
+        # the state change condition
+        if event.event_type == "exit":
+            self.close_job()
+        new_status = event.node.status
+        with self._lock:
+            old_status = cur_node.status
+            status_change_flow: NodeStateFlow = get_node_state_flow(
+                old_status, event.event_type, new_status
+            )
+            cur_node.update_status(new_status)
+            # If there is no matched state change, return directly
+            # If the node has been succeed, return directly
+            if (
+                status_change_flow is None
+                or status_change_flow.from_status == NodeStatus.SUCCEEDED
+            ):
+                return
+
+            # Update the node status
+            new_status = status_change_flow.to_status
+            cur_node.set_exit_reason(event.node.exit_reason)
+            self._process_node_events(status_change_flow, cur_node)
+
+            should_relaunch = self._should_relaunch(
+                cur_node, status_change_flow
+            )
+            if should_relaunch and self._wait_pending_relaunch:
+                self._pending_relaunch_count += 1
+
+        logger.info(
+            "%s status change: %s to %s, by evt_type %s reason %s",
+            cur_node.name,
+            old_status,
+            new_status,
+            event.event_type,
+            cur_node.exit_reason,
+        )
+
+        if should_relaunch:
+            self._relaunch_node(cur_node)
+
+    def _process_node_events(
+        self, status_change_flow: NodeStateFlow, node: Node
+    ):
+        cluster_context = ClusterContext(job_manager=self)
+        if status_change_flow.to_status == NodeStatus.RUNNING:
+            [
+                callback.on_node_started(node, cluster_context)
+                for callback in self._node_event_callbacks
+            ]
+        elif status_change_flow.to_status == NodeStatus.SUCCEEDED:
+            [
+                callback.on_node_succeeded(node, cluster_context)
+                for callback in self._node_event_callbacks
+            ]
+        elif status_change_flow.to_status == NodeStatus.FAILED:
+            [
+                callback.on_node_failed(node, cluster_context)
+                for callback in self._node_event_callbacks
+            ]
+        elif (
+            status_change_flow.from_status != NodeStatus.FAILED
+            and status_change_flow.from_status != NodeStatus.SUCCEEDED
+            and status_change_flow.to_status == NodeStatus.DELETED
+        ):
+            [
+                callback.on_node_deleted(node, cluster_context)
+                for callback in self._node_event_callbacks
+            ]
+
+    def _should_relaunch(self, node: Node, status_change_flow: NodeStateFlow):
+        should_relaunch = (
+            status_change_flow.should_relaunch
+            and self._enable_relaunch_node
+            and node.relaunchable
+        )
+        if should_relaunch:
+            if (
+                node.exit_reason == NodeExitReason.FATAL_ERROR
+                and not _dlrover_context.relaunch_always
+            ):
+                should_relaunch = False
+            elif node.exit_reason == NodeExitReason.OOM:
+                mem = node.config_resource.memory
+                if mem >= NodeResourceLimit.MAX_MEMORY:
+                    should_relaunch = False
+                    logger.warning(
+                        "The memory of worker %s is beyond the limit %s MB.",
+                        mem,
+                        NodeResourceLimit.MAX_MEMORY,
+                    )
+                elif node.relaunch_count >= node.max_relaunch_count:
+                    should_relaunch = False
+                    logger.warning(
+                        "The relaunched count %s is beyond the maximum %s.",
+                        node.relaunch_count,
+                        node.max_relaunch_count,
+                    )
+                else:
+                    node.is_recovered_oom = True
+                    self._job_optimizer.adjust_oom_resource(node)
+            elif node.exit_reason != NodeExitReason.KILLED:
+                if node.relaunch_count >= node.max_relaunch_count:
+                    logger.warning(
+                        "The relaunch count "
+                        f"{node.relaunch_count}/{node.max_relaunch_count} "
+                        "has been exhausted."
+                    )
+                    should_relaunch = False
+        if should_relaunch:
+            node.inc_relaunch_count()
+
+        return should_relaunch
+
+    def _relaunch_node(self, node: Node):
+        if node.type == NodeType.WORKER:
+            plan = self._worker_manager.relaunch_node(node)
+        elif node.type == NodeType.PS:
+            plan = self._ps_manager.relaunch_node(node)
+        elif node.type == NodeType.EVALUATOR:
+            plan = self._evaluator_manager.relaunch_node(node)
+        elif node.type == NodeType.CHIEF or node.type == NodeType.MASTER:
+            plan = self._chief_manager.relaunch_node(node)
+        else:
+            logger.error("Not support node type %s", node.type)
+        self._set_ps_addrs_in_plan(plan)
+        self._scaler.scale(plan)
+
+    def all_workers_exited(self):
+        return (
+            self._chief_manager.all_nodes_exited()
+            and self._worker_manager.all_nodes_exited()
+            and self._evaluator_manager.all_nodes_exited()
+        )
+
+    def all_workers_failed(self):
+        return (
+            self._chief_manager.all_nodes_failed()
+            and self._worker_manager.all_nodes_failed()
+            and self._evaluator_manager.all_nodes_failed()
+        )
+
+    def all_workers_deleted(self):
+        return (
+            self._chief_manager.all_nodes_deleted()
+            and self._worker_manager.all_nodes_deleted()
+            and self._evaluator_manager.all_nodes_deleted()
+        )
+
+    def all_critical_node_completed(self):
+        alive_critical_nodes = []
+        for _, nodes in self._job_nodes.items():
+            for node in nodes.values():
+                if node.critical and node.status in [
+                    NodeStatus.INITIAL,
+                    NodeStatus.PENDING,
+                    NodeStatus.RUNNING,
+                ]:
+                    alive_critical_nodes.append(node.name)
+
+        completed = not alive_critical_nodes
+        if not completed:
+            logger.info("Critical nodes %s are running.", alive_critical_nodes)
+        return completed
+
+    def remove_worker(self, worker_id):
+        if self._job_nodes[NodeType.WORKER][worker_id].critical:
+            logger.info("Skip the critical worker %s", worker_id)
+        else:
+            logger.info("Delete worker %s", worker_id)
+            plan = self._worker_manager.remove_node(worker_id)
+            logger.info("plan %s", plan.toJSON())
+            self._scaler.scale(plan)
+
+    def get_running_nodes(self):
+        nodes = self._chief_manager.get_running_nodes()
+        nodes.extend(self._worker_manager.get_running_nodes())
+        nodes.extend(self._evaluator_manager.get_running_nodes())
+        nodes.extend(self._ps_manager.get_running_nodes())
+        return nodes
+
+    def get_running_workers(self):
+        workers = self._worker_manager.get_running_nodes()
+        chiefs = self._chief_manager.get_running_nodes()
+        workers.extend(chiefs)
+        return workers
+
+    def post_ps_ready(self):
+        plan = self._ps_manager.process_after_ps_cluster_ready()
+        if not plan.empty():
+            self._scaler.scale(plan)
+        else:
+            logger.info("Skip an empty scaleplan")
+
+    def stop(self):
+        self._enable_relaunch_node = False
+        with self._lock:
+            for node_type in self._job_nodes.keys():
+                for node in self._job_nodes[node_type].values():
+                    node.critical = False
+                    node.is_released = True
+                    node.relaunchable = False
+            for node in self._job_nodes[NodeType.WORKER].values():
+                node.eval_time = self._speed_monitor.get_worker_eval_time(
+                    node.id
+                )
+        self._stop_monitor = True
+
+    def update_node_resource_usage(self, node_type, node_id, cpu, memory):
+        node = self._job_nodes[node_type][node_id]
+        node.update_resource_usage(cpu, memory)
+
+    def update_node_service_addr(self, node_type, node_id, service_addr):
+        node = self._job_nodes[node_type][node_id]
+        node.update_service_address(service_addr)
+        node.status = NodeStatus.RUNNING
+        node.is_released = False
+        self._job_nodes[node_type][node_id] = node
+
+    def get_cur_cluster_ps(self):
+        """Get PS nodes in the current training cluster."""
+        logger.info("job nodes are {}".format(self._job_nodes))
+        return self._ps_manager.get_training_ps_cluster()
+
+    def get_next_cluster_ps(self):
+        """Get PS nodes in the next training cluster."""
+        return self._ps_manager.get_next_training_ps_cluster()
+
+    def ready_for_new_ps_cluster(self):
+        """Check whether ps cluster is used to training"""
+        return self._ps_manager.get_ready_for_new_ps_cluster()
+
+    def has_ps_failure(self):
+        """Check whether ther is PS failure"""
+        return self._ps_manager.has_ps_failure()
+
+    def remove_training_nodes(self):
+        """Remove all PS and workers"""
+        self._job_autoscaler.stop_auto_scaling()
+        plan = ScalePlan()
+        training_nodes = list(
+            self._job_nodes[NodeType.WORKER].values()
+        ) + list(self._job_nodes[NodeType.PS].values())
+        for node in training_nodes:
+            if (
+                node.status in [NodeStatus.RUNNING, NodeStatus.PENDING]
+                and not node.is_released
+            ):
+                node.critical = False
+                node.relaunchable = False
+                node.is_released = True
+                node.status = NodeStatus.DELETED
+                logger.info("Remove node %s", node.name)
+                plan.remove_nodes.append(node)
+        self._scaler.scale(plan)
+
+    def start_auto_scaling(self):
+        """Start to auto-scale nodes to improve the training throughput."""
+        self._job_autoscaler.start_auto_scaling()
+
+    def _set_ps_addrs_in_plan(self, plan: ScalePlan):
+        ps_addrs = self._ps_manager.get_ps_addrs()
+        plan.ps_addrs.extend(ps_addrs)
+
+    def all_running_node_hanged(self):
+        node_hang = self._worker_manager.running_nodes_hanged()
+        node_hang.extend(self._chief_manager.running_nodes_hanged())
+        node_hang.extend(self._evaluator_manager.running_nodes_hanged())
+        node_hang.extend(self._ps_manager.running_nodes_hanged())
+        if node_hang:
+            return all(node_hang)
+        return False
+
+    def remove_not_joined_rdzv_workers(self, worker_ranks):
+        plan = self._worker_manager.remove_not_joined_rdzv_workers(
+            worker_ranks
+        )
+        self._scaler.scale(plan)
+
+    def pend_without_workers(self):
+        """Check whether to wait for evicted workers."""
+        if self._worker_manager.has_failed_worker():
+            return False
+        elif self._worker_manager.wait_worker_restart():
+            return True
+        else:
+            return False
+
+    def handle_training_failure(
+        self, node_type, node_id, restart_count=-1, error_data="", level=""
+    ):
+        """Process the training failure reported by the node."""
+        node = self._job_nodes[node_type][node_id]
+        self._error_monitor.process_error(
+            node, restart_count, error_data, level
+        )
+
+    def update_allreduce_node_unit(self, node_unit):
+        if isinstance(self._job_optimizer, AllreduceJobResourceOptimizer):
+            self._job_optimizer.set_node_unit(node_unit)
+
+
+def create_job_manager(args: JobArgs, speed_monitor) -> DistributedJobManager:
+    critical_worker_index = get_critical_worker_index(args)
+    # Custom distribution strategy does not exit if there are pending nodes
+    wait_pending_relaunch = (
+        args.distribution_strategy == DistributionStrategy.CUSTOM
+    )
+
+    elastic_job = new_elastic_job(args.platform, args.job_name, args.namespace)
+    node_watcher = new_node_watcher(
+        args.platform, args.job_name, args.namespace
+    )
+    job_scaler = new_job_scaler(args.platform, args.job_name, args.namespace)
+
+    return DistributedJobManager(
+        job_args=args,
+        critical_worker_index=critical_worker_index,
+        wait_pending_relaunch=wait_pending_relaunch,
+        speed_monitor=speed_monitor,
+        job=elastic_job,
+        node_watcher=node_watcher,
+        job_scaler=job_scaler,
+        error_monitor=ErrorLogMonitor(),
+    )

--- a/dlrover/python/master/node/job_manager.py
+++ b/dlrover/python/master/node/job_manager.py
@@ -10,670 +10,110 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-import copy
-import os
-import threading
-import time
-import traceback
-from typing import Dict, List
-
-from dlrover.python.common.constants import (
-    DistributionStrategy,
-    NodeEventType,
-    NodeExitReason,
-    NodeResourceLimit,
-    NodeStatus,
-    NodeType,
-)
-from dlrover.python.common.global_context import Context
-from dlrover.python.common.log import default_logger as logger
-from dlrover.python.common.node import Node, NodeGroupResource
-from dlrover.python.master.monitor.error_monitor import (
-    ErrorLogMonitor,
-    ErrorMonitor,
-)
-from dlrover.python.master.monitor.speed_monitor import SpeedMonitor
-from dlrover.python.master.node.event_callback import (
-    ClusterContext,
-    NodeEventCallback,
-)
-from dlrover.python.master.node.job_auto_scaler import (
-    JobAutoScaler,
-    new_job_auto_scaler,
-)
-from dlrover.python.master.node.ps import ParameterServerManager
-from dlrover.python.master.node.status_flow import (
-    NodeStateFlow,
-    get_node_state_flow,
-)
-from dlrover.python.master.node.training_node import (
-    get_critical_worker_index,
-    set_critical_node,
-    update_nodes_priority,
-)
-from dlrover.python.master.node.worker import (
-    ChiefManager,
-    EvaluatorManager,
-    WorkerManager,
-)
-from dlrover.python.master.resource.job import (
-    AllreduceJobResourceOptimizer,
-    JobResource,
-    JobResourceOptimizer,
-    PSJobResourceOptimizer,
-)
-from dlrover.python.master.scaler.base_scaler import ScalePlan, Scaler
-from dlrover.python.master.scaler.factory import new_job_scaler
-from dlrover.python.master.watcher.base_watcher import NodeEvent
-from dlrover.python.master.watcher.factory import (
-    new_node_watcher,
-    new_scale_plan_watcher,
-)
-from dlrover.python.scheduler.factory import new_elastic_job
-from dlrover.python.scheduler.job import ElasticJob, JobArgs
-
-_dlrover_context = Context.singleton_instance()
-
-_MAX_POD_RELAUNCH_COUNT = 5
+from abc import ABCMeta, abstractclassmethod
 
 
-class JobManager(object):
-    def __init__(
-        self,
-        job_args: JobArgs,
-        critical_worker_index={},
-        wait_pending_relaunch=False,
-        speed_monitor=None,
-        job=None,
-        node_watcher=None,
-        job_scaler=None,
-        error_monitor=None,
-    ):
-        self._job_resource = JobResource()
-        node_restart_count: Dict[str, int] = {}
-        for type, node_args in job_args.node_args.items():
-            self._job_resource.node_group_resources[
-                type
-            ] = node_args.group_resource
-            node_restart_count[type] = node_args.restart_count
+class JobManager(metaclass=ABCMeta):
+    """The manager manages the status of a job including the running
+    nodes and training hyper-parameters.
+    """
 
-        self._job_args = job_args
-        self._ps_is_critical = False
-        if (
-            job_args.distribution_strategy == DistributionStrategy.PS
-            or job_args.distribution_strategy == DistributionStrategy.CUSTOM
-        ):
-            self._ps_is_critical = (
-                job_args.node_args[NodeType.PS].critical_nodes == "all"
-            )
-            self._job_optimizer: JobResourceOptimizer = PSJobResourceOptimizer(
-                self._job_resource.node_group_resources[NodeType.WORKER],
-                self._job_resource.node_group_resources[NodeType.PS],
-                job_args.optimize_mode,
-                job_args.job_uuid,
-                job_args.resource_limits,
-            )
-        elif job_args.distribution_strategy == DistributionStrategy.ALLREDUCE:
-            self._job_optimizer = AllreduceJobResourceOptimizer(
-                self._job_resource.node_group_resources[NodeType.WORKER],
-                job_args.job_uuid,
-            )
-        else:
-            raise ValueError(
-                f"Distribution strategy {job_args.distribution_strategy} "
-                "is not supported. You can specify it with "
-                "ParameterServerStrategy/AllreduceStrategy."
-            )
-        logger.info("New job optimizer : %s", self._job_optimizer.__class__)
-
-        worker_restart_count = node_restart_count.get(NodeType.WORKER, 0)
-        ps_restart_count = node_restart_count.get(NodeType.PS, 0)
-
-        self._relaunch_on_worker_failure = min(
-            worker_restart_count, _MAX_POD_RELAUNCH_COUNT
-        )
-        self._wait_pending_relaunch = wait_pending_relaunch
-        self._start_launch_waiting_workers_time = time.time()
-        self._critical_worker_index = critical_worker_index
-        self._ps_relaunch_max_num = min(
-            ps_restart_count, _MAX_POD_RELAUNCH_COUNT
-        )
-        self._node_event_callbacks: List[NodeEventCallback] = []
-        self._stop_monitor = False
-        self._speed_monitor: SpeedMonitor = speed_monitor
-        self._error_monitor: ErrorMonitor = error_monitor
-
-        # Protects followed variables, which are accessed from event_cb.
-        self._lock = threading.Lock()
-        self._job_nodes: Dict[str, Dict[int, Node]] = {}
-
-        self._elastic_job: ElasticJob = job
-        self._node_watcher = node_watcher
-
-        self._scaler_watcher = new_scale_plan_watcher(
-            job_args.platform,
-            job_args.job_name,
-            job_args.namespace,
-            job_args.job_uuid,
-        )
-        self._scaler: Scaler = job_scaler
-        self._init_training_node_manager()
-
+    @abstractclassmethod
     def start(self):
-        self._job_optimizer.update_job_uuid(self._job_args.job_uuid)
-        self._job_optimizer.init_job_resource(self._job_resource)
-        self._adjust_worker_for_estimator()
-        self._init_nodes()
-        self._init_job_auto_scaler()
-        plan = self._create_initial_scale_plan()
-        self._scaler.scale(plan)
-        worker_num = 0
-        if NodeType.WORKER in plan.node_group_resources:
-            worker_num = plan.node_group_resources[NodeType.WORKER].count
-        if NodeType.CHIEF in plan.node_group_resources:
-            worker_num += plan.node_group_resources[NodeType.CHIEF].count
-        self._speed_monitor.set_target_worker_num(worker_num)
-        threading.Thread(
-            target=self._monitor_nodes, name="node_monitor", daemon=True
-        ).start()
-        if os.getenv("KUBERNETES_SERVICE_HOST"):
-            threading.Thread(
-                target=self._monitor_scale_plan_crd,
-                name="scaleplan_monitor",
-                daemon=True,
-            ).start()
+        pass
 
-    def _adjust_worker_for_estimator(self):
-        if self._job_args.distribution_strategy == DistributionStrategy.PS:
-            self._job_resource.adjust_worker_for_estimator()
-
-    def _create_initial_scale_plan(self):
-        scale_plan = ScalePlan()
-        scale_plan.node_group_resources = copy.deepcopy(
-            self._job_resource.node_group_resources
-        )
-        scale_plan.ps_addrs = self._ps_manager.get_ps_addrs()
-        return scale_plan
-
-    def _init_training_node_manager(self):
-        self._ps_manager = ParameterServerManager(
-            self._job_nodes.get(NodeType.PS, {}),
-            self._job_resource,
-            self._ps_relaunch_max_num,
-            self._elastic_job.get_node_service_addr,
-            self._elastic_job.get_node_name,
-        )
-
-        chief_nodes = self._job_nodes.get(NodeType.CHIEF, {})
-        if not chief_nodes:
-            chief_nodes = self._job_nodes.get(NodeType.MASTER, {})
-        self._chief_manager = ChiefManager(
-            chief_nodes,
-            self._job_resource,
-            self._relaunch_on_worker_failure,
-            self._elastic_job.get_node_service_addr,
-            self._elastic_job.get_node_name,
-        )
-        self._worker_manager = WorkerManager(
-            self._job_nodes.get(NodeType.WORKER, {}),
-            self._job_resource,
-            self._relaunch_on_worker_failure,
-            self._elastic_job.get_node_service_addr,
-            self._elastic_job.get_node_name,
-        )
-        self._evaluator_manager = EvaluatorManager(
-            self._job_nodes.get(NodeType.EVALUATOR, {}),
-            self._job_resource,
-            self._relaunch_on_worker_failure,
-            self._elastic_job.get_node_service_addr,
-            self._elastic_job.get_node_name,
-        )
-
+    @abstractclassmethod
     def add_node_event_callback(self, node_event_callback):
-        self._node_event_callbacks.append(node_event_callback)
+        pass
 
-    def _init_nodes(self):
-        self._job_nodes = self._job_resource.init_job_node_meta(
-            self._relaunch_on_worker_failure,
-            self._elastic_job.get_node_service_addr,
-            self._elastic_job.get_node_name,
-        )
-
-        # worker and eval ids for nodes that should be created
-        # after all ps are running.
-        self._workers_waiting_ps_running = []
-
-        self._enable_relaunch_node = True
-        self._pending_relaunch_count = 0
-
-        set_critical_node(
-            self._job_nodes,
-            self._ps_is_critical,
-            self._ps_relaunch_max_num,
-            self._critical_worker_index,
-        )
-        update_nodes_priority(self._job_nodes)
-
-        self._ps_manager.update_nodes(self._job_nodes.get(NodeType.PS, {}))
-        self._chief_manager.update_nodes(
-            self._job_nodes.get(NodeType.CHIEF, {})
-        )
-        self._worker_manager.update_nodes(
-            self._job_nodes.get(NodeType.WORKER, {})
-        )
-        self._evaluator_manager.update_nodes(
-            self._job_nodes.get(NodeType.EVALUATOR, {})
-        )
-
-    def _init_job_auto_scaler(self):
-        self._job_autoscaler: JobAutoScaler = new_job_auto_scaler(
-            self._job_args.distribution_strategy,
-            self._job_resource,
-            self._job_nodes,
-            self._job_optimizer,
-            self._speed_monitor,
-            self._ps_manager,
-            self._worker_manager,
-            self._scaler,
-        )
-        logger.info(
-            "Create job autoscaler: %s", self._job_autoscaler.__class__
-        )
-
-    def _monitor_nodes(self):
-        logger.info("Start to monitor nodes")
-        while True:
-            nodes = self._node_watcher.list()
-            self._process_list_nodes(nodes)
-            try:
-                if self._stop_monitor:
-                    logger.info("Stop processing node events")
-                    break
-                for event in self._node_watcher.watch():
-                    try:
-                        self._process_event(event)
-                    except Exception as e:
-                        logger.warning(e)
-                        detail_trace_back = traceback.format_exc()
-                        logger.warning(detail_trace_back)
-            except Exception as e:
-                logger.warning(e)
-                time.sleep(30)
-
-    def _monitor_scale_plan_crd(self):
-        """Monitor the Scaler CRD from users to adjust the job resource"""
-        logger.info("Start to monitor Scaler CRD")
-        while True:
-            try:
-                if self._stop_monitor:
-                    logger.info("Stop monitoring Scaler CRDs")
-                    break
-                for plan in self._scaler_watcher.watch():
-                    try:
-                        self._job_autoscaler.execute_job_optimization_plan(
-                            plan
-                        )
-                    except Exception as e:
-                        logger.warning(e)
-                        detail_trace_back = traceback.format_exc()
-                        logger.warning(detail_trace_back)
-            except Exception as e:
-                logger.warning(e)
-                detail_trace_back = traceback.format_exc()
-                logger.warning(detail_trace_back)
-                time.sleep(5)
-
-    def _process_list_nodes(self, nodes: List[Node]):
-        """Callback with node list by the list api of k8s."""
-        if not nodes:
-            return
-        exist_nodes: Dict[str, List[int]] = {}
-        for node_type in self._job_nodes.keys():
-            exist_nodes[node_type] = []
-        for node in nodes:
-            exist_nodes[node.type].append(node.id)
-            if node.status == NodeStatus.DELETED:
-                type = NodeEventType.DELETED
-            else:
-                type = NodeEventType.MODIFIED
-            # Mock event to avoid missing events
-            event = NodeEvent(type, node)
-            self._process_event(event)
-
-        for node_type in self._job_nodes.keys():
-            for node_id, node in self._job_nodes[node_type].items():
-                if (
-                    node.status != NodeStatus.INITIAL
-                    and not node.is_released
-                    and node_id not in exist_nodes[node_type]
-                ):
-                    logger.info(
-                        "Node %s %s is deleted without the event",
-                        node_type,
-                        node_id,
-                    )
-                    node.is_released = True
-                    new_node = copy.deepcopy(node)
-                    new_node.status = NodeStatus.DELETED
-                    event = NodeEvent(NodeEventType.DELETED, new_node)
-                    self._process_event(event)
-
-    def close_job(self):
-        plan = ScalePlan()
-        ps_resource = NodeGroupResource.new_empty()
-        worker_reource = NodeGroupResource.new_empty()
-        plan.node_group_resources = {
-            "worker": worker_reource,
-            "ps": ps_resource,
-        }
-        self._scaler.scale(plan=plan)
-        os._exit(0)
-
-    def _process_event(self, event: NodeEvent):
-        node_type = event.node.type
-        node_id = event.node.id
-        if node_id not in self._job_nodes[node_type]:
-            self._job_nodes[node_type][node_id] = event.node
-            return
-        else:
-            cur_node = self._job_nodes[node_type][node_id]
-            cur_node.update_info(
-                name=event.node.name,
-                start_time=event.node.start_time,
-                create_time=event.node.create_time,
-                host_name=event.node.host_name,
-                host_ip=event.node.host_ip,
-            )
-
-        # For the given node id, check whether it meets
-        # the state change condition
-        if event.event_type == "exit":
-            self.close_job()
-        new_status = event.node.status
-        with self._lock:
-            old_status = cur_node.status
-            status_change_flow: NodeStateFlow = get_node_state_flow(
-                old_status, event.event_type, new_status
-            )
-            cur_node.update_status(new_status)
-            # If there is no matched state change, return directly
-            # If the node has been succeed, return directly
-            if (
-                status_change_flow is None
-                or status_change_flow.from_status == NodeStatus.SUCCEEDED
-            ):
-                return
-
-            # Update the node status
-            new_status = status_change_flow.to_status
-            cur_node.set_exit_reason(event.node.exit_reason)
-            self._process_node_events(status_change_flow, cur_node)
-
-            should_relaunch = self._should_relaunch(
-                cur_node, status_change_flow
-            )
-            if should_relaunch and self._wait_pending_relaunch:
-                self._pending_relaunch_count += 1
-
-        logger.info(
-            "%s status change: %s to %s, by evt_type %s reason %s",
-            cur_node.name,
-            old_status,
-            new_status,
-            event.event_type,
-            cur_node.exit_reason,
-        )
-
-        if should_relaunch:
-            self._relaunch_node(cur_node)
-
-    def _process_node_events(
-        self, status_change_flow: NodeStateFlow, node: Node
-    ):
-        cluster_context = ClusterContext(job_manager=self)
-        if status_change_flow.to_status == NodeStatus.RUNNING:
-            [
-                callback.on_node_started(node, cluster_context)
-                for callback in self._node_event_callbacks
-            ]
-        elif status_change_flow.to_status == NodeStatus.SUCCEEDED:
-            [
-                callback.on_node_succeeded(node, cluster_context)
-                for callback in self._node_event_callbacks
-            ]
-        elif status_change_flow.to_status == NodeStatus.FAILED:
-            [
-                callback.on_node_failed(node, cluster_context)
-                for callback in self._node_event_callbacks
-            ]
-        elif (
-            status_change_flow.from_status != NodeStatus.FAILED
-            and status_change_flow.from_status != NodeStatus.SUCCEEDED
-            and status_change_flow.to_status == NodeStatus.DELETED
-        ):
-            [
-                callback.on_node_deleted(node, cluster_context)
-                for callback in self._node_event_callbacks
-            ]
-
-    def _should_relaunch(self, node: Node, status_change_flow: NodeStateFlow):
-        should_relaunch = (
-            status_change_flow.should_relaunch
-            and self._enable_relaunch_node
-            and node.relaunchable
-        )
-        if should_relaunch:
-            if (
-                node.exit_reason == NodeExitReason.FATAL_ERROR
-                and not _dlrover_context.relaunch_always
-            ):
-                should_relaunch = False
-            elif node.exit_reason == NodeExitReason.OOM:
-                mem = node.config_resource.memory
-                if mem >= NodeResourceLimit.MAX_MEMORY:
-                    should_relaunch = False
-                    logger.warning(
-                        "The memory of worker %s is beyond the limit %s MB.",
-                        mem,
-                        NodeResourceLimit.MAX_MEMORY,
-                    )
-                elif node.relaunch_count >= node.max_relaunch_count:
-                    should_relaunch = False
-                    logger.warning(
-                        "The relaunched count %s is beyond the maximum %s.",
-                        node.relaunch_count,
-                        node.max_relaunch_count,
-                    )
-                else:
-                    node.is_recovered_oom = True
-                    self._job_optimizer.adjust_oom_resource(node)
-            elif node.exit_reason != NodeExitReason.KILLED:
-                if node.relaunch_count >= node.max_relaunch_count:
-                    logger.warning(
-                        "The relaunch count "
-                        f"{node.relaunch_count}/{node.max_relaunch_count} "
-                        "has been exhausted."
-                    )
-                    should_relaunch = False
-        if should_relaunch:
-            node.inc_relaunch_count()
-
-        return should_relaunch
-
-    def _relaunch_node(self, node: Node):
-        if node.type == NodeType.WORKER:
-            plan = self._worker_manager.relaunch_node(node)
-        elif node.type == NodeType.PS:
-            plan = self._ps_manager.relaunch_node(node)
-        elif node.type == NodeType.EVALUATOR:
-            plan = self._evaluator_manager.relaunch_node(node)
-        elif node.type == NodeType.CHIEF or node.type == NodeType.MASTER:
-            plan = self._chief_manager.relaunch_node(node)
-        else:
-            logger.error("Not support node type %s", node.type)
-        self._set_ps_addrs_in_plan(plan)
-        self._scaler.scale(plan)
-
-    def all_workers_exited(self):
-        return (
-            self._chief_manager.all_nodes_exited()
-            and self._worker_manager.all_nodes_exited()
-            and self._evaluator_manager.all_nodes_exited()
-        )
-
-    def all_workers_failed(self):
-        return (
-            self._chief_manager.all_nodes_failed()
-            and self._worker_manager.all_nodes_failed()
-            and self._evaluator_manager.all_nodes_failed()
-        )
-
-    def all_workers_deleted(self):
-        return (
-            self._chief_manager.all_nodes_deleted()
-            and self._worker_manager.all_nodes_deleted()
-            and self._evaluator_manager.all_nodes_deleted()
-        )
-
-    def all_critical_node_completed(self):
-        alive_critical_nodes = []
-        for _, nodes in self._job_nodes.items():
-            for node in nodes.values():
-                if node.critical and node.status in [
-                    NodeStatus.INITIAL,
-                    NodeStatus.PENDING,
-                    NodeStatus.RUNNING,
-                ]:
-                    alive_critical_nodes.append(node.name)
-
-        completed = not alive_critical_nodes
-        if not completed:
-            logger.info("Critical nodes %s are running.", alive_critical_nodes)
-        return completed
-
-    def remove_worker(self, worker_id):
-        if self._job_nodes[NodeType.WORKER][worker_id].critical:
-            logger.info("Skip the critical worker %s", worker_id)
-        else:
-            logger.info("Delete worker %s", worker_id)
-            plan = self._worker_manager.remove_node(worker_id)
-            logger.info("plan %s", plan.toJSON())
-            self._scaler.scale(plan)
-
-    def get_running_nodes(self):
-        nodes = self._chief_manager.get_running_nodes()
-        nodes.extend(self._worker_manager.get_running_nodes())
-        nodes.extend(self._evaluator_manager.get_running_nodes())
-        nodes.extend(self._ps_manager.get_running_nodes())
-        return nodes
-
-    def get_running_workers(self):
-        workers = self._worker_manager.get_running_nodes()
-        chiefs = self._chief_manager.get_running_nodes()
-        workers.extend(chiefs)
-        return workers
-
-    def post_ps_ready(self):
-        plan = self._ps_manager.process_after_ps_cluster_ready()
-        if not plan.empty():
-            self._scaler.scale(plan)
-        else:
-            logger.info("Skip an empty scaleplan")
-
-    def stop(self):
-        self._enable_relaunch_node = False
-        with self._lock:
-            for node_type in self._job_nodes.keys():
-                for node in self._job_nodes[node_type].values():
-                    node.critical = False
-                    node.is_released = True
-                    node.relaunchable = False
-            for node in self._job_nodes[NodeType.WORKER].values():
-                node.eval_time = self._speed_monitor.get_worker_eval_time(
-                    node.id
-                )
-        self._stop_monitor = True
-
+    @abstractclassmethod
     def update_node_resource_usage(self, node_type, node_id, cpu, memory):
-        node = self._job_nodes[node_type][node_id]
-        node.update_resource_usage(cpu, memory)
+        pass
 
-    def update_node_service_addr(self, node_type, node_id, service_addr):
-        node = self._job_nodes[node_type][node_id]
-        node.update_service_address(service_addr)
-        node.status = NodeStatus.RUNNING
-        node.is_released = False
-        self._job_nodes[node_type][node_id] = node
+    @abstractclassmethod
+    def close_job(self):
+        pass
 
-    def get_cur_cluster_ps(self):
-        """Get PS nodes in the current training cluster."""
-        logger.info("job nodes are {}".format(self._job_nodes))
-        return self._ps_manager.get_training_ps_cluster()
-
-    def get_next_cluster_ps(self):
-        """Get PS nodes in the next training cluster."""
-        return self._ps_manager.get_next_training_ps_cluster()
-
-    def ready_for_new_ps_cluster(self):
-        """Check whether ps cluster is used to training"""
-        return self._ps_manager.get_ready_for_new_ps_cluster()
-
-    def has_ps_failure(self):
-        """Check whether ther is PS failure"""
-        return self._ps_manager.has_ps_failure()
-
-    def remove_training_nodes(self):
-        """Remove all PS and workers"""
-        self._job_autoscaler.stop_auto_scaling()
-        plan = ScalePlan()
-        training_nodes = list(
-            self._job_nodes[NodeType.WORKER].values()
-        ) + list(self._job_nodes[NodeType.PS].values())
-        for node in training_nodes:
-            if (
-                node.status in [NodeStatus.RUNNING, NodeStatus.PENDING]
-                and not node.is_released
-            ):
-                node.critical = False
-                node.relaunchable = False
-                node.is_released = True
-                node.status = NodeStatus.DELETED
-                logger.info("Remove node %s", node.name)
-                plan.remove_nodes.append(node)
-        self._scaler.scale(plan)
-
-    def start_auto_scaling(self):
-        """Start to auto-scale nodes to improve the training throughput."""
-        self._job_autoscaler.start_auto_scaling()
-
-    def _set_ps_addrs_in_plan(self, plan: ScalePlan):
-        ps_addrs = self._ps_manager.get_ps_addrs()
-        plan.ps_addrs.extend(ps_addrs)
-
-    def all_running_node_hanged(self):
-        node_hang = self._worker_manager.running_nodes_hanged()
-        node_hang.extend(self._chief_manager.running_nodes_hanged())
-        node_hang.extend(self._evaluator_manager.running_nodes_hanged())
-        node_hang.extend(self._ps_manager.running_nodes_hanged())
-        if node_hang:
-            return all(node_hang)
+    @abstractclassmethod
+    def all_workers_exited(self):
         return False
 
-    def remove_not_joined_rdzv_workers(self, worker_ranks):
-        plan = self._worker_manager.remove_not_joined_rdzv_workers(
-            worker_ranks
-        )
-        self._scaler.scale(plan)
+    @abstractclassmethod
+    def all_workers_failed(self):
+        return False
 
+    @abstractclassmethod
+    def all_workers_deleted(self):
+        return False
+
+    @abstractclassmethod
+    def all_critical_node_completed(self):
+        return False
+
+    @abstractclassmethod
+    def remove_worker(self, worker_id):
+        pass
+
+    @abstractclassmethod
+    def get_running_nodes(self):
+        pass
+
+    @abstractclassmethod
+    def get_running_workers(self):
+        pass
+
+    @abstractclassmethod
+    def post_ps_ready(self):
+        pass
+
+    @abstractclassmethod
+    def stop(self):
+        pass
+
+    @abstractclassmethod
+    def update_node_service_addr(self, node_type, node_id, service_addr):
+        pass
+
+    @abstractclassmethod
+    def get_cur_cluster_ps(self):
+        pass
+
+    @abstractclassmethod
+    def get_next_cluster_ps(self):
+        pass
+
+    @abstractclassmethod
+    def ready_for_new_ps_cluster(self):
+        pass
+
+    @abstractclassmethod
+    def has_ps_failure(self):
+        pass
+
+    @abstractclassmethod
+    def remove_training_nodes(self):
+        """Remove all PS and workers"""
+        pass
+
+    @abstractclassmethod
+    def start_auto_scaling(self):
+        pass
+
+    @abstractclassmethod
+    def all_running_node_hanged(self):
+        pass
+
+    @abstractclassmethod
+    def remove_not_joined_rdzv_workers(self, worker_ranks):
+        pass
+
+    @abstractclassmethod
     def pend_without_workers(self):
-        """Check whether to wait for evicted workers."""
-        if self._worker_manager.has_failed_worker():
-            return False
-        elif self._worker_manager.wait_worker_restart():
-            return True
-        else:
-            return False
+        pass
+
+    @abstractclassmethod
+    def update_allreduce_node_unit(self, node_unit):
+        pass
 
     def handle_training_failure(
         self, node_type, node_id, restart_count=-1, error_data="", level=""
@@ -683,32 +123,3 @@ class JobManager(object):
         self._error_monitor.process_error(
             node, restart_count, error_data, level
         )
-
-    def update_allreduce_node_unit(self, node_unit):
-        if isinstance(self._job_optimizer, AllreduceJobResourceOptimizer):
-            self._job_optimizer.set_node_unit(node_unit)
-
-
-def create_job_manager(args: JobArgs, speed_monitor) -> JobManager:
-    critical_worker_index = get_critical_worker_index(args)
-    # Custom distribution strategy does not exit if there are pending nodes
-    wait_pending_relaunch = (
-        args.distribution_strategy == DistributionStrategy.CUSTOM
-    )
-
-    elastic_job = new_elastic_job(args.platform, args.job_name, args.namespace)
-    node_watcher = new_node_watcher(
-        args.platform, args.job_name, args.namespace
-    )
-    job_scaler = new_job_scaler(args.platform, args.job_name, args.namespace)
-
-    return JobManager(
-        job_args=args,
-        critical_worker_index=critical_worker_index,
-        wait_pending_relaunch=wait_pending_relaunch,
-        speed_monitor=speed_monitor,
-        job=elastic_job,
-        node_watcher=node_watcher,
-        job_scaler=job_scaler,
-        error_monitor=ErrorLogMonitor(),
-    )

--- a/dlrover/python/master/node/local_job_manager.py
+++ b/dlrover/python/master/node/local_job_manager.py
@@ -1,0 +1,145 @@
+# Copyright 2022 The DLRover Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import Dict
+
+from dlrover.python.common.constants import NodeStatus, NodeType
+from dlrover.python.common.node import Node
+from dlrover.python.master.monitor.error_monitor import (
+    ErrorLogMonitor,
+    ErrorMonitor,
+)
+from dlrover.python.master.monitor.speed_monitor import SpeedMonitor
+from dlrover.python.master.node.job_manager import JobManager
+from dlrover.python.master.resource.job import JobResource
+from dlrover.python.scheduler.job import JobArgs
+
+
+class LocalJobManager(JobManager):
+    """The manager manages a local job on a single node. It can:
+    - collect the running metrics of a local job.
+    - optimize the hyper-parameters of a local job, like batch size and
+        `num_workers` of the dataloader.
+    """
+
+    def __init__(
+        self,
+        job_args: JobArgs,
+        speed_monitor=None,
+        error_monitor=None,
+    ):
+        self._job_resource = JobResource()
+        self._job_args = job_args
+        self._job_optimizer = None
+        self._stop_monitor = False
+        self._speed_monitor: SpeedMonitor = speed_monitor
+        self._error_monitor: ErrorMonitor = error_monitor
+
+        self._job_nodes: Dict[str, Dict[int, Node]] = {}
+
+    def start(self):
+        self._job_nodes[NodeType.WORKER] = {}
+        self._job_nodes[NodeType.WORKER][0] = Node(
+            node_type=NodeType.WORKER,
+            node_id=0,
+            status=NodeStatus.RUNNING,
+        )
+
+    def add_node_event_callback(self, node_event_callback):
+        pass
+
+    def update_node_resource_usage(self, node_type, node_id, cpu, memory):
+        node = self._job_nodes[node_type][node_id]
+        node.update_resource_usage(cpu, memory)
+
+    def handle_training_failure(
+        self, node_type, node_id, restart_count=-1, error_data="", level=""
+    ):
+        """Process the training failure reported by the node."""
+        node = self._job_nodes[node_type][node_id]
+        self._error_monitor.process_error(
+            node, restart_count, error_data, level
+        )
+
+    def close_job(self):
+        pass
+
+    def all_workers_exited(self):
+        return False
+
+    def all_workers_failed(self):
+        return False
+
+    def all_workers_deleted(self):
+        return False
+
+    def all_critical_node_completed(self):
+        return False
+
+    def remove_worker(self, worker_id):
+        pass
+
+    def get_running_nodes(self):
+        nodes = list(self._job_nodes[NodeType.WORKER].values())
+        return nodes
+
+    def get_running_workers(self):
+        workers = list(self._job_nodes[NodeType.WORKER].values())
+        return workers
+
+    def post_ps_ready(self):
+        pass
+
+    def stop(self):
+        self._stop_monitor = True
+
+    def update_node_service_addr(self, node_type, node_id, service_addr):
+        pass
+
+    def get_cur_cluster_ps(self):
+        return []
+
+    def get_next_cluster_ps(self):
+        return []
+
+    def ready_for_new_ps_cluster(self):
+        return True
+
+    def has_ps_failure(self):
+        return False
+
+    def remove_training_nodes(self):
+        """Remove all PS and workers"""
+        pass
+
+    def start_auto_scaling(self):
+        pass
+
+    def all_running_node_hanged(self):
+        return False
+
+    def remove_not_joined_rdzv_workers(self, worker_ranks):
+        pass
+
+    def pend_without_workers(self):
+        return False
+
+    def update_allreduce_node_unit(self, node_unit):
+        pass
+
+
+def create_job_manager(args: JobArgs, speed_monitor) -> LocalJobManager:
+    return LocalJobManager(
+        job_args=args,
+        speed_monitor=speed_monitor,
+        error_monitor=ErrorLogMonitor(),
+    )

--- a/dlrover/python/master/servicer.py
+++ b/dlrover/python/master/servicer.py
@@ -36,6 +36,7 @@ from dlrover.python.master.elastic_training.rdzv_manager import (
     RendezvousManager,
 )
 from dlrover.python.master.monitor.speed_monitor import SpeedMonitor
+from dlrover.python.master.node.job_manager import JobManager
 from dlrover.python.master.shard.dataset_splitter import new_dataset_splitter
 from dlrover.python.master.shard.task_manager import TaskManager
 from dlrover.python.master.stats.job_collector import JobMetricCollector
@@ -48,7 +49,6 @@ try:
         ElasticPsService,
     )
     from dlrover.python.master.elastic_training.sync_service import SyncService
-    from dlrover.python.master.node.job_manager import JobManager
 except ImportError:
     logger.info("Run the master locally.")
     pass
@@ -176,8 +176,7 @@ class MasterServicer(elastic_training_pb2_grpc.MasterServicer):
         return empty_pb2.Empty()
 
     def ready_for_ps_relaunch(self, request, _):
-        if self._job_manager:
-            self._job_manager.post_ps_ready()
+        self._job_manager.post_ps_ready()
         return empty_pb2.Empty()
 
     def get_shard_checkpoint(self, request, _):
@@ -203,10 +202,9 @@ class MasterServicer(elastic_training_pb2_grpc.MasterServicer):
         memory = request.memory
         pod_id = request.node_id
         pod_type = request.node_type
-        if self._job_manager:
-            self._job_manager.update_node_resource_usage(
-                pod_type, pod_id, cpu, memory
-            )
+        self._job_manager.update_node_resource_usage(
+            pod_type, pod_id, cpu, memory
+        )
         return empty_pb2.Empty()
 
     def get_dataset_epoch(self, request, _):
@@ -253,8 +251,7 @@ class MasterServicer(elastic_training_pb2_grpc.MasterServicer):
     def _check_start_auto_scale_worker(self):
         sample_count = self._speed_monitor.get_sample_count()
         if (
-            self._job_manager
-            and not self._start_autoscale
+            not self._start_autoscale
             and sample_count >= _dlrover_context.sample_count_to_adjust_worker
         ):
             logger.info(
@@ -298,7 +295,7 @@ class MasterServicer(elastic_training_pb2_grpc.MasterServicer):
         node_id = request.id
         server_addr = request.addr
 
-        if server_addr and self._job_manager:
+        if server_addr:
             self._job_manager.update_node_service_addr(
                 node_type, node_id, server_addr
             )
@@ -332,8 +329,6 @@ class MasterServicer(elastic_training_pb2_grpc.MasterServicer):
 
     def query_ps_nodes(self, request, _):
         res = elastic_training_pb2.QueryPsNodesResponse()
-        if not self._job_manager:
-            return res
         training_ps: List[Node] = self._job_manager.get_next_cluster_ps()
         ready = self._job_manager.ready_for_new_ps_cluster()
         ps_failure = self._job_manager.has_ps_failure()
@@ -350,8 +345,6 @@ class MasterServicer(elastic_training_pb2_grpc.MasterServicer):
 
     def query_running_nodes(self, request, _):
         res = elastic_training_pb2.RunningNodes()
-        if not self._job_manager:
-            return res
         nodes: List[Node] = self._job_manager.get_running_nodes()
         for node in nodes:
             meta = elastic_training_pb2.NodeMeta()
@@ -462,14 +455,13 @@ class MasterServicer(elastic_training_pb2_grpc.MasterServicer):
         return res
 
     def report_failure(self, request, _):
-        if self._job_manager:
-            self._job_manager.handle_training_failure(
-                request.node_type,
-                request.node_id,
-                request.restart_count,
-                request.error_data,
-                request.level,
-            )
+        self._job_manager.handle_training_failure(
+            request.node_type,
+            request.node_id,
+            request.restart_count,
+            request.error_data,
+            request.level,
+        )
         res = elastic_training_pb2.Response()
         res.success = True
         return res

--- a/dlrover/python/tests/test_job_auto_scaler.py
+++ b/dlrover/python/tests/test_job_auto_scaler.py
@@ -20,11 +20,11 @@ from dlrover.python.common.constants import NodeStatus, NodeType
 from dlrover.python.common.global_context import Context
 from dlrover.python.common.node import NodeGroupResource, NodeResource
 from dlrover.python.master.monitor.speed_monitor import SpeedMonitor
+from dlrover.python.master.node.dist_job_manager import create_job_manager
 from dlrover.python.master.node.job_auto_scaler import (
     AllreduceTrainingAutoScaler,
     PSTrainingAutoScaler,
 )
-from dlrover.python.master.node.job_manager import create_job_manager
 from dlrover.python.master.resource.optimizer import ResourcePlan
 from dlrover.python.tests.test_utils import (
     MockK8sAllreduceJobArgs,

--- a/dlrover/python/tests/test_job_manager.py
+++ b/dlrover/python/tests/test_job_manager.py
@@ -27,12 +27,12 @@ from dlrover.python.common.constants import (
 from dlrover.python.common.node import NodeGroupResource, NodeResource
 from dlrover.python.master.dist_master import DistributedJobMaster
 from dlrover.python.master.monitor.speed_monitor import SpeedMonitor
+from dlrover.python.master.node.dist_job_manager import create_job_manager
 from dlrover.python.master.node.event_callback import (
     ClusterContext,
     TaskRescheduleCallback,
     TFPSNodeHandlingCallback,
 )
-from dlrover.python.master.node.job_manager import create_job_manager
 from dlrover.python.master.node.status_flow import (
     NODE_STATE_FLOWS,
     NodeStateFlow,

--- a/dlrover/python/tests/test_servicer.py
+++ b/dlrover/python/tests/test_servicer.py
@@ -20,7 +20,7 @@ from dlrover.proto import elastic_training_pb2
 from dlrover.python.common.constants import NodeStatus, NodeType
 from dlrover.python.master.elastic_training.elastic_ps import ElasticPsService
 from dlrover.python.master.monitor.speed_monitor import SpeedMonitor
-from dlrover.python.master.node.job_manager import create_job_manager
+from dlrover.python.master.node.dist_job_manager import create_job_manager
 from dlrover.python.master.servicer import MasterServicer
 from dlrover.python.master.shard.task_manager import TaskManager
 from dlrover.python.master.stats.job_collector import JobMetricCollector

--- a/dlrover/python/tests/test_sync_service.py
+++ b/dlrover/python/tests/test_sync_service.py
@@ -16,7 +16,7 @@ import unittest
 from dlrover.python.common.constants import NodeStatus, NodeType
 from dlrover.python.master.elastic_training.sync_service import SyncService
 from dlrover.python.master.monitor.speed_monitor import SpeedMonitor
-from dlrover.python.master.node.job_manager import create_job_manager
+from dlrover.python.master.node.dist_job_manager import create_job_manager
 from dlrover.python.tests.test_utils import MockK8sPSJobArgs, mock_k8s_client
 
 

--- a/dlrover/python/tests/test_utils.py
+++ b/dlrover/python/tests/test_utils.py
@@ -250,6 +250,9 @@ def mock_k8s_client():
     k8s_client.create_service = mock.MagicMock(  # type: ignore
         return_value=True
     )
+    k8s_client.get_service = mock.MagicMock(  # type: ignore
+        return_value=False
+    )
 
 
 def start_local_master():


### PR DESCRIPTION
### What changes were proposed in this pull request?

A local job manager manages the status of the job on a single node.

### Why are the changes needed?

DLrover need collect the workload and training metrics of the job on a single node.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

UT.
