### PR TITLE
Update ps addrs only when it is not empty.

### DIFF
--- a/dlrover/python/tests/test_pod_scaler.py
+++ b/dlrover/python/tests/test_pod_scaler.py
@@ -132,8 +132,10 @@ class PodScalerTest(unittest.TestCase):
             NodeType.CHIEF: NodeGroupResource(1, resource),
             NodeType.PS: NodeGroupResource(2, resource),
         }
+        scale_plan.ps_addrs = ["ps-0:22222"]
         scaler.scale(scale_plan)
         self.assertEqual(len(scaler._create_node_queue), 3)
+        self.assertListEqual(scaler._ps_addrs, scale_plan.ps_addrs)
 
         worker_ids = []
         chief_ids = []


### PR DESCRIPTION
### What changes were proposed in this pull request?

Update ps addrs only when it is not empty.

### Why are the changes needed?

The PS hosts in the plan may be empty.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

UT.
