### PR TITLE
Add __init__.py into the folder of hyperparams.

### DIFF
--- a/dlrover/python/master/hyperparams/__init__.py
+++ b/dlrover/python/master/hyperparams/__init__.py
@@ -10,4 +10,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/dlrover/python/master/hyperparams/__init__.py
+++ b/dlrover/python/master/hyperparams/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2023 The DLRover Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add __init__.py into the folder of hyperparams.
### Why are the changes needed?

The folder is not a Python module if there is no `__init__.py`.

### Does this PR introduce any user-facing change?

No.
### How was this patch tested?

UT
