### PR TITLE
Install dlrover[k8s] to build the master image.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,5 +9,5 @@ RUN pip install pyparsing -i https://pypi.org/simple
 
 ENV VERSION="0.3.0rc1"
 COPY --from=builder /dlrover/dist/dlrover-${VERSION}-py3-none-any.whl /
-RUN pip install /dlrover-${VERSION}-py3-none-any.whl --extra-index-url=https://pypi.org/simple && rm -f /*.whl
+RUN pip install /dlrover-${VERSION}-py3-none-any.whl[k8s] --extra-index-url=https://pypi.org/simple && rm -f /*.whl
 RUN unset VERSION


### PR DESCRIPTION
### What changes were proposed in this pull request?

Install dlrover[k8s] in the dockerfile to build the image of master.

### Why are the changes needed?

The kubernetes package is necessary for jobs on the kubernetes cluster.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

![image](https://github.com/intelligent-machine-learning/dlrover/assets/18071380/5f6589e1-95c8-429b-ae5f-ab85f4acc653)

