### PR TITLE
Set relaunch_always by the restartPolicy of worker spec.

### DIFF
--- a/dlrover/python/scheduler/kubernetes.py
+++ b/dlrover/python/scheduler/kubernetes.py
@@ -377,10 +377,14 @@ class K8sJobArgs(JobArgs):
         self.optimize_mode = job["spec"].get(
             "optimizeMode", OptimizeMode.SINGLE_JOB
         )
-        relaunch_strategy = job["spec"].get("relaunchStrategy", "")
-        self.relaunch_always = relaunch_strategy == "always"
 
         for replica, spec in job["spec"]["replicaSpecs"].items():
+            if replica == NodeType.WORKER:
+                restart_policy = spec["template"]["spec"].get(
+                    "restartPolicy", ""
+                )
+                self.relaunch_always = restart_policy == "Always"
+
             priority = spec.get("priority", "")
             num = int(spec.get("replicas", 0))
             container = spec["template"]["spec"]["containers"][0]

--- a/dlrover/python/tests/data/elasticjob_sample.yaml
+++ b/dlrover/python/tests/data/elasticjob_sample.yaml
@@ -53,7 +53,7 @@ spec:
             annotations:
               sidecar.istio.io/inject: "false"
           spec:
-            restartPolicy: Never
+            restartPolicy: Always
             containers:
               - name: main
                 image: dlrover/elasticjob:iris_estimator

--- a/dlrover/python/tests/test_job_params.py
+++ b/dlrover/python/tests/test_job_params.py
@@ -48,3 +48,4 @@ class k8sJobArgsTest(unittest.TestCase):
         self.assertEqual(
             ps_params.group_resource.node_resource.priority, "high"
         )
+        self.assertTrue(params.relaunch_always)

--- a/dlrover/python/tests/test_pod_scaler.py
+++ b/dlrover/python/tests/test_pod_scaler.py
@@ -43,7 +43,7 @@ class PodScalerTest(unittest.TestCase):
         self.assertEqual(
             main_container.image, "dlrover/elasticjob:iris_estimator"
         )
-        self.assertEqual(worker_pod.spec.restart_policy, "Never")
+        self.assertEqual(worker_pod.spec.restart_policy, "Always")
         self.assertListEqual(
             main_container.command,
             [

--- a/examples/pytorch/mnist/debug_elastic_job.yaml
+++ b/examples/pytorch/mnist/debug_elastic_job.yaml
@@ -11,7 +11,7 @@ spec:
       replicas: 4
       template:
         spec:
-          restartPolicy: Never
+          restartPolicy: Always
           containers:
             - name: main
               # yamllint disable-line rule:line-length
@@ -20,7 +20,7 @@ spec:
               command:
                 - /bin/bash
                 - -c
-                - "dlrover-run --nnodes=$WORKER_NUM \
+                - "dlrover-run --network-check --nnodes=$WORKER_NUM \
                   --nproc_per_node=2 --max_restarts=3  \
                   examples/pytorch/mnist/cnn_train.py --num_epochs 2 \
                   --training_data /data/mnist_png/training/ \

--- a/examples/pytorch/mnist/elastic_job.yaml
+++ b/examples/pytorch/mnist/elastic_job.yaml
@@ -11,7 +11,7 @@ spec:
       replicas: 4
       template:
         spec:
-          restartPolicy: Never
+          restartPolicy: Always
           containers:
             - name: main
               # yamllint disable-line rule:line-length


### PR DESCRIPTION
### What changes were proposed in this pull request?

Set relaunch_always by the restartPolicy of worker spec.

### Why are the changes needed?

To support fault-tolerance of worker Pods.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

Create a training job and use `kubectl -n dlrover delete` a worker Pod. 