### PR TITLE
Implement a CheckpointManager to save and load the checkpoint.

### DIFF
--- a/dlrover/trainer/tests/torch/checkpoint_manager_test.py
+++ b/dlrover/trainer/tests/torch/checkpoint_manager_test.py
@@ -84,9 +84,9 @@ class CheckpointManagerTest(unittest.TestCase):
                 tmpdirname,
                 max_to_keep=2,
             )
-            ckpt_manager.save(step=10)
-            ckpt_manager.save(step=20)
-            ckpt_manager.save(step=30)
+            ckpt_manager.save(epoch=0, step=10)
+            ckpt_manager.save(epoch=0, step=20)
+            ckpt_manager.save(epoch=0, step=30)
             ckpt_dirs = os.listdir(tmpdirname)
             self.assertEqual(len(ckpt_dirs), 2)
 

--- a/dlrover/trainer/tests/torch/checkpoint_manager_test.py
+++ b/dlrover/trainer/tests/torch/checkpoint_manager_test.py
@@ -1,0 +1,98 @@
+# Copyright 2023 The DLRover Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import tempfile
+import unittest
+
+import numpy as np
+import torch.nn as nn
+import torch.nn.functional as F
+import torch.optim as optim
+from torch.utils.data import DataLoader, Dataset
+
+from dlrover.trainer.torch.elastic.checkpoint import (
+    CheckpointManger,
+    get_latest_checkpoint,
+)
+from dlrover.trainer.torch.elastic.sampler import ElasticDistributedSampler
+
+
+class SimpleDataset(Dataset):
+    def __init__(self):
+        self.data = np.arange(0, 60001)
+
+    def __len__(self):
+        return len(self.data)
+
+    def __getitem__(self, index):
+        return self.data[index]
+
+
+class SimpleNet(nn.Module):
+    def __init__(self):
+        super(SimpleNet, self).__init__()
+        self.fc1 = nn.Linear(128, 64)
+        self.fc2 = nn.Linear(64, 10)
+
+    def forward(self, x):
+        x = self.fc1(x)
+        x = F.relu(x)
+        x = self.dropout2(x)
+        x = self.fc2(x)
+        output = F.log_softmax(x, dim=1)
+        return output
+
+
+class CheckpointManagerTest(unittest.TestCase):
+    def setUp(self):
+        self.model = SimpleNet()
+        self.optimizer = optim.SGD(
+            self.model.parameters(),
+            lr=0.01,
+            momentum=0.001,
+        )
+        self.dataset = SimpleDataset()
+        self.sampler = ElasticDistributedSampler(
+            dataset=self.dataset,
+            num_replicas=2,
+            rank=0,
+            shuffle=False,
+        )
+        self.dataloader = DataLoader(
+            self.dataset,
+            batch_size=4,
+            sampler=self.sampler,
+        )
+
+    def test_save_load(self):
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            ckpt_manager = CheckpointManger(
+                self.model,
+                self.optimizer,
+                self.dataloader,
+                tmpdirname,
+                max_to_keep=2,
+            )
+            ckpt_manager.save(step=10)
+            ckpt_manager.save(step=20)
+            ckpt_manager.save(step=30)
+            ckpt_dirs = os.listdir(tmpdirname)
+            self.assertEqual(len(ckpt_dirs), 2)
+
+            ckpt_dir = get_latest_checkpoint(tmpdirname)
+            expected_dir = os.path.join(tmpdirname, "checkpoint-30")
+            self.assertEqual(ckpt_dir, expected_dir)
+
+            ckpt_manager.load()
+            self.assertEqual(self.dataloader.sampler.total_size, 60002)

--- a/dlrover/trainer/torch/elastic/checkpoint.py
+++ b/dlrover/trainer/torch/elastic/checkpoint.py
@@ -13,12 +13,15 @@
 
 import os
 import shutil
+from abc import ABCMeta, abstractmethod
 
 import torch
 import torch.distributed as dist
 from torch.distributed.fsdp import FullStateDictConfig
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from torch.distributed.fsdp import StateDictType
+from torch.distributed.fsdp.api import FullOptimStateDictConfig
+from torch.nn.parallel import DistributedDataParallel as DDP
 
 from dlrover.python.common.log import default_logger as logger
 from dlrover.trainer.torch.elastic.sampler import ElasticDistributedSampler
@@ -37,7 +40,21 @@ def sync():
         dist.barrier()
 
 
