### PR TITLE
Add the cpu_offload argument in the examples.

### DIFF
--- a/examples/pytorch/mnist/cnn_train.py
+++ b/examples/pytorch/mnist/cnn_train.py
@@ -133,11 +133,14 @@ def train(args):
             my_auto_wrap_policy = functools.partial(
                 size_based_auto_wrap_policy, min_num_params=1000
             )
+            cpu_offload = (
+                CPUOffload(offload_params=True) if args.cpu_offload else None
+            )
             model = FSDP(
                 model,
                 device_id=local_rank,
                 auto_wrap_policy=my_auto_wrap_policy,
-                cpu_offload=CPUOffload(offload_params=True),
+                cpu_offload=cpu_offload,
             )
         else:
             print(f"Running basic DDP example on local rank {local_rank}.")
@@ -283,7 +286,8 @@ def arg_parser():
     parser.add_argument("--batch_size", type=int, default=32, required=False)
     parser.add_argument("--num_epochs", type=int, default=1, required=False)
     parser.add_argument("--shuffle", type=bool, default=True, required=False)
-    parser.add_argument("--use_fsdp", type=bool, default=False, required=False)
+    parser.add_argument("--use_fsdp", action="store_true", required=False)
+    parser.add_argument("--cpu_offload", action="store_true", required=False)
     parser.add_argument(
         "--fixed_batch_size", type=bool, default=True, required=False
     )

--- a/examples/pytorch/mnist/elastic_job.yaml
+++ b/examples/pytorch/mnist/elastic_job.yaml
@@ -11,10 +11,11 @@ spec:
       replicas: 4
       template:
         spec:
+          restartPolicy: Always
           containers:
             - name: main
               # yamllint disable-line rule:line-length
-              image: registry.cn-hangzhou.aliyuncs.com/intell-ai/dlrover:torch201-mnist-test
+              image: registry.cn-hangzhou.aliyuncs.com/intell-ai/dlrover:torch201-mnist
               imagePullPolicy: Always
               command:
                 - /bin/bash

--- a/examples/pytorch/nanogpt/train.py
+++ b/examples/pytorch/nanogpt/train.py
@@ -253,11 +253,14 @@ def train():
                 transformer_auto_wrap_policy,
                 transformer_layer_cls={Block},
             )
+            cpu_offload = (
+                CPUOffload(offload_params=True) if args.cpu_offload else None
+            )
             model = FSDP(
                 model,
                 device_id=local_rank,
                 auto_wrap_policy=my_auto_wrap_policy,
-                cpu_offload=CPUOffload(offload_params=True),
+                cpu_offload=cpu_offload,
             )
         else:
             print(f"Running basic DDP example on local rank {local_rank}.")
@@ -505,6 +508,7 @@ def arg_parser():
     )
     parser.add_argument("--compile", type=str, default="False", required=False)
     parser.add_argument("--use_fsdp", action="store_true", required=False)
+    parser.add_argument("--cpu_offload", action="store_true", required=False)
     parser.add_argument(
         "--checkpoint_step", type=int, default=100, required=False
     )


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add the cpu_offload argument in the examples.

### Why are the changes needed?

CPU Offload can decrease the CUDA memory but also make the training slow.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

cnn_train.py --cpu_offload
