### PR TITLE
Return the default value if the args has no the attribute.

### DIFF
--- a/dlrover/trainer/torch/elastic_run.py
+++ b/dlrover/trainer/torch/elastic_run.py
@@ -230,10 +230,12 @@ def _elastic_config_from_args(
 ) -> Tuple[ElasticLaunchConfig, Union[Callable, str], List[str]]:
     config, cmd, cmd_args = config_from_args(args)
     elastic_config = ElasticLaunchConfig(**config.__dict__)
-    elastic_config.network_check = args.network_check
-    elastic_config.node_unit = args.node_unit
-    elastic_config.auto_tunning = args.auto_tunning
-    elastic_config.exclude_straggler = args.exclude_straggler
+    elastic_config.network_check = getattr(args, "network_check", False)
+    elastic_config.node_unit = getattr(args, "node_unit", 1)
+    elastic_config.auto_tunning = getattr(args, "auto_tunning", False)
+    elastic_config.exclude_straggler = getattr(
+        args, "exclude_straggler", False
+    )
     return elastic_config, cmd, cmd_args
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Return the default value if the args has no the attribute.

### Why are the changes needed?

```
Traceback (most recent call last):
--
File "/opt/conda/lib/python3.8/runpy.py", line 194, in _run_module_as_main
return _run_code(code, main_globals, None,
File "/opt/conda/lib/python3.8/runpy.py", line 87, in _run_code
exec(code, run_globals)
File "/opt/conda/lib/python3.8/site-packages/atorch/distributed/run.py", line 374, in <module>
main()
File "/opt/conda/lib/python3.8/site-packages/atorch/distributed/run.py", line 357, in main
elastic_run(args)
File "/opt/conda/lib/python3.8/site-packages/atorch/distributed/run.py", line 368, in elastic_run
dlrover_run(args)
File "/opt/conda/lib/python3.8/site-packages/dlrover/trainer/torch/elastic_run.py", line 266, in run
config, cmd, cmd_args = _elastic_config_from_args(args)
File "/opt/conda/lib/python3.8/site-packages/dlrover/trainer/torch/elastic_run.py", line 235, in _elastic_config_from_args
elastic_config.auto_tunning = args.auto_tunning
AttributeError: 'Namespace' object has no attribute 'auto_tunning

```

