### PR TITLE
Fix: Do not remove the ps node when relaunching it.

### DIFF
--- a/dlrover/python/master/node/dist_job_manager.py
+++ b/dlrover/python/master/node/dist_job_manager.py
@@ -394,7 +394,7 @@ class DistributedJobManager(JobManager):
         node_type = event.node.type
         node_id = event.node.id
         if node_id not in self._job_nodes[node_type]:
-            self._job_nodes[node_type][node_id] = event.node
+            logger.info(f"The node {event.node.name} is released.")
             return
         else:
             cur_node = self._job_nodes[node_type][node_id]

--- a/dlrover/python/master/node/ps.py
+++ b/dlrover/python/master/node/ps.py
@@ -85,7 +85,6 @@ class ParameterServerManager(TrainingNodeManager):
             node.is_released = True
             new_id = next(self._node_id_iter)
             self._nodes[new_id] = node.get_relaunch_node_info(new_id)
-            self._nodes.pop(node.id)
             if node in self._training_ps_cluster:
                 i = self._training_ps_cluster.index(node)
                 self._training_ps_cluster[i] = self._nodes[new_id]

--- a/dlrover/python/tests/test_job_manager.py
+++ b/dlrover/python/tests/test_job_manager.py
@@ -283,7 +283,7 @@ class DistributedJobManagerTest(unittest.TestCase):
             nodes.append(node)
         manager._process_list_nodes(nodes)
         ps_ids = list(manager._job_nodes[NodeType.PS].keys())
-        self.assertListEqual(ps_ids, [0, 1, 3])
+        self.assertListEqual(ps_ids, [0, 1, 2, 3])
 
     def test_create_allreduce_job_manager(self):
         params = MockK8sPSJobArgs()


### PR DESCRIPTION
### What changes were proposed in this pull request?

Do not remove the ps node when relaunching it.

### Why are the changes needed?

To avoid repeatedly relaunching a Pod before the event may repeat.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

UT.
