### PR TITLE
Feat: Update batch size by the config from the master.

### DIFF
--- a/dlrover/python/common/grpc.py
+++ b/dlrover/python/common/grpc.py
@@ -393,7 +393,12 @@ class OptimizerConfig(Message):
 
 
 @dataclass
-class ParallelismConfig(Message):
+class ParallelConfigRequest(Message):
+    pass
+
+
+@dataclass
+class ParallelConfig(Message):
     version: int = 0
     dataloader: DataLoaderConfig = DataLoaderConfig()
     optimizer: OptimizerConfig = OptimizerConfig()

--- a/dlrover/python/common/grpc.py
+++ b/dlrover/python/common/grpc.py
@@ -380,6 +380,7 @@ class DataLoaderConfig(Message):
             device/CUDA pinned memory before returning them.
     """
 
+    version: int = 0
     dataloader_name: str = ""
     batch_size: int = 0
     num_workers: int = 0
@@ -388,6 +389,7 @@ class DataLoaderConfig(Message):
 
 @dataclass
 class OptimizerConfig(Message):
+    version: int = 0
     optimizer_name: str = ""
     learning_rate: float = 0.0
 
@@ -399,6 +401,5 @@ class ParallelConfigRequest(Message):
 
 @dataclass
 class ParallelConfig(Message):
-    version: int = 0
     dataloader: DataLoaderConfig = DataLoaderConfig()
     optimizer: OptimizerConfig = OptimizerConfig()

--- a/dlrover/python/elastic_agent/master_client.py
+++ b/dlrover/python/elastic_agent/master_client.py
@@ -123,8 +123,8 @@ class MasterClient(object):
 
     def kv_store_get(self, key):
         request = grpc.KeyValuePair(key)
-        response: grpc.KeyValuePair = self._get(request)
-        return response.value
+        result: grpc.KeyValuePair = self._get(request)
+        return result.value
 
     def get_task(self, dataset_name):
         """Get a task from master.
@@ -229,8 +229,8 @@ class MasterClient(object):
             task_id=task_id,
             version_type=version_type,
         )
