### PR TITLE
Implement the start method to initialize attributes about the job.

### DIFF
--- a/dlrover/python/master/node/dist_job_manager.py
+++ b/dlrover/python/master/node/dist_job_manager.py
@@ -746,6 +746,7 @@ def create_job_manager(args: JobArgs, speed_monitor) -> DistributedJobManager:
         args.platform, args.job_name, args.namespace
     )
     job_scaler = new_job_scaler(args.platform, args.job_name, args.namespace)
+    job_scaler.start()
 
     return DistributedJobManager(
         job_args=args,

--- a/dlrover/python/master/scaler/base_scaler.py
+++ b/dlrover/python/master/scaler/base_scaler.py
@@ -54,8 +54,15 @@ class Scaler(metaclass=ABCMeta):
 
     def __init__(self, job_name):
         self._job_name = job_name
+        self._job = None
+        self._job_uid = ""
+
+    @abstractmethod
+    def start(self):
+        """Start the scaler."""
+        pass
 
     @abstractmethod
     def scale(self, plan: ScalePlan):
-        """Scale the job with the plan"""
+        """Scale the job with the plan."""
         pass

--- a/dlrover/python/master/scaler/elasticjob_scaler.py
+++ b/dlrover/python/master/scaler/elasticjob_scaler.py
@@ -160,6 +160,8 @@ class ElasticJobScaler(Scaler):
         self._namespace = namespace
         self._scaleplan_name = self._job_name + "-scaleplan"
         self._scaleplan_index = 0
+
+    def start(self):
         self._job = self._retry_to_get_job()
         self._job_uid = self._job["metadata"]["uid"]
 

--- a/dlrover/python/master/scaler/pod_scaler.py
+++ b/dlrover/python/master/scaler/pod_scaler.py
@@ -86,17 +86,19 @@ class PodScaler(Scaler):
         self._plan = ScalePlan()
         self._ps_addrs: List[str] = []
         self._pod_stats: Dict[str, int] = {}
-        self._init_pod_config_by_job()
         self._job_uid = ""
+        self.api_client = client.ApiClient()
+        self._k8s_client.api_instance
+
+    def start(self):
+        self._job = self._retry_to_get_job()
+        self._init_pod_config_by_job()
         self._master_pod = self._retry_to_get_master_pod()
         threading.Thread(
             target=self._periodic_create_pod, name="pod-creater", daemon=True
         ).start()
-        self.api_client = client.ApiClient()
-        self._k8s_client.api_instance
 
     def _init_pod_config_by_job(self):
-        self._job = self._retry_to_get_job()
         self._distribution_strategy = self._job["spec"].get(
             "distributionStrategy", None
         )

--- a/dlrover/python/master/scaler/ray_scaler.py
+++ b/dlrover/python/master/scaler/ray_scaler.py
@@ -45,7 +45,7 @@ class ActorScaler(Scaler):
         self._namespace = namespace
         self._lock = threading.Lock()
 
-    def _retry_to_get_job(self):
+    def start(self):
         pass
 
     def scale(self, plan: ScalePlan):

--- a/dlrover/python/tests/test_elasticjob_scaler.py
+++ b/dlrover/python/tests/test_elasticjob_scaler.py
@@ -52,6 +52,7 @@ class ElasticJobScalerTest(unittest.TestCase):
         plan.node_group_resources["worker"] = group_resource
 
         scaler = ElasticJobScaler("test", "dlrover")
+        scaler.start()
         scaler_crd = scaler._generate_scale_plan_crd(plan)
 
         expected_dict = {

--- a/dlrover/python/tests/test_pod_scaler.py
+++ b/dlrover/python/tests/test_pod_scaler.py
@@ -34,6 +34,7 @@ class PodScalerTest(unittest.TestCase):
 
     def test_init_pod_template(self):
         scaler = PodScaler("elasticjob-sample", "default")
+        scaler.start()
         self.assertEqual(
             scaler._distribution_strategy,
             DistributionStrategy.PS,
@@ -57,6 +58,7 @@ class PodScalerTest(unittest.TestCase):
 
     def test_create_pod(self):
         scaler = PodScaler("elasticjob-sample", "default")
+        scaler.start()
         scaler._init_pod_config_by_job()
         scaler._distribution_strategy = DistributionStrategy.PS
         resource = NodeResource(4, 8192)
@@ -120,6 +122,7 @@ class PodScalerTest(unittest.TestCase):
 
     def test_create_service(self):
         scaler = PodScaler("elasticjob-sample", "default")
+        scaler.start()
         service = scaler._create_service_obj(
             name="elasticjob-sample-edljob-worker-0",
             port="2222",


### PR DESCRIPTION
### What changes were proposed in this pull request?

A start method to  initialize attributes about the job.

### Why are the changes needed?

To simplify the `__init__` of Scaler classes.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

UT.
