### PR TITLE
Fix: Add the shell script into the dlrover package.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ setup(
             "proto/*",
             "docker/*",
             "Makefile",
+            "trainer/check/*",
         ]
     },
     entry_points={


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add `trainer/check/*` into the package data.

### Why are the changes needed?

The gpu_check.py need to run `gpu_inspector.sh`

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

Check whether there is `gpu_inspector.sh` in the installed dlrover.
