### PR TITLE
Chief manager also manges the training master node of TF.

### DIFF
--- a/dlrover/python/master/node/dist_job_manager.py
+++ b/dlrover/python/master/node/dist_job_manager.py
@@ -274,15 +274,14 @@ class DistributedJobManager(JobManager):
         update_nodes_priority(self._job_nodes)
 
         self._ps_manager.update_nodes(self._job_nodes.get(NodeType.PS, {}))
-        self._chief_manager.update_nodes(
-            self._job_nodes.get(NodeType.CHIEF, {})
-        )
-        self._worker_manager.update_nodes(
-            self._job_nodes.get(NodeType.WORKER, {})
-        )
-        self._evaluator_manager.update_nodes(
-            self._job_nodes.get(NodeType.EVALUATOR, {})
-        )
+        chief_nodes = self._job_nodes.get(NodeType.CHIEF, {})
+        if not chief_nodes:
+            chief_nodes = self._job_nodes.get(NodeType.MASTER, {})
+        self._chief_manager.update_nodes(chief_nodes)
+        workers = self._job_nodes.get(NodeType.WORKER, {})
+        self._worker_manager.update_nodes(workers)
+        evaluators = self._job_nodes.get(NodeType.EVALUATOR, {})
+        self._evaluator_manager.update_nodes(evaluators)
 
     def _init_job_auto_scaler(self):
         self._job_autoscaler: JobAutoScaler = new_job_auto_scaler(

--- a/dlrover/python/tests/test_job_manager.py
+++ b/dlrover/python/tests/test_job_manager.py
@@ -233,6 +233,21 @@ class DistributedJobManagerTest(unittest.TestCase):
         should_relaunch = manager._should_relaunch(node, NODE_STATE_FLOWS[6])
         self.assertFalse(should_relaunch)
 
+    def test_relaunch_training_master(self):
+        params = MockK8sPSJobArgs()
+        params.initilize()
+        manager = create_job_manager(params, SpeedMonitor())
+        group_resources = manager._job_resource.node_group_resources
+        group_resources[NodeType.MASTER] = NodeGroupResource(
+            1, NodeResource(1, 256)
+        )
+
+        manager._init_nodes()
+        master = Node(NodeType.MASTER, 0, NodeResource(1, 256))
+        manager._job_nodes[NodeType.MASTER][0] = master
+        plan = manager._chief_manager.relaunch_node(master)
+        self.assertEqual(plan.launch_nodes[0].id, 1)
+
     def test_process_list_nodes(self):
         params = MockK8sPSJobArgs()
         params.initilize()


### PR DESCRIPTION
### What changes were proposed in this pull request?

Chief manager also manges the training master node of TF.

### Why are the changes needed?

TF1.x estimator use the master as chief.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

UT
