### PR TITLE
Do not check whether the evaluator hangs.

### DIFF
--- a/dlrover/python/master/node/dist_job_manager.py
+++ b/dlrover/python/master/node/dist_job_manager.py
@@ -685,7 +685,6 @@ class DistributedJobManager(JobManager):
     def all_running_node_hanged(self):
         node_hang = self._worker_manager.running_nodes_hanged()
         node_hang.extend(self._chief_manager.running_nodes_hanged())
-        node_hang.extend(self._evaluator_manager.running_nodes_hanged())
         node_hang.extend(self._ps_manager.running_nodes_hanged())
         if node_hang:
             return all(node_hang)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Remove the code to check whether the evaluator hangs.

### Why are the changes needed?

The evaluator does not participate in training.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

UT.
