### PR TITLE
The new plan does not start until the latest plan is completed.

### DIFF
--- a/dlrover/python/master/scaler/pod_scaler.py
+++ b/dlrover/python/master/scaler/pod_scaler.py
@@ -132,6 +132,9 @@ class PodScaler(Scaler):
         with self._lock:
             if plan.empty():
                 return
+            while self._create_node_queue:
+                logger.info("Wait the latest plan completes.")
+                time.sleep(60)
             self._plan = plan
             job_pods = self._list_job_pods()
             logger.info("Scale the job by plan %s", plan.to_json())

--- a/dlrover/python/tests/test_pod_scaler.py
+++ b/dlrover/python/tests/test_pod_scaler.py
@@ -159,6 +159,7 @@ class PodScalerTest(unittest.TestCase):
                 chief_ids.append(node.id)
         self.assertListEqual(chief_ids, [0])
         self.assertListEqual(worker_ids, [3, 4])
+        scaler._create_node_queue.clear()
 
         scale_plan.node_group_resources = {
             NodeType.WORKER: NodeGroupResource(3, resource),


### PR DESCRIPTION
### What changes were proposed in this pull request?

The new plan does not start until the latest plan is completed.

### Why are the changes needed?

The new plan may disturb the latest uncompleted plan.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

UT.
