### PR TITLE
The master stops if the oom recovered pod pends too long.

### DIFF
--- a/dlrover/python/master/dist_master.py
+++ b/dlrover/python/master/dist_master.py
@@ -171,6 +171,10 @@ class DistributedJobMaster(JobMaster):
             while True:
                 if self._stop_requested:
                     break
+                msg = self.job_manager.early_stop()
+                if msg:
+                    self.request_stop(False, msg)
+                    continue
                 if self.job_manager and self.job_manager.all_workers_exited():
                     if self.job_manager.pend_without_workers():
                         time.sleep(30)

--- a/dlrover/python/master/node/dist_job_manager.py
+++ b/dlrover/python/master/node/dist_job_manager.py
@@ -192,6 +192,16 @@ class DistributedJobManager(JobManager):
                 daemon=True,
             ).start()
 
+    def early_stop(self):
+        nodes = self._ps_manager.get_pending_timeout_oom_recovered_node()
+        msg = ""
+        if len(nodes) > 0:
+            msg = (
+                "Stop the training early because "
+                "OOM recoverd pod pends too long."
+            )
+        return msg
+
     def _adjust_worker_for_estimator(self):
         if self._job_args.distribution_strategy == DistributionStrategy.PS:
             self._job_resource.adjust_worker_for_estimator()

--- a/dlrover/python/master/node/job_manager.py
+++ b/dlrover/python/master/node/job_manager.py
@@ -115,6 +115,10 @@ class JobManager(metaclass=ABCMeta):
     def update_allreduce_node_unit(self, node_unit):
         pass
 
+    @abstractclassmethod
+    def early_stop(self):
+        pass
+
     def handle_training_failure(
         self, node_type, node_id, restart_count=-1, error_data="", level=""
     ):

--- a/dlrover/python/master/node/local_job_manager.py
+++ b/dlrover/python/master/node/local_job_manager.py
@@ -54,6 +54,9 @@ class LocalJobManager(JobManager):
             status=NodeStatus.RUNNING,
         )
 
+    def early_stop(self):
+        return False
+
     def add_node_event_callback(self, node_event_callback):
         pass
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

The master stops if the oom recovered PS pod pends too long.

### Why are the changes needed?

The worker will wait for pending PS Pods which wastes resource.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

UT
