### PR TITLE
Use the image from dockerhub to run test cases.

### DIFF
--- a/.github/actions/dlrover-system-test-criteo-deeprec/action.yaml
+++ b/.github/actions/dlrover-system-test-criteo-deeprec/action.yaml
@@ -3,7 +3,7 @@ name: dlrover-trainer-test-criteo-deeprec
 description: run pytest to execute python test cases of dlrover-trainer
 runs:
   using: 'docker'
-  image: "registry.cn-hangzhou.aliyuncs.com/dlrover_deeprec/deeprec:v1"
+  image: "easydl/dlrover:deeprec_ci"
   args:
     - "/bin/bash"
     - "-c"

--- a/.github/actions/dlrover-system-test-deepfm/action.yaml
+++ b/.github/actions/dlrover-system-test-deepfm/action.yaml
@@ -3,7 +3,7 @@ name: dlrover-system-test-deepfm_tf
 description: run pytest to execute python test cases of dlrover-trainer
 runs:
   using: 'docker'
-  image: "registry.cn-hangzhou.aliyuncs.com/dlrover_deeprec/deeprec:v1"
+  image: "easydl/dlrover:deeprec_ci"
   args:
     - "/bin/bash"
     - "-c"


### PR DESCRIPTION
### What changes were proposed in this pull request?

Actions use the image on dockerhub to run test cases.

### Why are the changes needed?

Github action often fails to download the image from the ALIYUN.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

Test cases.
