### PR TITLE
Fix: check the config file to update batch size after a step.

### DIFF
--- a/dlrover/trainer/torch/elastic/dataloader.py
+++ b/dlrover/trainer/torch/elastic/dataloader.py
@@ -99,7 +99,7 @@ class ElasticDataLoader(DataLoader):
             else:
                 return
             batch_size = dl_config.get("batch_size", 0)
-            if batch_size > 0:
+            if batch_size > 0 and self.batch_sampler.batch_size != batch_size:
                 self.batch_sampler.batch_size = batch_size
                 logger.info(
                     f"Update the batch size of dataloader to {batch_size}"

--- a/dlrover/trainer/torch/elastic/trainer.py
+++ b/dlrover/trainer/torch/elastic/trainer.py
@@ -231,6 +231,8 @@ class ElasticTrainer(object):
 
     Args:
         model (`torch.nn.Module`): PyTorch Module.
+        dataloader (`ElasticDataloader`): An ElasticDataloader can
+            update the batch size of sampler.
 
     **Available attributes:**
         - **step** -- the number of local step on the process.

--- a/dlrover/trainer/torch/elastic/trainer.py
+++ b/dlrover/trainer/torch/elastic/trainer.py
@@ -25,6 +25,7 @@ import torch.distributed as dist
 from dlrover.python.common.constants import ConfigPath
 from dlrover.python.common.log import default_logger as logger
 from dlrover.python.common.serialize import JsonSerializable
+from dlrover.trainer.torch.elastic.dataloader import ElasticDataLoader
 
 
 def find_free_port() -> int:
@@ -246,6 +247,7 @@ class ElasticTrainer(object):
     def __init__(
         self,
         model,
+        dataloader: ElasticDataLoader = None,
         use_fsdp: bool = False,
         ckpt_interval: CheckpointInterval = None,
         shared_storage_path: str = None,
@@ -256,7 +258,7 @@ class ElasticTrainer(object):
                     'shared_storage_path' must be provided and not None."
             )
         self.model = model
-        self.optimizer = None
+        self.dataloader = dataloader
         self.gradient_state = GradientState()
         self.gradient_accumulation_steps = 1
         self.use_fsdp = use_fsdp
@@ -264,6 +266,17 @@ class ElasticTrainer(object):
         self.shared_storage_path = shared_storage_path
         self._report_step_interval = 15  # 15s
         self._last_report_time = 0
+
+        self._check()
+
+    def _check(self):
+        if self.dataloader and not isinstance(
+            self.dataloader, ElasticDataLoader
+        ):
+            logger.warning(
+                "Cannot adjust the batch size of dataloader and "
+                "you should use ElasticDataloader not Dataloader."
+            )
 
     def prepare(self, optimizer, lr_scheduler=None):
         """
@@ -399,6 +412,8 @@ class ElasticTrainer(object):
             if now - self._last_report_time > self._report_step_interval:
                 self.report_training_step()
                 self._last_report_time = now
+        if self.dataloader and isinstance(self.dataloader, ElasticDataLoader):
+            self.dataloader.update_batch_size()
 
     def _set_gradient_accumulation_steps(self):
         max_worker_num = int(os.getenv("WORKER_NUM", 1))

--- a/examples/pytorch/mnist/cnn_train.py
+++ b/examples/pytorch/mnist/cnn_train.py
@@ -28,6 +28,7 @@ from torch.optim.lr_scheduler import StepLR
 from torch.utils.data import DataLoader
 from torchvision import transforms
 
+from dlrover.trainer.torch.elastic.dataloader import ElasticDataLoader
 from dlrover.trainer.torch.elastic.sampler import ElasticDistributedSampler
 from dlrover.trainer.torch.elastic.trainer import ElasticTrainer
 
@@ -101,10 +102,9 @@ def train(args):
     )
     #  Setup sampler for elastic training.
     sampler = ElasticDistributedSampler(dataset=train_data)
-    train_loader = DataLoader(
+    train_loader = ElasticDataLoader(
         dataset=train_data,
         batch_size=args.batch_size,
-        num_workers=2,
         sampler=sampler,
     )
 
@@ -175,7 +175,7 @@ def train_with_fixed_batch_size(
     """
     The global batch size will not change if the number of workers changes.
     """
-    elastic_trainer = ElasticTrainer(model)
+    elastic_trainer = ElasticTrainer(model, dataloader=train_loader)
     optimizer, scheduler = elastic_trainer.prepare(optimizer, scheduler)
 
     epoch = 0
@@ -304,7 +304,7 @@ def arg_parser():
     parser.add_argument("--shuffle", type=bool, default=True, required=False)
     parser.add_argument("--use_fsdp", type=bool, default=False, required=False)
     parser.add_argument(
-        "--fixed_batch_size", type=bool, default=False, required=False
+        "--fixed_batch_size", type=bool, default=True, required=False
     )
     parser.add_argument(
         "--learning_rate", type=float, default=0.1, required=False


### PR DESCRIPTION
### What changes were proposed in this pull request?

ElasticTrainer checks the config file to update batch size after a step.

### Why are the changes needed?

We can dynamically update the batch size to improve throughput.

### Does this PR introduce any user-facing change?

Users need to initialize `ElasticTrainer` withe the dataloader.

### How was this patch tested?

UT
