### PR TITLE
Fix: only print the log when the node hangs with timeout.

### DIFF
--- a/dlrover/python/common/node.py
+++ b/dlrover/python/common/node.py
@@ -176,6 +176,7 @@ class Node(object):
         self.eval_time = 0
         self.host_name = host_name
         self.host_ip = host_ip
+        self.hang = False
 
     def inc_relaunch_count(self):
         self.relaunch_count += 1

--- a/dlrover/python/master/node/training_node.py
+++ b/dlrover/python/master/node/training_node.py
@@ -321,15 +321,18 @@ class TrainingNodeManager(object):
         node_hang = []
         for _, node in self._nodes.items():
             if node.status == NodeStatus.RUNNING:
+                timeout = NodeResourceLimit.MAX_HANG_TIMEOUT_SECS
                 hang = (
                     node.start_hang_time > 0
-                    and cur_time - node.start_hang_time
-                    > NodeResourceLimit.MAX_HANG_TIMEOUT_SECS
+                    and cur_time - node.start_hang_time > timeout
                 )
-                if hang:
+                if not node.hang and hang:
                     time_array = time.localtime(node.start_hang_time)
                     date_time = time.strftime("%Y-%m-%d %H:%M:%S", time_array)
-                    logger.warning("Node %s hangs at %s", node.name, date_time)
+                    logger.warning(
+                        f"Node {node.name} hangs with timeout "
+                        f"{timeout} from {date_time}!!!")
+                node.hang = hang
                 node_hang.append(hang)
         return node_hang
 

--- a/dlrover/python/master/node/training_node.py
+++ b/dlrover/python/master/node/training_node.py
@@ -331,7 +331,8 @@ class TrainingNodeManager(object):
                     date_time = time.strftime("%Y-%m-%d %H:%M:%S", time_array)
                     logger.warning(
                         f"Node {node.name} hangs with timeout "
-                        f"{timeout} from {date_time}!!!")
+                        f"{timeout} from {date_time}!!!"
+                    )
                 node.hang = hang
                 node_hang.append(hang)
         return node_hang


### PR DESCRIPTION
### What changes were proposed in this pull request?

Print the log when the node hangs with timeout.

### Why are the changes needed?

The log repeats per 1min and there will be too many the repeated log.

### Does this PR introduce any user-facing change?

No.
### How was this patch tested?

No.