-class CheckpointManger(object):
+def get_latest_checkpoint(checkpoint_dir):
+    """Get the checkpoint directory with the maximum step."""
+    if not os.path.exists(checkpoint_dir):
+        return ""
+    max_step = 0
+    for fn in os.listdir(checkpoint_dir):
+        if not fn.startswith(CKPT_DIR_PREFIX):
+            continue
+        step = int(fn.split("-")[-1])
+        max_step = step if step > max_step else max_step
+    path = os.path.join(checkpoint_dir, f"{CKPT_DIR_PREFIX}{max_step}")
+    return path
+
+
+class CheckpointManger(metaclass=ABCMeta):
     """CheckpontManager can save and load checkpoint states.
 
     Args:
@@ -50,15 +67,7 @@ class CheckpointManger(object):
         rank (int): the rank of process in the communication world.
         max_to_keep (int): the max number of checkpoint to keep. The oldest
             checkpoint files will be removed if the number of checkpoints
-            is bigger than max_to_kepp.
-
-    Example::
-        >>> ckpt_manager = CheckpointManager(
-        >>>    model, optimizer, train_dataloader, "/tmp/checkpoint/"
-        >>> )
-        >>> ckpt_manager.save(0, 10)
-        >>> ckpt_manger.load()
-
+            is bigger than max_to_kep.
     """
 
     def __init__(
@@ -84,47 +93,8 @@ class CheckpointManger(object):
     def _is_rank0(self):
         return self.rank == 0
 
-    def save(self, epoch, step):
-        """
-        Save the checkpoint of model, optimizer, dataloader into the directory
-        `{self.directory}/checkpoint-{step}/`. If use_fdsp, all ranks will save
-        the part of the model and optimizer states into the file
-        `checkpoint-{step}/part-{rank}.pt`. If not use_fsdp, only rank0 saves
-        the total model and optimizer states into the file
-        `checkpoint-{step}/checkpoint.pt`.
-
-        Args:
-            epoch (int): the epoch index.
-            step (int): the iteration step in the epoch.
-        """
-        self.log_rank0(f"Save checkpoint of step={step} of epoch={epoch}.")
-        step = step + epoch * len(self.dataloader)
-        is_fsdp_model = isinstance(self.model, FSDP)
-        msd, osd = get_model_optim_state(
-            self.model, self.optimizer, is_fsdp_model
-        )
-        ssd = {}
-        if isinstance(self.dataloader.sampler, ElasticDistributedSampler):
-            ssd = self.dataloader.sampler.state_dict(
-                step, self.dataloader.batch_size
-            )
-        checkpoint = {"model": msd, "optimizer": osd, "sampler": ssd}
-        ckpt_dir = os.path.join(self.directory, f"{CKPT_DIR_PREFIX}{step}")
-        if self._is_rank0():
-            init_dir(ckpt_dir)
-        sync()
-        if is_fsdp_model:
-            ckpt_path = os.path.join(ckpt_dir, f"part-{self.rank}.pt")
-            torch.save(checkpoint, ckpt_path)
-        else:
-            # Only rank0 saves the checkpoint for DDP model.
-            if self._is_rank0():
-                ckpt_path = os.path.join(ckpt_dir, "checkpoint.pt")
-                torch.save(checkpoint, ckpt_path)
-        self._keep_topk_checkpoint()
-        sync()
-
     def _keep_topk_checkpoint(self):
+        """Keep top k checkpoints and remove other checkpoints."""
         if not self.max_to_keep or not self._is_rank0():
             return
         steps = []
@@ -142,27 +112,107 @@ class CheckpointManger(object):
             dir_name = os.path.join(self.directory, f"{CKPT_DIR_PREFIX}{step}")
             shutil.rmtree(dir_name)
 
+    @abstractmethod
+    def save(self, epoch, step):
+        """
+        Save the checkpoint of model, optimizer and sampler.
+
+        Args:
+            epoch (int): the epoch index.
+            step (int): the iteration step in the epoch.
+        """
+        pass
+
+    @abstractmethod
     def load(self, ckpt_path=None):
         """
-        The manager firstly searches the checkpoint directory with the maximum
-        step. Then, the manager loads the states from the files in the
+        The manager loads the states from the files in the
         checkpoint direcotry to the model, optimizer and sampler.
 
         ckpt_path (str, optinoal): The manager will load checkpoint from the
             path. If the path is None, the manager will load the state
             checkpoint from the file with the maximum step.
         """
-        is_fsdp_model = isinstance(self.model, FSDP)
+        pass
+
+    @classmethod
+    def init_checkpoint_manager(
+        cls, model, optimizer, dataloader, directory, rank=0, max_to_keep=None
+    ):
+        """A factory method to initialize a checkpoint manager by the model
+        class.
+        """
+        if not dist.is_initialized():
+            return LocalCheckpointManger(
+                model,
+                optimizer,
+                dataloader,
+                directory,
+                rank,
+                max_to_keep,
+            )
+        elif isinstance(model, DDP):
+            return DDPCheckpointManger(
+                model,
+                optimizer,
+                dataloader,
+                directory,
+                rank,
+                max_to_keep,
+            )
+        elif isinstance(model, FSDP):
+            return FSDPCheckpointManger(
+                model,
+                optimizer,
+                dataloader,
+                directory,
+                rank,
+                max_to_keep,
+            )
+        else:
+            raise ValueError(f"Not support model class {model}")
+
+
+class LocalCheckpointManger(CheckpointManger):
+    """The manager saves and loads checkpoint states of the local
+    model and optimizer without distributed execution.
+
+    Example::
+        >>> ckpt_manager = LocalCheckpointManger(
+        >>>    model, optimizer, train_dataloader, "/tmp/checkpoint/"
+        >>> )
+        >>> ckpt_manager.save(0, 10)
+        >>> ckpt_manger.load()
+
+    """
+
+    def save(self, epoch, step):
+        """
+        Save the checkpoint of model, optimizer, dataloader into the directory
+        `{self.directory}/checkpoint-{step}/checkpoint.pt`.
+        """
+        logger.info(f"Save checkpoint of step={step} of epoch={epoch}.")
+        step = step + epoch * len(self.dataloader)
+        msd = self.model.state_dict()
+        osd = self.optimizer.state_dict()
+        ssd = {}
+        if isinstance(self.dataloader.sampler, ElasticDistributedSampler):
+            ssd = self.dataloader.sampler.state_dict(
+                step, self.dataloader.batch_size
+            )
+        checkpoint = {"model": msd, "optimizer": osd, "sampler": ssd}
+        ckpt_dir = os.path.join(self.directory, f"{CKPT_DIR_PREFIX}{step}")
+        init_dir(ckpt_dir)
+        ckpt_path = os.path.join(ckpt_dir, "checkpoint.pt")
+        torch.save(checkpoint, ckpt_path)
+        self._keep_topk_checkpoint()
+
+    def load(self, ckpt_path=None):
         latest_ckpt_dir = get_latest_checkpoint(self.directory)
         if not latest_ckpt_dir:
             return
         if not ckpt_path:
-            if is_fsdp_model:
-                ckpt_path = os.path.join(
-                    latest_ckpt_dir, f"part-{self.rank}.pt"
-                )
-            else:
-                ckpt_path = os.path.join(latest_ckpt_dir, "checkpoint.pt")
+            ckpt_path = os.path.join(latest_ckpt_dir, "checkpoint.pt")
         if not os.path.exists(ckpt_path):
             return
         logger.info(f"Load checkpoint from {ckpt_path}")
@@ -171,49 +221,112 @@ class CheckpointManger(object):
         if isinstance(sampler, ElasticDistributedSampler):
             sampler.load_state_dict(checkpoint.get("sampler", {}))
         model_state_dict = checkpoint.get("model", {})
-        self.model.load_state_dict(model_state_dict)
         optim_state_dict = checkpoint.get("optimizer", {})
-        if is_fsdp_model:
-            FSDP.set_state_dict_type(
-                self.model,
-                StateDictType.FULL_STATE_DICT,
-                FullStateDictConfig(rank0_only=False),
-            )
-            # called from all ranks, though only rank0 has
-            # a valid param for full_osd.
-            optim_state_dict = FSDP.optim_state_dict_to_load(
-                optim_state_dict, self.model, self.optimizer
-            )
-            self.optimizer.load_state_dict(optim_state_dict)
-        else:
-            self.optimizer.load_state_dict(optim_state_dict)
+        self.model.load_state_dict(model_state_dict)
+        self.optimizer.load_state_dict(optim_state_dict)
 
 
-def get_model_optim_state(model, optimizer, use_fsdp=False):
-    """Get model and optimizer states."""
-    if use_fsdp:
+class DDPCheckpointManger(LocalCheckpointManger):
+    """DDPCheckpontManager saves and loads checkpoint states of a DDP model.
+
+    Example::
+        >>> ckpt_manager = CheckpointManager(
+        >>>    model, optimizer, train_dataloader, "/tmp/checkpoint/"
+        >>> )
+        >>> ckpt_manager.save(0, 10)
+        >>> ckpt_manger.load()
+    """
+
+    def save(self, epoch, step):
+        """
+        Save the checkpoint of model, optimizer, dataloader into the directory
+        `{self.directory}/checkpoint-{step}/checkpoint.pt`.
+        """
+        self.log_rank0(f"Save checkpoint of step={step} of epoch={epoch}.")
+        step = step + epoch * len(self.dataloader)
+        msd = self.model.state_dict()
+        osd = self.optimizer.state_dict()
+        ssd = {}
+        if isinstance(self.dataloader.sampler, ElasticDistributedSampler):
+            ssd = self.dataloader.sampler.state_dict(
+                step, self.dataloader.batch_size
+            )
+        checkpoint = {"model": msd, "optimizer": osd, "sampler": ssd}
+        ckpt_dir = os.path.join(self.directory, f"{CKPT_DIR_PREFIX}{step}")
+        if self._is_rank0():
+            init_dir(ckpt_dir)
+        sync()
+        # Only rank0 saves the checkpoint for DDP model.
+        if self._is_rank0():
+            ckpt_path = os.path.join(ckpt_dir, "checkpoint.pt")
+            torch.save(checkpoint, ckpt_path)
+        self._keep_topk_checkpoint()
+        sync()
+
+
+class FSDPCheckpointManger(CheckpointManger):
+    def save(self, epoch, step):
+        """
+        Save the checkpoint of model, optimizer, dataloader into the directory
+        `{self.directory}/checkpoint-{step}/`. All ranks will save
+        the part of the model and optimizer states into the file
+        `checkpoint-{step}/part-{rank}.pt`.
+        """
+        self.log_rank0(f"Save checkpoint of step={step} of epoch={epoch}.")
+        step = step + epoch * len(self.dataloader)
         FSDP.set_state_dict_type(
-            model,
+            self.model,
             StateDictType.FULL_STATE_DICT,
             FullStateDictConfig(rank0_only=False),
+            FullOptimStateDictConfig(rank0_only=False),
         )
-        model_state = model.state_dict()
-        optim_state = FSDP.optim_state_dict(model, optimizer)
-    else:
-        model_state = model.state_dict()
-        optim_state = optimizer.state_dict()
-    return model_state, optim_state
+        msd = self.model.state_dict()
+        osd = FSDP.optim_state_dict(self.model, self.optimizer)
+        ssd = {}
+        if isinstance(self.dataloader.sampler, ElasticDistributedSampler):
+            ssd = self.dataloader.sampler.state_dict(
+                step, self.dataloader.batch_size
+            )
+        checkpoint = {"model": msd, "optimizer": osd, "sampler": ssd}
+        ckpt_dir = os.path.join(self.directory, f"{CKPT_DIR_PREFIX}{step}")
+        if self._is_rank0():
+            init_dir(ckpt_dir)
+        sync()
+        ckpt_path = os.path.join(ckpt_dir, f"part-{self.rank}.pt")
+        torch.save(checkpoint, ckpt_path)
+        self._keep_topk_checkpoint()
+        sync()
 
+    def load(self, ckpt_path=None):
+        latest_ckpt_dir = get_latest_checkpoint(self.directory)
+        if not latest_ckpt_dir:
+            return
+        if not ckpt_path:
+            ckpt_path = os.path.join(latest_ckpt_dir, f"part-{self.rank}.pt")
+        if not os.path.exists(ckpt_path):
+            return
+        logger.info(f"Load checkpoint from {ckpt_path}")
+        checkpoint = torch.load(ckpt_path)
+        sampler = self.dataloader.sampler
+        if isinstance(sampler, ElasticDistributedSampler):
+            sampler.load_state_dict(checkpoint.get("sampler", {}))
+        model_state_dict = checkpoint.get("model", {})
+        optim_state_dict = checkpoint.get("optimizer", {})
 
-def get_latest_checkpoint(checkpoint_dir):
-    """Get the checkpoint directory with the maximum step."""
-    if not os.path.exists(checkpoint_dir):
-        return ""
-    max_step = 0
-    for fn in os.listdir(checkpoint_dir):
-        if not fn.startswith(CKPT_DIR_PREFIX):
-            continue
-        step = int(fn.split("-")[-1])
-        max_step = step if step > max_step else max_step
-    path = os.path.join(checkpoint_dir, f"{CKPT_DIR_PREFIX}{max_step}")
-    return path
+        FSDP.set_state_dict_type(
+            self.model,
+            StateDictType.FULL_STATE_DICT,
+            FullStateDictConfig(rank0_only=False),
+            FullOptimStateDictConfig(rank0_only=False),
+        )
+        self.model.load_state_dict(model_state_dict)
+
+        # called from all ranks, though only rank0 has
+        # a valid param for full_osd.
+        optim_state_dict = FSDP.optim_state_dict_to_load(
+            model=self.model,
+            optim=self.optimizer,
+            optim_state_dict=optim_state_dict,
+        )
+        self.optimizer.load_state_dict(optim_state_dict)
+        sync()

--- a/dlrover/trainer/torch/elastic/checkpoint.py
+++ b/dlrover/trainer/torch/elastic/checkpoint.py
@@ -116,7 +116,8 @@ class CheckpointManger(object):
                 ckpt_path = os.path.join(ckpt_dir, "checkpoint.pt")
                 torch.save(checkpoint, ckpt_path)
         self._keep_topk_checkpoint()
-        dist.barrier()
+        if dist.is_initialized():
+            dist.barrier()
 
     def _keep_topk_checkpoint(self):
         if not self.max_to_keep or not self._is_rank0():
@@ -152,8 +153,7 @@ class CheckpointManger(object):
             return
         if not ckpt_path:
             if is_fsdp_model:
-                rank = dist.get_rank()
-                ckpt_path = os.path.join(latest_ckpt_dir, f"part-{rank}.pt")
+                ckpt_path = os.path.join(latest_ckpt_dir, f"part-{self.rank}.pt")
             else:
                 ckpt_path = os.path.join(latest_ckpt_dir, "checkpoint.pt")
         if not os.path.exists(ckpt_path):

--- a/dlrover/trainer/torch/elastic/checkpoint.py
+++ b/dlrover/trainer/torch/elastic/checkpoint.py
@@ -153,7 +153,9 @@ class CheckpointManger(object):
             return
         if not ckpt_path:
             if is_fsdp_model:
-                ckpt_path = os.path.join(latest_ckpt_dir, f"part-{self.rank}.pt")
+                ckpt_path = os.path.join(
+                    latest_ckpt_dir, f"part-{self.rank}.pt"
+                )
             else:
                 ckpt_path = os.path.join(latest_ckpt_dir, "checkpoint.pt")
         if not os.path.exists(ckpt_path):

--- a/dlrover/trainer/torch/elastic/checkpoint.py
+++ b/dlrover/trainer/torch/elastic/checkpoint.py
@@ -1,0 +1,204 @@
+# Copyright 2023 The DLRover Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import shutil
+
+import torch
+import torch.distributed as dist
+from torch.distributed.fsdp import FullStateDictConfig
+from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+from torch.distributed.fsdp import StateDictType
+
+from dlrover.python.common.log import default_logger as logger
+from dlrover.trainer.torch.elastic.sampler import ElasticDistributedSampler
+
+CKPT_DIR_PREFIX = "checkpoint-"
+
+
+def init_dir(dir):
+    if os.path.exists(dir):
+        shutil.rmtree(dir)
+    os.makedirs(dir)
+
+
+class CheckpointManger(object):
+    """CheckpontManager can save and load checkpoint states.
+
+    Args:
+        model (nn.Module): an instance of `torch.nn.Module`.
+        optimizer (Optimizer): an instance of `torch.optim.Optimizer`.
+        dataloader (DataLader): an instance of `torch.utils.data.DataLoader`.
+            The sampler of DataLoader should be an instance of
+            `dlrover.trainer.torch.elastic.ElasticDistribuedSampler`.
+        directory (str): the directory to save the checkpoint states.
+        rank (int): the rank of process in the communication world.
+        max_to_keep (int): the max number of checkpoint to keep. The oldest
+            checkpoint files will be removed if the number of checkpoints
+            is bigger than max_to_kepp.
+
+    Example::
+        >>> ckpt_manager = CheckpointManager(
+        >>>    model, optimizer, train_dataloader, "/tmp/checkpoint/"
+        >>> )
+        >>> ckpt_manager.save(10)
+        >>> ckpt_manger.load()
+
+    """
+
+    def __init__(
+        self,
+        model,
+        optimizer,
+        dataloader,
+        directory,
+        rank=0,
+        max_to_keep=None,
+    ):
+        self.model = model
+        self.optimizer = optimizer
+        self.dataloader = dataloader
+        self.directory = directory
+        self.rank = rank
+        self.max_to_keep = max_to_keep
+
+    def log_rank0(self, log):
+        if self.rank == 0:
+            logger.info(log)
+
+    def save(self, step):
+        """
+        Save the checkpoint of model, optimizer, dataloader into the directory
+        `{self.directory}/checkpoint-{step}/`. If use_fdsp, all ranks will save
+        the part of the model and optimizer states into the file
+        `checkpoint-{step}/part-{rank}.pt`. If not use_fsdp, only rank0 saves
+        the total model and optimizer states into the file
+        `checkpoint-{step}/checkpoint.pt`.
+
+        Args:
+            step (int): the iteration step.
+        """
+        self.log_rank0(f"Save checkpoint of step={step}.")
+        is_fsdp_model = isinstance(self.model, FSDP)
+        msd, osd = get_model_optim_state(
+            self.model, self.optimizer, is_fsdp_model
+        )
+        ssd = {}
+        if isinstance(self.dataloader.sampler, ElasticDistributedSampler):
+            ssd = self.dataloader.sampler.state_dict(
+                step, self.dataloader.batch_size
+            )
+        checkpoint = {"model": msd, "optimizer": osd, "sampler": ssd}
+        ckpt_dir = os.path.join(self.directory, f"{CKPT_DIR_PREFIX}{step}")
+        init_dir(ckpt_dir)
+        if is_fsdp_model:
+            ckpt_path = os.path.join(ckpt_dir, f"part-{self.rank}.pt")
+            torch.save(checkpoint, ckpt_path)
+            dist.barrier()
+        elif self.rank == 0:
+            ckpt_path = os.path.join(ckpt_dir, "checkpoint.pt")
+            torch.save(checkpoint, ckpt_path)
+        self._keep_topk_checkpoint()
+
+    def _keep_topk_checkpoint(self):
+        if not self.max_to_keep:
+            return
+        steps = []
+        for dir_name in os.listdir(self.directory):
+            if not dir_name.startswith(CKPT_DIR_PREFIX):
+                continue
+            step = int(dir_name.split("-")[-1])
+            steps.append(step)
+
+        steps = sorted(steps)
+        if len(steps) <= self.max_to_keep:
+            return
+        remove_steps = steps[: -1 * self.max_to_keep]
+        for step in remove_steps:
+            dir_name = os.path.join(self.directory, f"{CKPT_DIR_PREFIX}{step}")
+            shutil.rmtree(dir_name)
+
+    def load(self, ckpt_path=None):
+        """
+        The manager firstly searches the checkpoint directory with the maximum
+        step. Then, the manager loads the states from the files in the
+        checkpoint direcotry to the model, optimizer and sampler.
+
+        ckpt_path (str, optinoal): The manager will load checkpoint from the
+            path. If the path is None, the manager will load the state
+            checkpoint from the file with the maximum step.
+        """
+        is_fsdp_model = isinstance(self.model, FSDP)
+        latest_ckpt_dir = get_latest_checkpoint(self.directory)
+        if not latest_ckpt_dir:
+            return
+        if not ckpt_path:
+            if is_fsdp_model:
+                rank = dist.get_rank()
+                ckpt_path = os.path.join(latest_ckpt_dir, f"part-{rank}.pt")
+            else:
+                ckpt_path = os.path.join(latest_ckpt_dir, "checkpoint.pt")
+        if not os.path.exists(ckpt_path):
+            return
+        logger.info(f"Load checkpoint from {ckpt_path}")
+        checkpoint = torch.load(ckpt_path)
+        sampler = self.dataloader.sampler
+        if isinstance(sampler, ElasticDistributedSampler):
+            sampler.load_state_dict(checkpoint.get("sampler", {}))
+        model_state_dict = checkpoint.get("model", {})
+        self.model.load_state_dict(model_state_dict)
+        optim_state_dict = checkpoint.get("optimizer", {})
+        if is_fsdp_model:
+            FSDP.set_state_dict_type(
+                self.model,
+                StateDictType.FULL_STATE_DICT,
+                FullStateDictConfig(rank0_only=False),
+            )
+            # called from all ranks, though only rank0 has
+            # a valid param for full_osd.
+            optim_state_dict = FSDP.optim_state_dict_to_load(
+                optim_state_dict, self.model, self.optimizer
+            )
+            self.optimizer.load_state_dict(optim_state_dict)
+        else:
+            self.optimizer.load_state_dict(optim_state_dict)
+
+
+def get_model_optim_state(model, optimizer, use_fsdp=False):
+    """Get model and optimizer states."""
+    if use_fsdp:
+        FSDP.set_state_dict_type(
+            model,
+            StateDictType.FULL_STATE_DICT,
+            FullStateDictConfig(rank0_only=False),
+        )
+        model_state = model.state_dict()
+        optim_state = FSDP.optim_state_dict(model, optimizer)
+    else:
+        model_state = model.state_dict()
+        optim_state = optimizer.state_dict()
+    return model_state, optim_state
+
+
+def get_latest_checkpoint(checkpoint_dir):
+    """Get the checkpoint directory with the maximum step."""
+    if not os.path.exists(checkpoint_dir):
+        return ""
+    max_step = 0
+    for fn in os.listdir(checkpoint_dir):
+        if not fn.startswith(CKPT_DIR_PREFIX):
+            continue
+        step = int(fn.split("-")[-1])
+        max_step = step if step > max_step else max_step
+    path = os.path.join(checkpoint_dir, f"{CKPT_DIR_PREFIX}{max_step}")
+    return path

--- a/dlrover/trainer/torch/elastic/checkpoint.py
+++ b/dlrover/trainer/torch/elastic/checkpoint.py
@@ -170,7 +170,7 @@ class CheckpointManger(metaclass=ABCMeta):
                 max_to_keep,
             )
         else:
