### PR TITLE
Support configuring the range of PyTorch distributed master port for TCPStore

### DIFF
--- a/dlrover/python/common/global_context.py
+++ b/dlrover/python/common/global_context.py
@@ -157,7 +157,7 @@ class Context(object):
         if port > 0:
             self.master_port = port
         else:
-            self.master_port = find_free_port_in_range(50001, 65535)
+            self.master_port = find_free_port_in_range(20000, 30000)
 
     def get_param_value_from_brain(self, key_name, default_value, dtype=int):
         """TODO: Get the configured value from Brain service."""

--- a/dlrover/python/common/grpc.py
+++ b/dlrover/python/common/grpc.py
@@ -81,10 +81,8 @@ def find_free_port_in_range(start, end):
     for port in range(start, end):
         try:
             return find_free_port(port)
-        except OSError as e:
-            logger.info(
-                f"Socket creation attempt failed with {port}.", exc_info=e
-            )
+        except OSError:
+            logger.warning(f"Socket creation attempt failed with {port}.")
     return RuntimeError(f"Fail to find a free port in [{start}, {end})")
 
 

--- a/dlrover/python/elastic_agent/torch/training.py
+++ b/dlrover/python/elastic_agent/torch/training.py
@@ -57,6 +57,7 @@ from dlrover.python.common.constants import (
     RendezvousName,
     TrainingMsgLevel,
 )
+from dlrover.python.common.grpc import find_free_port_in_range
 from dlrover.python.common.log import default_logger as logger
 from dlrover.python.elastic_agent.config.paral_config_tuner import (
     ParalConfigTuner,
@@ -107,11 +108,21 @@ class ElasticLaunchConfig(LaunchConfig):
     node_unit: int = 1
     auto_tunning: bool = False
     exclude_straggler: bool = False
+    master_port_range: List[int] = None  # type: ignore
 
     def set_node_unit(self, node_unit):
         """Set the number unint of ndoes."""
         self.node_unit = node_unit
         self.rdzv_configs["node_unit"] = node_unit
+
+    def set_master_port_range(self, port_range: str):
+        """Set the range to PyTorch Distributed master port."""
+        self.master_port_range = []
+        if not port_range:
+            return
+        ports = port_range.strip().split(":")
+        self.master_port_range.append(int(ports[0]))
+        self.master_port_range.append(int(ports[1]))
 
 
 @dataclass
@@ -361,6 +372,7 @@ class ElasticTrainingAgent(LocalElasticAgent):
         worker_group.group_world_size = group_world_size
 
         if group_rank == 0:
+            self._set_master_port(spec)
             self._set_master_addr_port(
                 store,
                 spec.master_addr,
@@ -385,6 +397,14 @@ class ElasticTrainingAgent(LocalElasticAgent):
             f"  global_world_sizes="
             f"{[worker.world_size for worker in workers]}\n"
         )
+
+    def _set_master_port(self, spec: WorkerSpec):
+        if spec.master_port is None and self._config.master_port_range:
+            port = find_free_port_in_range(
+                self._config.master_port_range[0],
+                self._config.master_port_range[1],
+            )
+            spec.master_port = port
 
     # pyre-fixme[56]: Pyre was not able to infer the type of the decorator
     #  `torch.distributed.elastic.metrics.prof`.

--- a/dlrover/python/tests/test_elastic_training_agent.py
+++ b/dlrover/python/tests/test_elastic_training_agent.py
@@ -235,12 +235,27 @@ class ElasticTrainingAgentRunTest(unittest.TestCase):
             monitor.report_resource_with_step()
             self.assertEqual(self._master.speed_monitor._global_step, 100)
 
-    def test_(self):
+    def test_check_network_rdzv_for_elastic_training(self):
         self._master.rdzv_managers[
             RendezvousName.NETWORK_CHECK
         ].join_rendezvous(0, 8)
         with self.assertRaises(RendezvousOutSyncError):
             self.rdzv_handler._check_network_rdzv_for_elastic_training()
+
+    def test_master_port(self):
+        self.config.network_check = False
+        self.config.set_master_port_range("20000:30000")
+        agent = ElasticTrainingAgent(
+            rank_id=0,
+            config=self.config,
+            entrypoint="echo",
+            spec=self.spec,
+            start_method=self.config.start_method,
+            log_dir=self.config.log_dir,
+        )
+        spec = agent._worker_group.spec
+        agent._set_master_port(spec)
+        self.assertTrue(spec.master_port >= 20000)
 
 
 class NetworkCheckElasticAgentTest(unittest.TestCase):

--- a/dlrover/trainer/tests/torch/elastic_run_test.py
+++ b/dlrover/trainer/tests/torch/elastic_run_test.py
@@ -45,5 +45,6 @@ class ElasticRunTest(unittest.TestCase):
         self.assertTrue(config.network_check)
         self.assertTrue(config.auto_tunning)
         self.assertEqual(config.node_unit, 4)
+        self.assertListEqual(config.master_port_range, [20000, 30000])
         self.assertEqual(cmd, "/usr/local/bin/python")
         self.assertListEqual(cmd_args, ["-u", "test.py", "--batch_size", "16"])

--- a/dlrover/trainer/torch/elastic_run.py
+++ b/dlrover/trainer/torch/elastic_run.py
@@ -130,6 +130,15 @@ def parse_args(args):
         "the argument is True. The argument only works when network-check "
         "is True.",
     )
+    parser.add_argument(
+        "--master-port-range",
+        "--master_port_range",
+        type=str,
+        action=env,
+        default="20000:30000",
+        help="str, the worker will find a free port in the range to create TCP"
+        "store to initialize the process group.",
+    )
     return parser.parse_args(args)
 
 
@@ -236,6 +245,9 @@ def _elastic_config_from_args(
         args, "exclude_straggler", False
     )
     elastic_config.set_node_unit(getattr(args, "node_unit", 1))
+    elastic_config.set_master_port_range(
+        getattr(args, "master_port_range", "")
+    )
     return elastic_config, cmd, cmd_args
 
 

--- a/dlrover/trainer/torch/run_network_check.py
+++ b/dlrover/trainer/torch/run_network_check.py
@@ -89,6 +89,7 @@ def main(task):
             f"Init process group costs {init_time}."
             f"Execution costs {task_time}s"
         )
+    dist.destroy_process_group()
     return elapsed_time
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add an argument to set the range of PyTorch distributed master port  for TCPStore.

### Why are the changes needed?

The random port may be grabbed by other processes when the network of Pod is the host.

### Does this PR introduce any user-facing change?

`dlrover-run --master_port_range 10000:20000`

### How was this patch tested?

`kubectl -n dlrover apply -f examples/pytorch/mnist/elastic_job.yaml`