### PR TITLE
Fix: set the default value of retry as 2 to check network.

### DIFF
--- a/dlrover/python/elastic_agent/torch/training.py
+++ b/dlrover/python/elastic_agent/torch/training.py
@@ -749,7 +749,7 @@ def network_check(
 
 def run_network_check(config, entrypoint):
     cmd_args = ["-m", "dlrover.trainer.torch.run_network_check"]
-    for _ in range(config.max_restarts):
+    for _ in range(2):
         # If network fails because other abnormal node, We
         # will retry to check network after the new node is starting.
         # DLRover will replace the abnormal node with a new node.


### PR DESCRIPTION
### What changes were proposed in this pull request?

Set the default value of retry as 2 to check network.

### Why are the changes needed?

The max_restarts may be 0.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

UT.
