### PR TITLE
Set master addr if MY_POD_IP is not envs.

### DIFF
--- a/dlrover/python/elastic_agent/torch/training.py
+++ b/dlrover/python/elastic_agent/torch/training.py
@@ -78,6 +78,13 @@ def _set_paral_config():
     os.environ[ConfigPath.ENV_RUNTIME_METRICS] = ConfigPath.RUNTIME_METRICS
 
 
+def _get_local_ip():
+    local_ip = os.getenv("MY_POD_IP", "")
+    if not local_ip:
+        local_ip = socket.gethostbyname(_get_fq_hostname())
+    return local_ip
+
+
 @dataclass
 class ElasticLaunchConfig(LaunchConfig):
     """
@@ -566,10 +573,7 @@ def launch_agent(
         local_addr=config.local_addr,
         **config.rdzv_configs,
     )
-    master_addr = os.getenv("MY_POD_IP", "")
-    if not master_addr:
-        master_addr = socket.gethostbyname(_get_fq_hostname())
-
+    master_addr = _get_local_ip()
     rdzv_handler = MasterRendezvousHandler(
         RendezvousName.ELASTIC_TRAINING,
         rank_id,
@@ -819,9 +823,7 @@ def network_check(
         **config.rdzv_configs,
     )
 
-    master_addr = os.environ.get(
-        "MY_POD_IP", socket.gethostbyname(_get_fq_hostname())
-    )
+    master_addr = _get_local_ip()
     rdzv_handler = MasterRendezvousHandler(
         RendezvousName.NETWORK_CHECK,
         rank_id,

--- a/dlrover/python/elastic_agent/torch/training.py
+++ b/dlrover/python/elastic_agent/torch/training.py
@@ -566,10 +566,9 @@ def launch_agent(
         local_addr=config.local_addr,
         **config.rdzv_configs,
     )
-
-    master_addr = os.environ.get(
-        "MY_POD_IP", socket.gethostbyname(_get_fq_hostname())
-    )
+    master_addr = os.getenv("MY_POD_IP", "")
+    if not master_addr:
+        master_addr = socket.gethostbyname(_get_fq_hostname())
 
     rdzv_handler = MasterRendezvousHandler(
         RendezvousName.ELASTIC_TRAINING,

--- a/dlrover/python/tests/test_elastic_training_agent.py
+++ b/dlrover/python/tests/test_elastic_training_agent.py
@@ -34,6 +34,7 @@ from dlrover.python.elastic_agent.torch.training import (
     ElasticTrainingAgent,
     MasterRendezvousHandler,
     NetworkCheckElasticAgent,
+    _get_local_ip,
     _set_paral_config,
 )
 from dlrover.python.tests.test_utils import start_local_master
@@ -141,6 +142,13 @@ class ElasticTrainingAgentTest(unittest.TestCase):
         self.assertEqual(worker.local_rank, 1)
         self.assertEqual(worker.global_rank, 9)
         self.assertEqual(worker.world_size, 16)
+
+    def test_get_local_ip(self):
+        local_ip = _get_local_ip()
+        self.assertNotEqual(local_ip, "")
+        os.environ["MY_POD_IP"] = "127.0.0.1"
+        local_ip = _get_local_ip()
+        self.assertEqual(local_ip, "127.0.0.1")
 
 
 class ElasticTrainingAgentRunTest(unittest.TestCase):


### PR DESCRIPTION
### What changes were proposed in this pull request?

Set the master addr if MY_POD_IP is not envs.

### Why are the changes needed?

socket.gaierror: [Errno -2] Name or service not known


### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

UT.