### PR TITLE
BugFix: Skip the pending GPU Pod.

### DIFF
--- a/dlrover/python/master/node/training_node.py
+++ b/dlrover/python/master/node/training_node.py
@@ -107,7 +107,11 @@ def reduce_timeout_pending_node_resource(node: Node):
     """Reduce CPU cores or memroy and relaunch it if the pending
     time is too long"""
     now = time.time()
-    if node.is_released or not node.create_time:
+    if (
+        node.is_released
+        or not node.create_time
+        or node.config_resource.gpu_num > 0
+    ):
         return False
     pending_time = now - node.create_time.timestamp()
     if pending_time < _dlrover_context.seconds_to_wait_pending_pod:

--- a/dlrover/python/tests/test_worker_manager.py
+++ b/dlrover/python/tests/test_worker_manager.py
@@ -137,6 +137,12 @@ class WorkerManagerTest(unittest.TestCase):
         plan = worker_manager.reduce_pending_node_resource()
         self.assertEqual(len(plan.launch_nodes), 5)
 
+        for node in worker_manager._nodes.values():
+            node.config_resource.gpu_num = 1
+
+        plan = worker_manager.reduce_pending_node_resource()
+        self.assertTrue(plan.empty())
+
     def test_pending_without_workers(self):
         worker_manager = WorkerManager(
             self._job_nodes[NodeType.WORKER],


### PR DESCRIPTION
### What changes were proposed in this pull request?

The master does not reduce the resources of pending GPU Pod.

### Why are the changes needed?

GPU Pod pends because GPU is not enough.

### Does this PR introduce any user-facing change?

No.
### How was this patch tested?

UT.
