### PR TITLE
Exit elastic-training rendezvous if the network-check has workers

### DIFF
--- a/dlrover/python/elastic_agent/torch/training.py
+++ b/dlrover/python/elastic_agent/torch/training.py
@@ -243,7 +243,7 @@ class MasterRendezvousHandler(RendezvousHandler):
         rank = list(world.keys()).index(self._rank_id)
         world_size = len(world)
         logger.info(
-            f"The node{node_name} has joined round {round} of "
+            f"The node {node_name} has joined round {round} of "
             f"the {self._name} rendezvous as rank {rank} in a world of size "
             f"{world_size}."
         )
@@ -458,7 +458,7 @@ class ElasticTrainingAgent(LocalElasticAgent):
                 super()._initialize_workers(worker_group)
             except RendezvousOutSyncError:
                 logger.info(
-                    "Exit elastic-training rendezvous when there are"
+                    "Exit elastic-training rendezvous when there are "
                     "agents to join the network-check rendezvous."
                 )
             else:

--- a/dlrover/python/elastic_agent/torch/training.py
+++ b/dlrover/python/elastic_agent/torch/training.py
@@ -85,6 +85,10 @@ def _get_local_ip():
     return local_ip
 
 
+class RendezvousOutSyncError(Exception):
+    pass
+
+
 @dataclass
 class ElasticLaunchConfig(LaunchConfig):
     """
@@ -206,6 +210,7 @@ class MasterRendezvousHandler(RendezvousHandler):
         round = self._join_rendezvous()
         start_pending = 0
         while True:
+            self._check_network_rdzv_for_elastic_training()
             group, world = self._client.get_comm_world(
                 self._name, self._rank_id
             )
@@ -250,6 +255,18 @@ class MasterRendezvousHandler(RendezvousHandler):
             self._report_failure(err_msg, level=TrainingMsgLevel.WARNING)
         store = self._get_store(round, group)
         return store, world
+
+    def _check_network_rdzv_for_elastic_training(self):
+        """The worker need to exit the elastic-training rendezvous if there are
+        workers to join the network-check rendezvous.
+        """
+        if self._name == RendezvousName.ELASTIC_TRAINING:
+            num = self._client.num_nodes_waiting(RendezvousName.NETWORK_CHECK)
+            if num > 0:
+                raise RendezvousOutSyncError(
+                    "Some workers join the network-check rendezvous"
+                    "not the elastic-training rendezvous."
+                )
 
     def _report_failure(self, err_msg, level):
         if self._rank_id == 0:
@@ -301,7 +318,7 @@ class ElasticTrainingAgent(LocalElasticAgent):
     def __init__(
         self,
         rank_id,
-        config,
+        config: ElasticLaunchConfig,
         entrypoint,
         spec: WorkerSpec,
         start_method="spawn",
@@ -434,9 +451,18 @@ class ElasticTrainingAgent(LocalElasticAgent):
         return workers
 
     def _initialize_workers(self, worker_group):
-        if self._config.network_check:
-            run_network_check(self._config, self._entrypoint)
-        super()._initialize_workers(worker_group)
+        while True:
+            try:
+                if self._config.network_check:
+                    run_network_check(self._config, self._entrypoint)
+                super()._initialize_workers(worker_group)
+            except RendezvousOutSyncError:
+                logger.info(
+                    "Exit elastic-training rendezvous when there are"
+                    "agents to join the network-check rendezvous."
+                )
+            else:
+                break
 
     def _invoke_run(self, role: str = DEFAULT_ROLE) -> RunResult:
         # NOTE: currently only works for a single role
@@ -521,7 +547,12 @@ class ElasticTrainingAgent(LocalElasticAgent):
 
     def _membership_changed(self, role, rdzv_handler: RendezvousHandler):
         # Timeout may happen when to query TCPStore.
-        num_nodes_waiting = rdzv_handler.num_nodes_waiting()
+        if self._config.network_check:
+            num_nodes_waiting = self._client.num_nodes_waiting(
+                RendezvousName.NETWORK_CHECK
+            )
+        else:
+            num_nodes_waiting = rdzv_handler.num_nodes_waiting()
         group_rank = self._worker_group.group_rank
         if num_nodes_waiting > 0:
             logger.info(

--- a/dlrover/python/master/elastic_training/rdzv_manager.py
+++ b/dlrover/python/master/elastic_training/rdzv_manager.py
@@ -63,6 +63,9 @@ class RendezvousManager(metaclass=ABCMeta):
         self._name = ""
         self._latest_rdzv_nodes = []
 
+    def clear_waiting_nodes(self):
+        self._waiting_nodes.clear()
+
     def add_alive_node(self, node: Node):
         """When a node is running, the master will add it to alive list."""
         self._alive_nodes.add(node.id)

--- a/dlrover/python/master/servicer.py
+++ b/dlrover/python/master/servicer.py
@@ -105,7 +105,7 @@ class MasterServicer(elastic_training_pb2_grpc.MasterServicer):
         elif isinstance(req_message, grpc.JoinRendezvousRequest):
             message = self._join_rendezvous(req_message)
         elif isinstance(req_message, grpc.WaitingNodeNumRequest):
-            message = self._num_nodes_waiting()
+            message = self._num_nodes_waiting(req_message.rdzv_name)
         elif isinstance(req_message, grpc.NetworkReadyRequest):
             message = self._check_fault_node()
         elif isinstance(req_message, grpc.StragglerExistRequest):
@@ -239,11 +239,8 @@ class MasterServicer(elastic_training_pb2_grpc.MasterServicer):
         res = grpc.RendezvousState(round=round)
         return res
 
-    def _num_nodes_waiting(self):
-        waiting_num = 0
-        for rdzv_manager in self._rdzv_managers.values():
-            num = rdzv_manager.num_nodes_waiting()
-            waiting_num = max(num, waiting_num)
+    def _num_nodes_waiting(self, rdzv_name):
+        waiting_num = self._rdzv_managers[rdzv_name].num_nodes_waiting()
         res = grpc.RendezvousState(waiting_num=waiting_num)
         return res
 

--- a/dlrover/python/master/servicer.py
+++ b/dlrover/python/master/servicer.py
@@ -236,6 +236,13 @@ class MasterServicer(elastic_training_pb2_grpc.MasterServicer):
         round = rdzv_manager.join_rendezvous(
             request.node_id, request.local_world_size
         )
+        if request.rdzv_name == RendezvousName.NETWORK_CHECK:
+            # The waiting node in the training rdzv should clear if
+            # a worker join network-check rdzv.
+            training_manager = self._rdzv_managers[
+                RendezvousName.ELASTIC_TRAINING
+            ]
+            training_manager.clear_waiting_nodes()
         res = grpc.RendezvousState(round=round)
         return res
 

--- a/dlrover/python/tests/test_elastic_training_agent.py
+++ b/dlrover/python/tests/test_elastic_training_agent.py
@@ -34,6 +34,7 @@ from dlrover.python.elastic_agent.torch.training import (
     ElasticTrainingAgent,
     MasterRendezvousHandler,
     NetworkCheckElasticAgent,
+    RendezvousOutSyncError,
     _get_local_ip,
     _set_paral_config,
 )
@@ -233,6 +234,13 @@ class ElasticTrainingAgentRunTest(unittest.TestCase):
 
             monitor.report_resource_with_step()
             self.assertEqual(self._master.speed_monitor._global_step, 100)
+
+    def test_(self):
+        self._master.rdzv_managers[
+            RendezvousName.NETWORK_CHECK
+        ].join_rendezvous(0, 8)
+        with self.assertRaises(RendezvousOutSyncError):
+            self.rdzv_handler._check_network_rdzv_for_elastic_training()
 
 
 class NetworkCheckElasticAgentTest(unittest.TestCase):

--- a/dlrover/python/tests/test_rdzv_manager.py
+++ b/dlrover/python/tests/test_rdzv_manager.py
@@ -132,6 +132,9 @@ class ElasticTrainingRendezvousManagerTest(unittest.TestCase):
             rdzv_manager.join_rendezvous(i, 8)
         num = rdzv_manager.num_nodes_waiting()
         self.assertEqual(num, 6)
+        rdzv_manager.clear_waiting_nodes()
+        num = rdzv_manager.num_nodes_waiting()
+        self.assertEqual(num, 0)
 
 
 class NetworkCheckRendezvousManagerTest(unittest.TestCase):

--- a/dlrover/python/tests/test_rdzv_manager.py
+++ b/dlrover/python/tests/test_rdzv_manager.py
@@ -134,7 +134,7 @@ class ElasticTrainingRendezvousManagerTest(unittest.TestCase):
         self.assertEqual(num, 6)
 
 
-class NcclCheckRendezvousManagerTest(unittest.TestCase):
+class NetworkCheckRendezvousManagerTest(unittest.TestCase):
     def test_network_check_rdzv(self):
         rdzv_manager = NetworkCheckRendezvousManager()
         rdzv_manager.update_rdzv_params(4, 4, 60, 1)


### PR DESCRIPTION
### What changes were proposed in this pull request?

The agent drops to join the elastic-training rdzv if there are workers join the network-check rdzv.

### Why are the changes needed?

If some workers join the elastic-rdzv and others join the network-check rdzv, the rdzv will raise a timeout error.

### Does this PR introduce any user-facing change?
No.

### How was this patch tested?

UT.