### PR TITLE
Start ParalConfigTuner if the args.auto_tuning is True.

### DIFF
--- a/dlrover/python/elastic_agent/config/paral_config_tuner.py
+++ b/dlrover/python/elastic_agent/config/paral_config_tuner.py
@@ -39,14 +39,18 @@ class ParalConfigTuner(object):
         )
         self.config_path = os.environ[ConfigPath.ENV_PARAL_CONFIG]
         self._create_paral_config_file()
+        self._started = False
 
     def start(self):
+        if self._started:
+            return
         threading.Thread(
             target=self._periodically_update_paral_config,
             name="config-updater",
             daemon=True,
         ).start()
         logger.info("Started parallelism config tuner.")
+        self._started = True
 
     def _periodically_update_paral_config(self):
         """

--- a/dlrover/python/tests/test_elastic_training_agent.py
+++ b/dlrover/python/tests/test_elastic_training_agent.py
@@ -142,7 +142,7 @@ class ElasticTrainingAgentRunTest(unittest.TestCase):
     def setUp(self) -> None:
         self._master, addr = start_local_master()
         GlobalMasterClient.MASTER_CLIENT = build_master_client(addr)
-        launch_config = ElasticLaunchConfig(
+        launch_config = LaunchConfig(
             min_nodes=1,
             max_nodes=1,
             nproc_per_node=2,

--- a/dlrover/python/tests/test_elastic_training_agent.py
+++ b/dlrover/python/tests/test_elastic_training_agent.py
@@ -19,6 +19,7 @@ import unittest
 
 from torch.distributed.elastic.agent.server.api import WorkerSpec, WorkerState
 from torch.distributed.elastic.rendezvous import RendezvousParameters
+from torch.distributed.launcher.api import LaunchConfig
 
 from dlrover.python.common.constants import RendezvousName
 from dlrover.python.elastic_agent.master_client import (
@@ -38,12 +39,13 @@ class ElasticTrainingAgentTest(unittest.TestCase):
     def setUp(self) -> None:
         self._master, addr = start_local_master()
         GlobalMasterClient.MASTER_CLIENT = build_master_client(addr)
-        self.config = ElasticLaunchConfig(
+        launch_config = LaunchConfig(
             min_nodes=2,
             max_nodes=2,
             nproc_per_node=8,
             run_id="test",
         )
+        self.config = ElasticLaunchConfig(**launch_config.__dict__)
         rdzv_parameters = RendezvousParameters(
             backend=self.config.rdzv_backend,
             endpoint=self.config.rdzv_endpoint,
@@ -140,13 +142,14 @@ class ElasticTrainingAgentRunTest(unittest.TestCase):
     def setUp(self) -> None:
         self._master, addr = start_local_master()
         GlobalMasterClient.MASTER_CLIENT = build_master_client(addr)
-        self.config = ElasticLaunchConfig(
+        launch_config = ElasticLaunchConfig(
             min_nodes=1,
             max_nodes=1,
             nproc_per_node=2,
             run_id="test",
             monitor_interval=0.1,
         )
+        self.config = ElasticLaunchConfig(**launch_config.__dict__)
         rdzv_parameters = RendezvousParameters(
             backend=self.config.rdzv_backend,
             endpoint=self.config.rdzv_endpoint,

--- a/dlrover/python/tests/test_elastic_training_agent.py
+++ b/dlrover/python/tests/test_elastic_training_agent.py
@@ -19,7 +19,6 @@ import unittest
 
 from torch.distributed.elastic.agent.server.api import WorkerSpec, WorkerState
 from torch.distributed.elastic.rendezvous import RendezvousParameters
-from torch.distributed.launcher.api import LaunchConfig
 
 from dlrover.python.common.constants import RendezvousName
 from dlrover.python.elastic_agent.master_client import (
@@ -28,6 +27,7 @@ from dlrover.python.elastic_agent.master_client import (
 )
 from dlrover.python.elastic_agent.monitor.training import TorchTrainingMonitor
 from dlrover.python.elastic_agent.torch.training import (
+    ElasticLaunchConfig,
     ElasticTrainingAgent,
     MasterRendezvousHandler,
 )
@@ -38,7 +38,7 @@ class ElasticTrainingAgentTest(unittest.TestCase):
     def setUp(self) -> None:
         self._master, addr = start_local_master()
         GlobalMasterClient.MASTER_CLIENT = build_master_client(addr)
-        self.config = LaunchConfig(
+        self.config = ElasticLaunchConfig(
             min_nodes=2,
             max_nodes=2,
             nproc_per_node=8,
@@ -140,7 +140,7 @@ class ElasticTrainingAgentRunTest(unittest.TestCase):
     def setUp(self) -> None:
         self._master, addr = start_local_master()
         GlobalMasterClient.MASTER_CLIENT = build_master_client(addr)
-        self.config = LaunchConfig(
+        self.config = ElasticLaunchConfig(
             min_nodes=1,
             max_nodes=1,
             nproc_per_node=2,

--- a/dlrover/trainer/tests/torch/elastic_run_test.py
+++ b/dlrover/trainer/tests/torch/elastic_run_test.py
@@ -15,7 +15,9 @@ import unittest
 
 from dlrover.trainer.torch.elastic_run import (
     _check_dlrover_master_available,
+    _elastic_config_from_args,
     _launch_dlrover_local_master,
+    parse_args,
 )
 
 
@@ -25,3 +27,23 @@ class ElasticRunTest(unittest.TestCase):
         available = _check_dlrover_master_available(addr)
         self.assertTrue(available)
         handler.close()
+
+    def test_elastic_config_from_args(self):
+        args = [
+            "--network_check",
+            "--auto_tunning",
+            "--node_unit",
+            "4",
+            "--nnodes",
+            "4",
+            "test.py",
+            "--batch_size",
+            "16",
+        ]
+        args = parse_args(args)
+        config, cmd, cmd_args = _elastic_config_from_args(args)
+        self.assertTrue(config.network_check)
+        self.assertTrue(config.auto_tunning)
+        self.assertEqual(config.node_unit, 4)
+        self.assertEqual(cmd, "/usr/local/bin/python")
+        self.assertListEqual(cmd_args, ["-u", "test.py", "--batch_size", "16"])

--- a/dlrover/trainer/torch/elastic_run.py
+++ b/dlrover/trainer/torch/elastic_run.py
@@ -17,12 +17,11 @@ import telnetlib
 import tempfile
 import time
 import uuid
-from typing import Callable, Union
+from typing import Callable, List, Tuple, Union
 
 from torch.distributed.argparse_util import check_env, env
 from torch.distributed.elastic.multiprocessing.api import SubprocessHandler
 from torch.distributed.elastic.multiprocessing.errors import record
-from torch.distributed.launcher.api import LaunchConfig
 from torch.distributed.launcher.api import launch_agent as torch_launch_agent
 from torch.distributed.run import config_from_args, get_args_parser
 
@@ -33,7 +32,10 @@ from dlrover.python.elastic_agent.master_client import (
     GlobalMasterClient,
     build_master_client,
 )
-from dlrover.python.elastic_agent.torch.training import launch_agent
+from dlrover.python.elastic_agent.torch.training import (
+    ElasticLaunchConfig,
+    launch_agent,
+)
 
 
 def parse_args(args):
@@ -52,6 +54,12 @@ def parse_args(args):
         default=1,
         help="The number unit of nodes to schedule. The scheduled number of "
         "nodes should be a multiple of node_unit.",
+    )
+    parser.add_argument(
+        "--auto_tunning",
+        "--auto-tunning",
+        action=check_env,
+        help="Whether to auto-tune the parallel configuraion.",
     )
     return parser.parse_args(args)
 
@@ -87,7 +95,7 @@ class elastic_launch:
 
     def __init__(
         self,
-        config: LaunchConfig,
+        config: ElasticLaunchConfig,
         entrypoint: Union[Callable, str, None],
         use_dlrover_launch: bool,
     ):
@@ -148,6 +156,17 @@ def _check_dlrover_master_available(addr, timeout=60):
             return False
 
 
+def _elastic_config_from_args(
+    args,
+) -> Tuple[ElasticLaunchConfig, Union[Callable, str], List[str]]:
+    config, cmd, cmd_args = config_from_args(args)
+    elastic_config = ElasticLaunchConfig(**config.__dict__)
+    elastic_config.network_check = args.network_check
+    elastic_config.node_unit = args.node_unit
+    elastic_config.auto_tunning = args.auto_tunning
+    return elastic_config, cmd, cmd_args
+
+
 def run(args):
     master_handler = None
     master_addr = os.getenv(NodeEnv.DLROVER_MASTER_ADDR, "")
@@ -174,17 +193,11 @@ def run(args):
             f"**************************************\n"
         )
 
-    config, cmd, cmd_args = config_from_args(args)
-    setattr(config, "network_check", False)
-    setattr(config, "node_unit", 1)
-    if not hasattr(config, "local_addr"):
-        setattr(config, "local_addr", None)
-    if hasattr(args, "network_check"):
-        config.network_check = args.network_check
-    if hasattr(args, "node_unit"):
-        config.rdzv_configs["node_unit"] = args.node_unit
+    config, cmd, cmd_args = _elastic_config_from_args(args)
     elastic_launch(
-        config=config, entrypoint=cmd, use_dlrover_launch=use_dlrover_launch
+        config=config,
+        entrypoint=cmd,
+        use_dlrover_launch=use_dlrover_launch,
     )(*cmd_args)
 
     if master_handler:


### PR DESCRIPTION
### What changes were proposed in this pull request?
- Refactor to create ElasticLaunchConfig from args.
- Start the thread of ParalConfigTuner if the args.auto_tuning is True.

### Why are the changes needed?

Auto-tuning is the optional feature of DLRover. So, we should start the thread to launch ParalConfigTuner only when it
is enabled. 

Fix #725 

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

Users can test it by `dlrover-run --auto-tuning`