### PR TITLE
Bugfix: all agent can update rendezvous params.

### DIFF
--- a/dlrover/python/elastic_agent/torch/training.py
+++ b/dlrover/python/elastic_agent/torch/training.py
@@ -106,13 +106,12 @@ class MasterRendezvousHandler(RendezvousHandler):
         self._store = MasterKVStore(self._name, timedelta(seconds=60))
         lastcall_timeout = int(rdzv_params.get("lastcall_timeout", 60))
         node_unit = int(rdzv_params.get("node_unit", "1"))
-        if self._rank_id == 0:
-            self._client.report_rdzv_params(
-                rdzv_params.min_nodes,
-                rdzv_params.max_nodes,
-                lastcall_timeout,
-                node_unit,
-            )
+        self._client.report_rdzv_params(
+            rdzv_params.min_nodes,
+            rdzv_params.max_nodes,
+            lastcall_timeout,
+            node_unit,
+        )
 
     def get_backend(self) -> str:
         return "dlrover-master"

--- a/dlrover/python/master/elastic_training/rdzv_manager.py
+++ b/dlrover/python/master/elastic_training/rdzv_manager.py
@@ -93,15 +93,16 @@ class RendezvousManager(metaclass=ABCMeta):
                 a multiple of worker_unit.
         """
         with self._lock:
-            self._rdzv_params.min_nodes = min_nodes
-            self._rdzv_params.max_nodes = max_ndoes
-            self._rdzv_params.waiting_timeout = waiting_timeout
-            self._node_unit = node_unit
-            logger.info(
-                f"{self._name} manager updates rdzv params: "
-                f"min_nodes={min_nodes}, max_nodes={max_ndoes}, "
-                f"waiting_timeout={waiting_timeout}, node_unit={node_unit}"
-            )
+            if self._rdzv_params.max_nodes == 0:
+                self._rdzv_params.min_nodes = min_nodes
+                self._rdzv_params.max_nodes = max_ndoes
+                self._rdzv_params.waiting_timeout = waiting_timeout
+                self._node_unit = node_unit
+                logger.info(
+                    f"{self._name} manager updates rdzv params: "
+                    f"min_nodes={min_nodes}, max_nodes={max_ndoes}, "
+                    f"waiting_timeout={waiting_timeout}, node_unit={node_unit}"
+                )
 
     def _check_rdzv_completed(self):
         rdzv_completed = False


### PR DESCRIPTION
### What changes were proposed in this pull request?

Remove the limit where only the rank0 worker report rdzv params to the master.

### Why are the changes needed?

The worker whose rank is not 0 may start before the worker-0.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

UT.
