### PR TITLE
[BugFix]: Reduce the target number of worker if it is completed.

### DIFF
--- a/dlrover/python/master/node/event_callback.py
+++ b/dlrover/python/master/node/event_callback.py
@@ -166,10 +166,10 @@ class TFPSNodeHandlingCallback(NodeEventCallback):
                     reason=JobExitReason.SUCCEEDED,
                     msg="All critical nodes completed",
                 )
-        self._master.speed_monitor.remove_running_worker(node.type, node.id)
         self._master.speed_monitor.reduce_target_worker_num(
             [(node.type, node.id)]
         )
+        self._master.speed_monitor.remove_running_worker(node.type, node.id)
         self._master.sync_service.remove_exited_worker_sync(node.type, node.id)
 
     @NodeEventCallback.log_callback_exception

--- a/dlrover/python/master/node/event_callback.py
+++ b/dlrover/python/master/node/event_callback.py
@@ -167,6 +167,9 @@ class TFPSNodeHandlingCallback(NodeEventCallback):
                     msg="All critical nodes completed",
                 )
         self._master.speed_monitor.remove_running_worker(node.type, node.id)
+        self._master.speed_monitor.reduce_target_worker_num(
+            [(node.type, node.id)]
+        )
         self._master.sync_service.remove_exited_worker_sync(node.type, node.id)
 
     @NodeEventCallback.log_callback_exception

--- a/dlrover/python/master/node/worker.py
+++ b/dlrover/python/master/node/worker.py
@@ -135,18 +135,13 @@ class WorkerManager(TrainingNodeManager):
             )
         )
         alive_workers = []
-        completed_worker_num = 0
         for worker in self._nodes.values():
             if worker.status in ALIVE_STATUS:
                 alive_workers.append(worker)
-            elif worker.status in [NodeStatus.SUCCEEDED, NodeStatus.FINISHED]:
-                completed_worker_num += 1
         alive_num = len(alive_workers)
         with self._lock:
-            if num > alive_num + completed_worker_num:
-                plan = self._scale_up_workers(
-                    num - alive_num - completed_worker_num
-                )
+            if num > alive_num:
+                plan = self._scale_up_workers(num - alive_num)
             elif num < alive_num:
                 plan = self._scale_down_workers(alive_num - num, alive_workers)
         return plan

--- a/dlrover/python/tests/test_job_manager.py
+++ b/dlrover/python/tests/test_job_manager.py
@@ -415,6 +415,10 @@ class DistributedJobManagerTest(unittest.TestCase):
         callback.on_node_failed(node, cluster_context)
         self.assertEqual(master.speed_monitor._target_worker_num, 1)
         self.assertEqual(len(master.speed_monitor.running_workers), 1)
+        master.speed_monitor.set_target_worker_num(2)
+        master.speed_monitor._workers.add(("worker", 0))
+        callback.on_node_succeeded(node, cluster_context)
+        self.assertEqual(master.speed_monitor._target_worker_num, 1)
 
     def test_all_running_node_hang(self):
         params = MockK8sPSJobArgs()


### PR DESCRIPTION
### What changes were proposed in this pull request?

Reduce the target number of workers if it is completed.

### Why are the changes needed?

The number of running workers is never equal to the target number of worker if some workers exit.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

UT.
