### PR TITLE
Update the base image to easydl/dlrover:ci

### DIFF
--- a/.github/actions/pre-commit/action.yml
+++ b/.github/actions/pre-commit/action.yml
@@ -3,7 +3,7 @@ name: pre-commit
 description: run pre-commit to check codes
 runs:
   using: 'docker'
-  image: "easydl/easydl:ci"
+  image: "easydl/dlrover:ci"
   args:
     - "/bin/bash"
     - "-c"

--- a/.github/actions/pre-commit/action.yml
+++ b/.github/actions/pre-commit/action.yml
@@ -7,4 +7,5 @@ runs:
   args:
     - "/bin/bash"
     - "-c"
-    - "pre-commit run -a --show-diff-on-failure --color=always"
+    - "git config --global --add safe.directory '*' && \
+    pre-commit run -a --show-diff-on-failure --color=always"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM easydl/easydl:ci as builder
+FROM easydl/dlrover:ci as builder
 
 WORKDIR /dlrover
 COPY ./ .

--- a/docker/ci.dockerfile
+++ b/docker/ci.dockerfile
@@ -33,7 +33,8 @@ COPY docker/scripts/install-protobuf.bash /
 RUN /install-protobuf.bash && rm /install-protobuf.bash
 
 # Install Pre-commit
-RUN pip install pre-commit pytest -i https://mirrors.aliyun.com/pypi/simple/
+RUN pip install pre-commit pytest kubernetes grpcio-tools psutil \
+    deprecated -i https://mirrors.aliyun.com/pypi/simple/
 
 # Configure envtest for integration tests of kubebuilder
 ENV KUBEBUILDER_CONTROLPLANE_START_TIMEOUT 60s

--- a/examples/pytorch/mnist/mnist.dockerfile
+++ b/examples/pytorch/mnist/mnist.dockerfile
@@ -1,4 +1,4 @@
-FROM easydl/easydl:ci as builder
+FROM easydl/dlrover:ci as builder
 
 WORKDIR /dlrover
 COPY ./ .

--- a/examples/pytorch/nanogpt/nanogpt.dockerfile
+++ b/examples/pytorch/nanogpt/nanogpt.dockerfile
@@ -1,4 +1,4 @@
-FROM easydl/easydl:ci as builder
+FROM easydl/dlrover:ci as builder
 
 WORKDIR /dlrover
 COPY ./ .


### PR DESCRIPTION
### What changes were proposed in this pull request?
Update the base image to easydl/dlrover:ci

### Why are the changes needed?

The python version of easydl/easydl:ci is py36. We need to build the image using PY38.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

Build the image to submit a job.