### PR TITLE
Remove the code to replace the model in the test.

### DIFF
--- a/examples/pytorch/mnist/cnn_train.py
+++ b/examples/pytorch/mnist/cnn_train.py
@@ -254,7 +254,6 @@ def test(model, device, test_loader):
     test_loss = 0
     correct = 0
     with torch.no_grad():
-        model = model.to(device)
         for data, target in test_loader:
             target = target.type(torch.LongTensor)
             data, target = data.to(device), target.to(device)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix a bug.

### Why are the changes needed?

Traceback (most recent call last):
--
File "examples/pytorch/mnist/cnn_train.py", line 312, in <module>
Traceback (most recent call last):
File "examples/pytorch/mnist/cnn_train.py", line 312, in <module>
train(args)
File "/usr/local/lib/python3.8/site-packages/torch/distributed/elastic/multiprocessing/errors/__init__.py", line 346, in wrapper
train(args)
File "/usr/local/lib/python3.8/site-packages/torch/distributed/elastic/multiprocessing/errors/__init__.py", line 346, in wrapper
return f(*args, **kwargs)
File "examples/pytorch/mnist/cnn_train.py", line 176, in train
train_epoch(
File "examples/pytorch/mnist/cnn_train.py", line 216, in train_epoch
loss.backward()
File "/usr/local/lib/python3.8/site-packages/torch/_tensor.py", line 487, in backward
return f(*args, **kwargs)
File "examples/pytorch/mnist/cnn_train.py", line 176, in train
torch.autograd.backward(
File "/usr/local/lib/python3.8/site-packages/torch/autograd/__init__.py", line 200, in backward
train_epoch(
File "examples/pytorch/mnist/cnn_train.py", line 216, in train_epoch
Variable._execution_engine.run_backward(  # Calls into the C++ engine to run the backward pass
SystemError: <built-in method run_backward of torch._C._EngineBase object at 0x7f1a31ae6990> returned NULL without setting an error
loss.backward()