-        response: grpc.ClusterVersion = self._get(request)
-        return response.version
+        result: grpc.ClusterVersion = self._get(request)
+        return result.version
 
     def update_node_addr(self, task_type, task_id, node_addr):
         message = grpc.NodeStatus(
@@ -260,8 +260,8 @@ class MasterClient(object):
 
     def query_ps_nodes(self):
         request = grpc.PsNodesRequest()
-        response: grpc.PsNodes = self._get(request)
-        return response.nodes, response.ps_failure
+        result: grpc.PsNodes = self._get(request)
+        return result.nodes, result.ps_failure
 
     def query_training_status(self):
         request = grpc.TrainingStatusRequest()
@@ -290,13 +290,13 @@ class MasterClient(object):
 
     def get_running_nodes(self):
         request = grpc.RunningNodesRequest()
-        response: grpc.RunningNodes = self._get(request)
-        return response.nodes
+        result: grpc.RunningNodes = self._get(request)
+        return result.nodes
 
     def num_nodes_waiting(self, rdzv_name):
         request = grpc.WaitingNodeNumRequest(rdzv_name=rdzv_name)
-        response: grpc.RendezvousState = self._get(request)
-        return response.waiting_num
+        result: grpc.RendezvousState = self._get(request)
+        return result.waiting_num
 
     def join_rendezvous(self, rank_id, local_world_size, rdzv_name=""):
         request = grpc.JoinRendezvousRequest(
@@ -304,27 +304,27 @@ class MasterClient(object):
             local_world_size=local_world_size,
             rdzv_name=rdzv_name,
         )
-        response: grpc.RendezvousState = self._get(request)
-        return response.round
+        result: grpc.RendezvousState = self._get(request)
+        return result.round
 
     def get_comm_world(self, rdzv_name, rank_id):
         request = grpc.CommWorldRequest(node_id=rank_id, rdzv_name=rdzv_name)
-        response: grpc.RendezvousState = self._get(request)
-        return response.group, response.world
+        result: grpc.RendezvousState = self._get(request)
+        return result.group, result.world
 
     def network_check_success(self, timeout=300):
         request = grpc.NetworkReadyRequest()
         start = time.time()
         while True:
-            response: grpc.NetworkReady = self._get(request)
+            result: grpc.NetworkReady = self._get(request)
             if (
-                response.reason == NetworkFailureReason.WAITING_NODE
+                result.reason == NetworkFailureReason.WAITING_NODE
                 and time.time() - start < timeout
             ):
                 time.sleep(5)
                 continue
             break
-        return response.success
+        return result.success
 
     def report_rdzv_params(
         self, min_nodes, max_nodes, waiting_timeout, node_unit
@@ -345,6 +345,14 @@ class MasterClient(object):
     def report_failures(self, error_data, restart_count=-1, level=""):
         message = grpc.NodeFailure(error_data, restart_count, level)
         self._report(message)
+
+    def report_paral_config(self, config: grpc.ParallelConfig):
+        self._report(config)
+
+    def get_paral_config(self) -> grpc.ParallelConfig:
+        request = grpc.ParallelConfigRequest()
+        result = self._get(request)
+        return result
 
 
 class LocalDataset(object):

--- a/dlrover/python/elastic_agent/torch/training.py
+++ b/dlrover/python/elastic_agent/torch/training.py
@@ -13,6 +13,7 @@
 import copy
 import functools
 import json
+import threading
 import os
 import socket
 import tempfile
@@ -60,8 +61,15 @@ from dlrover.python.common.log import default_logger as logger
 from dlrover.python.elastic_agent.master_client import GlobalMasterClient
 from dlrover.python.elastic_agent.monitor.resource import ResourceMonitor
 from dlrover.python.elastic_agent.torch.master_kv_store import MasterKVStore
+from dlrover.trainer.constants.torch import WorkerEnv
 
 __all__ = ["launch_agent"]
+
+
+def _set_paral_config():
+    config_dir = os.path.dirname(WorkerEnv.PARAL_CONFIG_PATH.default)
+    os.makedirs(config_dir, exist_ok=True)
+    os.environ[WorkerEnv.PARAL_CONFIG_PATH.name] = WorkerEnv.PARAL_CONFIG_PATH.default
 
 
 @dataclass
@@ -246,6 +254,20 @@ class ElasticTrainingAgent(LocalElasticAgent):
         self._restart_count = 0
         self._remaining_failovers = self._remaining_restarts
         self._client = GlobalMasterClient.MASTER_CLIENT
+        _set_paral_config()
+
+        threading.Thread(
+            target=self._periodically_update_paral_config,
+            name="cofig-updater",
+            daemon=True,
+        ).start()
+
+    def _periodically_update_paral_config(self):
+        while True:
+            config = self._client.get_paral_config()
+            with open(WorkerEnv.PARAL_CONFIG_PATH.default, "r") as f:
+                f.write(config.to_json())
+            time.sleep(30)
 
     @prof
     def _rendezvous(self, worker_group: WorkerGroup) -> None:

--- a/dlrover/python/elastic_agent/torch/training.py
+++ b/dlrover/python/elastic_agent/torch/training.py
@@ -267,7 +267,7 @@ class ElasticTrainingAgent(LocalElasticAgent):
     def _periodically_update_paral_config(self):
         while True:
             config = self._client.get_paral_config()
-            with open(WorkerEnv.PARAL_CONFIG_PATH.default, "r") as f:
+            with open(WorkerEnv.PARAL_CONFIG_PATH.default, "w") as f:
                 f.write(config.to_json())
             time.sleep(30)
 

--- a/dlrover/python/elastic_agent/torch/training.py
+++ b/dlrover/python/elastic_agent/torch/training.py
@@ -13,10 +13,10 @@
 import copy
 import functools
 import json
-import threading
 import os
 import socket
 import tempfile
+import threading
 import time
 import uuid
 from dataclasses import dataclass
@@ -69,7 +69,9 @@ __all__ = ["launch_agent"]
 def _set_paral_config():
     config_dir = os.path.dirname(WorkerEnv.PARAL_CONFIG_PATH.default)
     os.makedirs(config_dir, exist_ok=True)
-    os.environ[WorkerEnv.PARAL_CONFIG_PATH.name] = WorkerEnv.PARAL_CONFIG_PATH.default
+    os.environ[
+        WorkerEnv.PARAL_CONFIG_PATH.name
+    ] = WorkerEnv.PARAL_CONFIG_PATH.default
 
 
 @dataclass

--- a/dlrover/python/master/servicer.py
+++ b/dlrover/python/master/servicer.py
@@ -117,7 +117,7 @@ class MasterServicer(elastic_training_pb2_grpc.MasterServicer):
             message = self._query_ps_nodes()
         elif isinstance(req_message, grpc.TrainingStatusRequest):
             message = self._get_training_status()
-        elif isinstance(req_message, grpc.ParallelismConfig):
+        elif isinstance(req_message, grpc.ParallelConfigRequest):
             message = self._get_paral_config()
 
         if message:
@@ -250,7 +250,7 @@ class MasterServicer(elastic_training_pb2_grpc.MasterServicer):
         return res
 
     def _get_paral_config(self):
-        res = grpc.ParallelismConfig()
+        res = grpc.ParallelConfig()
         return res
 
     def report(self, request, _):
@@ -297,7 +297,7 @@ class MasterServicer(elastic_training_pb2_grpc.MasterServicer):
             success = self._ready_for_ps_relaunch()
         elif isinstance(message, grpc.KeyValuePair):
             success = self._kv_store_set(message)
-        elif isinstance(message, grpc.ParallelismConfig):
+        elif isinstance(message, grpc.ParallelConfig):
             success = self._report_paral_config(message)
 
         response.success = success
@@ -510,7 +510,7 @@ class MasterServicer(elastic_training_pb2_grpc.MasterServicer):
         self._kv_store.set(message.key, message.value)
         return True
 
-    def _report_paral_config(self, message: grpc.ParallelismConfig):
+    def _report_paral_config(self, message: grpc.ParallelConfig):
         logger.info(f"config = {message}")
         return True
 

--- a/dlrover/python/tests/test_master_client.py
+++ b/dlrover/python/tests/test_master_client.py
@@ -142,7 +142,5 @@ class MasterClientTest(unittest.TestCase):
         round = self._master_client.join_rendezvous(0, 8, "elastic-training")
         self.assertEqual(round, 0)
 
-    def test_paral_config(self):
-        config = grpc.ParallelConfig()
-        print(config.to_json())
-        self.assertFalse(True)
+        config = self._master_client.get_paral_config()
+        self.assertEqual(config.dataloader.version, 0)

--- a/dlrover/python/tests/test_master_client.py
+++ b/dlrover/python/tests/test_master_client.py
@@ -141,3 +141,8 @@ class MasterClientTest(unittest.TestCase):
 
         round = self._master_client.join_rendezvous(0, 8, "elastic-training")
         self.assertEqual(round, 0)
+
+    def test_paral_config(self):
+        config = grpc.ParallelConfig()
+        print(config.to_json())
+        self.assertFalse(True)

--- a/dlrover/python/tests/test_servicer.py
+++ b/dlrover/python/tests/test_servicer.py
@@ -340,14 +340,14 @@ class MasterServicerTest(unittest.TestCase):
         self.assertTrue(response.success)
 
     def test_paral_config(self):
-        message = grpc.ParallelismConfig()
+        message = grpc.ParallelConfig()
         request = elastic_training_pb2.Message()
         request.data = message.serialize()
         self.servicer.report(request, None)
 
         response = self.servicer.get(request, None)
         config = grpc.deserialize_message(response.data)
-        self.assertTrue(isinstance(config, grpc.ParallelismConfig))
+        self.assertTrue(isinstance(config, grpc.ParallelConfig))
 
 
 class MasterServicerForRayTest(unittest.TestCase):

--- a/dlrover/python/tests/test_servicer.py
+++ b/dlrover/python/tests/test_servicer.py
@@ -340,7 +340,7 @@ class MasterServicerTest(unittest.TestCase):
         self.assertTrue(response.success)
 
     def test_paral_config(self):
-        message = grpc.ParallelConfig()
+        message = grpc.ParallelConfigRequest()
         request = elastic_training_pb2.Message()
         request.data = message.serialize()
         self.servicer.report(request, None)

--- a/dlrover/trainer/constants/torch.py
+++ b/dlrover/trainer/constants/torch.py
@@ -1,3 +1,16 @@
+# Copyright 2023 The DLRover Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from dlrover.trainer.constants.constants import Constant
 
 

--- a/dlrover/trainer/constants/torch.py
+++ b/dlrover/trainer/constants/torch.py
@@ -1,0 +1,8 @@
+from dlrover.trainer.constants.constants import Constant
+
+
+class WorkerEnv(Constant):
+    PARAL_CONFIG_PATH = Constant(
+        "DLROVER_PARAL_CONFIG_PATH",
+        "/tmp/dlrover/auto_paral_config.json",
+    )

--- a/dlrover/trainer/tests/torch/elastic_dataloader_test.py
+++ b/dlrover/trainer/tests/torch/elastic_dataloader_test.py
@@ -11,12 +11,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+import tempfile
 import unittest
-from unittest.mock import patch
 
 import numpy as np
 from torch.utils.data import Dataset
 
+from dlrover.python.common.grpc import ParallelConfig
 from dlrover.trainer.torch.elastic.dataloader import ElasticDataLoader
 
 
@@ -40,48 +42,46 @@ class TestElasticDataLoader(unittest.TestCase):
         # Cleanup code to run after each test method
         pass
 
-    @patch("builtins.open", create=True)
-    def test_load_config(self, mock_open):
+    def test_load_config(self):
         dataset = SimpleDataset()
         # Create a temporary ElasticDataLoader instance for testing
         dataloader = ElasticDataLoader(dataset=dataset, batch_size=32)
 
         # Assert that the loaded batch_size is correct
-        self.assertEqual(dataloader.current_batch_size, 32)
+        self.assertEqual(dataloader.batch_sampler.batch_size, 32)
 
-        # Configure the mock_open to return the desired content
-        mock_open.return_value.__enter__.return_value.read.return_value = (
-            '{"batch_size": 64}'
-        )
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            config = ParallelConfig()
+            config.dataloader.batch_size = 128
+            config.dataloader.version = 1
+            config_file = os.path.join(tmpdirname, "config.json")
+            with open(config_file, "w") as f:
+                f.write(config.to_json())
 
-        # Call the load_config method
-        dataloader.load_config(config_file="config.json")
+            # Call the load_config method
+            dataloader.load_config(config_file=config_file)
+            dataloader = ElasticDataLoader(
+                dataset=dataset, config_file=config_file
+            )
 
-        # Configure the mock_open to return the desired content
-        mock_open.return_value.__enter__.return_value.read.return_value = (
-            '{"batch_size": 128}'
-        )
+            # Assert that the loaded batch_size is correct
+            self.assertEqual(dataloader.batch_sampler.batch_size, 128)
 
-        dataloader = ElasticDataLoader(
-            dataset=dataset, config_file="config.json"
-        )
-
-        # Assert that the loaded batch_size is correct
-        self.assertEqual(dataloader.current_batch_size, 128)
-
-    @patch("builtins.open", create=True)
-    def test_set_batch_size(self, mock_open):
+    def test_set_batch_size(self):
         dataset = SimpleDataset()
-        # Configure the mock_open to return the desired content
-        mock_open.return_value.__enter__.return_value.read.return_value = (
-            '{"batch_size": 128}'
-        )
-        dataloader = ElasticDataLoader(
-            dataset=dataset, batch_size=32, config_file="config.json"
-        )
+        config = ParallelConfig()
+        config.dataloader.batch_size = 128
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            config_file = os.path.join(tmpdirname, "config.json")
+            with open(config_file, "w") as f:
+                f.write(config.to_json())
 
-        # Call the set_batch_size method to change the batch_size
-        dataloader.set_batch_size(128)
+            dataloader = ElasticDataLoader(
+                dataset=dataset, batch_size=32, config_file=config_file
+            )
 
-        # Assert that the set batch_size is correct
-        self.assertEqual(dataloader.current_batch_size, 128)
+            # Call the set_batch_size method to change the batch_size
+            dataloader.update_batch_size(128)
+
+            # Assert that the set batch_size is correct
+            self.assertEqual(dataloader.batch_sampler.batch_size, 128)

--- a/dlrover/trainer/torch/elastic/dataloader.py
+++ b/dlrover/trainer/torch/elastic/dataloader.py
@@ -12,10 +12,11 @@
 # limitations under the License.
 
 import json
-import os
 import logging
+import os
 
 from torch.utils.data import DataLoader
+
 from dlrover.trainer.constants.torch import WorkerEnv
 
 logging.basicConfig(level=logging.NOTSET)
@@ -39,20 +40,20 @@ class ElasticDataLoader(DataLoader):
             the initial batch size (default: None).
 
     Attributes:
-        current_batch_size (int): The current batch size used by the
-        DataLoader. config_file (str): The path to the configuration file if
+        config_file (str): The path to the configuration file if
         provided.
 
     Methods:
         load_config(): Load the batch size configuration from the specified
-        JSON file. set_batch_size(batch_size): Dynamically set the batch size.
+        JSON file.
+        update_batch_size(batch_size): Dynamically set the batch size.
 
     Usage Example:
         >>> # create a elastic dataloader with config.json
         >>> loader = ElasticDataLoader(dataset, shuffle=True,
-        >>> config_file="config.json")
+        >>>     config_file="config.json")
         >>> # Dynamically change the batch size to 64.
-        >>> loader.set_batch_size(64)
+        >>> loader.update_params()
         >>> for batch in loader:
         ...     # Training loop
 
@@ -65,11 +66,12 @@ class ElasticDataLoader(DataLoader):
         super(ElasticDataLoader, self).__init__(*args, **kwargs)
         self._config_version = 0
         self.config_file = config_file
-        if self.config_file:
+        if not self.config_file:
             self.config_file = os.getenv(
                 WorkerEnv.PARAL_CONFIG_PATH.name,
                 WorkerEnv.PARAL_CONFIG_PATH.default,
             )
+        if self.config_file:
             self.load_config(self.config_file)
 
     def load_config(self, config_file=None):
@@ -88,23 +90,27 @@ class ElasticDataLoader(DataLoader):
             return
         with open(config_file, "r") as f:
             config = json.load(f)
-            config_version = config.get("version", 0)
+            if "dataloader" not in config:
+                return
+            dl_config = config["dataloader"]
+            config_version = dl_config.get("version", 0)
             if config_version > self._config_version:
                 self._config_version = config_version
             else:
                 return
-            if "dataloader" in config:
-                dl_config = config["dataloader"]
-                batch_size = dl_config.get("batch_size", 0)
-                if batch_size > 0:
-                    self.batch_sampler.batch_size = batch_size
-                    logger.info(
-                        f"Update the batch size of dataloader to {batch_size}"
-                    )
+            batch_size = dl_config.get("batch_size", 0)
+            if batch_size > 0:
+                self.batch_sampler.batch_size = batch_size
+                logger.info(
+                    f"Update the batch size of dataloader to {batch_size}"
+                )
 
-    def update_params(self):
+    def update_batch_size(self, batch_size=None):
         """
         Update parameters like batch size, num_workers of the dataloader
         From the parallelism config file.
         """
-        self.load_config(self.config_file)
+        if batch_size:
+            self.batch_sampler.batch_size = batch_size
+        else:
+            self.load_config(self.config_file)

--- a/docs/design/autotuing-design.md
+++ b/docs/design/autotuing-design.md
@@ -224,7 +224,6 @@ def tune_batch_size(hyper_param, gpu_stats):
     adjustments during data loading. This feature allows users to modify batch
     sizes in real-time, enhancing memory management and training efficiency.
 
-
 - Methods
   - *init*
     - Description: Initializes the `ElasticDataLoader` instance.

--- a/docs/design/autotuing-design.md
+++ b/docs/design/autotuing-design.md
@@ -224,10 +224,6 @@ def tune_batch_size(hyper_param, gpu_stats):
     adjustments during data loading. This feature allows users to modify batch
     sizes in real-time, enhancing memory management and training efficiency.
 
-- Attributes
-  - *current_batch_size*
-    - Type: Integer
-    - Description: The current batch size used for data loading. This attribute is initialized with the default batch size.
 
 - Methods
   - *init*
@@ -257,21 +253,13 @@ def tune_batch_size(hyper_param, gpu_stats):
 class ElasticDataLoader(DataLoader):
     def init(self, *args, **kwargs):
         super(ElasticDataLoader, self).init(*args, **kwargs)
-        self.current_batch_size = self.batch_size
-    def __iter__(self):
-        batch_sampler = BatchSampler(
-            self.sampler, batch_size=self.current_batch_size, drop_last=self.drop_last
-        )
-        for batch_indices in batch_sampler:
-            yield self.collate_fn([self.dataset[i] for i in batch_indices])
 
-    def set_batch_size(self, batch_size):
-        self.current_batch_size = batch_size
+    def update_batch_size(self, batch_size):
+        self.batch_sampler.batch_size = batch_size
 
     def update_batch_size_from_config(self, config_path):
-        # Read batch size from the configuration file and update current_batch_size
         batch_size_from_config = self._read_batch_size_from_config(config_path)
-        self.set_batch_size(batch_size_from_config)
+        self.update_batch_size(batch_size_from_config)
 
     def _read_batch_size_from_config(self, config_path):
         # Return the batch size value


### PR DESCRIPTION
### What changes were proposed in this pull request?

The `ElasticTrainingAgent` updates the config file from the master and 
the `ElasticDataloader` can update its batch size by the config file.

### Why are the changes needed?

The `ElasticDataloader` can update its batch size by the config file from the master.

### Does this PR introduce any user-facing change?

Users need to call `ElasticDataloader.update_params()` after a step.

### How was this patch tested?

UT.