-            raise ValueError(f"Not support model class {model}")
+            raise NotImplementedError(f"Not support model class {model}")
 
 
 class LocalCheckpointManger(CheckpointManger):

--- a/examples/pytorch/mnist/cnn_train.py
+++ b/examples/pytorch/mnist/cnn_train.py
@@ -12,9 +12,8 @@
 # limitations under the License.
 
 import argparse
-import datetime
 import os
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 import torch
 import torch.distributed as dist

--- a/examples/pytorch/mnist/cnn_train.py
+++ b/examples/pytorch/mnist/cnn_train.py
@@ -143,7 +143,7 @@ def train(args):
     )
     scheduler = StepLR(optimizer, step_size=1, gamma=0.5)
     rank = dist.get_rank()
-    ckpt_manager = CheckpointManger(
+    ckpt_manager = CheckpointManger.init_checkpoint_manager(
         model,
         optimizer,
         train_loader,

--- a/examples/pytorch/mnist/cnn_train.py
+++ b/examples/pytorch/mnist/cnn_train.py
@@ -292,12 +292,7 @@ def arg_parser():
     parser.add_argument(
         "--validation_data", type=str, default="", required=True
     )
-    parser.add_argument(
-        "--save_model",
-        type=bool,
-        default=True,
-        required=False,
-    )
+    parser.add_argument("--save_model", action="store_true", required=False)
     return parser
 
 

--- a/examples/pytorch/mnist/elastic_job.yaml
+++ b/examples/pytorch/mnist/elastic_job.yaml
@@ -14,7 +14,7 @@ spec:
           containers:
             - name: main
               # yamllint disable-line rule:line-length
-              image: registry.cn-hangzhou.aliyuncs.com/intell-ai/dlrover:torch201-mnist
+              image: registry.cn-hangzhou.aliyuncs.com/intell-ai/dlrover:torch201-mnist-test
               imagePullPolicy: Always
               command:
                 - /bin/bash
@@ -34,3 +34,17 @@ spec:
                   cpu: "2"  # turn up when using GPU
                   memory: 3Gi  # turn up when using GPU
                   # nvidia.com/gpu: 1 # optional
+          #     volumeMounts:
+          #       - name: pvc-nas
+          #         mountPath: /nas
+          # volumes:
+          #   - name: pvc-nas
+          #     persistentVolumeClaim:
+          #       claimName: pvc-nas
+    dlrover-master:
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: main
+              imagePullPolicy: Always

--- a/examples/pytorch/nanogpt/train.py
+++ b/examples/pytorch/nanogpt/train.py
@@ -14,13 +14,12 @@
 
 import argparse
 import contextlib
-import datetime
 import functools
 import math
 import os
 import pickle
 import time
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 import numpy as np
 import torch

--- a/examples/pytorch/nanogpt/train.py
+++ b/examples/pytorch/nanogpt/train.py
@@ -304,7 +304,7 @@ def train():
     # if data type is float16
 
     rank = dist.get_rank()
-    ckpt_manager = CheckpointManger(
+    ckpt_manager = CheckpointManger.init_checkpoint_manager(
         model, optimizer, train_loader, checkpoint_dir, rank, 3
     )
     ckpt_manager.load()

--- a/examples/pytorch/nanogpt/train.py
+++ b/examples/pytorch/nanogpt/train.py
@@ -380,7 +380,7 @@ def train():
                     if iter_num > max_iters:
                         break
                     if iter_num % args.checkpoint_step == 0:
-                        ckpt_manager.save(iter_num)
+                        ckpt_manager.save(epoch, iter_num)
         if args.save_model:
             rank = int(os.getenv("RANK", "0"))
             save_model(model, epoch, rank, use_fsdp)

--- a/examples/pytorch/nanogpt/train.py
+++ b/examples/pytorch/nanogpt/train.py
@@ -41,7 +41,7 @@ from dlrover.trainer.torch.elastic.trainer import ElasticTrainer
 os.environ["CUDA_DEVICE_ORDER"] = "PCI_BUS_ID"
 
 # We should use a shared storage to persist the checkpiont.
-checkpoint_dir = "/tmp/nanogpt-ckpt/"
+checkpoint_dir = "/nas/nanogpt-ckpt/"
 
 local_rank = None
 master_process = False
@@ -305,12 +305,15 @@ def train():
     # to simulate larger batch size and using the GradScaler
     # if data type is float16
 
+    rank = dist.get_rank()
     ckpt_manager = CheckpointManger(
-        model, optimizer, train_loader, checkpoint_dir
+        model, optimizer, train_loader, checkpoint_dir, rank, 3
     )
     ckpt_manager.load()
 
     for epoch in range(args.epochs):
+        # Note: set the epoch into the sampler.
+        train_loader.sampler.set_epoch(epoch)
         for X, Y in train_loader:
             with elastic_trainer.step():
                 # Determine and set the learning rate for this iteration

--- a/examples/pytorch/nanogpt/train.py
+++ b/examples/pytorch/nanogpt/train.py
@@ -213,8 +213,6 @@ def train():
     )  # For later use in torch.autocast
     if device_type == "cuda":
         torch.cuda.set_device(device)
-    # choose ddp or fdsp
-    use_fsdp = args.use_fsdp == "True"
     # Note: float16 data type will automatically use a GradScaler
     dtype = (
         "bfloat16"
@@ -248,7 +246,7 @@ def train():
     if torch.cuda.is_available() and device_type == "cuda":
         # Create model and move it to GPU with id rank
         model = model.to(local_rank)
-        if use_fsdp:
+        if args.use_fsdp:
             print(f"Running basic FSDP example on local rank {local_rank}.")
 
             my_auto_wrap_policy = functools.partial(
@@ -383,7 +381,7 @@ def train():
                         ckpt_manager.save(epoch, iter_num)
         if args.save_model:
             rank = int(os.getenv("RANK", "0"))
-            save_model(model, epoch, rank, use_fsdp)
+            save_model(model, epoch, rank, args.use_fsdp)
 
 
 def save_model(model, epoch, rank, use_fsdp=False):
@@ -505,16 +503,11 @@ def arg_parser():
         Defaults to 'cpu' if not specified.""",
     )
     parser.add_argument("--compile", type=str, default="False", required=False)
-    parser.add_argument(
-        "--use_fsdp", type=str, default="False", required=False
-    )
+    parser.add_argument("--use_fsdp", action="store_true", required=False)
     parser.add_argument(
         "--checkpoint_step", type=int, default=100, required=False
     )
-    parser.add_argument(
-        "--save_model", type=bool, default=True, required=False
-    )
-
+    parser.add_argument("--save_model", action="store_true", required=False)
     args = parser.parse_args()
 
     return args


### PR DESCRIPTION
### What changes were proposed in this pull request?

Implement a CheckpointManager to save and load the checkpoint.

### Why are the changes needed?

It is APIs for users to save and load checkpoint of DDP or FDSP model.

Fix #771 

### Does this PR introduce any user-facing change?

Yes. Users can use CheckpointManager to save and load checkpoint. For example.

``` python
>>> ckpt_manager = CheckpointManager(
>>>    model, optimizer, train_dataloader, "/tmp/checkpoint/"
>>> )
>>> ckpt_manager.save(0, 10)
>>> ckpt_manger.load()
```

### How was this patch tested?

We have tested it with a MNIST job.
