### PR TITLE
Get the round index of rendezvous when getting the comm world.

### DIFF
--- a/dlrover/python/elastic_agent/master_client.py
+++ b/dlrover/python/elastic_agent/master_client.py
@@ -308,7 +308,7 @@ class MasterClient(object):
     def get_comm_world(self, rdzv_name, rank_id):
         request = grpc.CommWorldRequest(node_id=rank_id, rdzv_name=rdzv_name)
         result: grpc.RendezvousState = self._get(request)
-        return result.group, result.world
+        return result.round, result.group, result.world
 
     def check_fault_node(self, timeout=300):
         request = grpc.NetworkReadyRequest()

--- a/dlrover/python/elastic_agent/torch/training.py
+++ b/dlrover/python/elastic_agent/torch/training.py
@@ -234,6 +234,7 @@ class MasterRendezvousHandler(RendezvousHandler):
                         raise TimeoutError(
                             f"Timeout {self.pend_timeout}s to wait more nodes"
                         )
+                    round = self._join_rendezvous()
                     continue
             elif time.time() - start_join > self.join_timeout:
                 timeout = self.join_timeout

--- a/dlrover/python/elastic_agent/torch/training.py
+++ b/dlrover/python/elastic_agent/torch/training.py
@@ -211,11 +211,11 @@ class MasterRendezvousHandler(RendezvousHandler):
             f"rendezvous '{self._name}' with timeout {self.join_timeout}."
         )
         logger.info(msg)
-        round = self._join_rendezvous()
+        self._join_rendezvous()
         start_pending = 0
         while True:
             self._check_network_rdzv_for_elastic_training()
-            group, world = self._client.get_comm_world(
+            round, group, world = self._client.get_comm_world(
                 self._name, self._rank_id
             )
             if world:
@@ -234,7 +234,6 @@ class MasterRendezvousHandler(RendezvousHandler):
                         raise TimeoutError(
                             f"Timeout {self.pend_timeout}s to wait more nodes"
                         )
-                    round = self._join_rendezvous()
                     continue
             elif time.time() - start_join > self.join_timeout:
                 timeout = self.join_timeout

--- a/dlrover/python/master/servicer.py
+++ b/dlrover/python/master/servicer.py
@@ -253,9 +253,10 @@ class MasterServicer(elastic_training_pb2_grpc.MasterServicer):
 
     def _get_comm_world(self, request: grpc.CommWorldRequest):
         rdzv_manager = self._rdzv_managers[request.rdzv_name]
-        group, nodes = rdzv_manager.get_comm_world(request.node_id)
+        rdzv_round, group, nodes = rdzv_manager.get_comm_world(request.node_id)
         res = grpc.RendezvousState(world={})
         res.group = group
+        res.round = rdzv_round
         for rank_id, worker_num in nodes.items():
             res.world[rank_id] = worker_num
         return res

--- a/dlrover/python/tests/test_elastic_training_agent.py
+++ b/dlrover/python/tests/test_elastic_training_agent.py
@@ -136,7 +136,7 @@ class ElasticTrainingAgentTest(unittest.TestCase):
         self.rdzv_handler._client.join_rendezvous(
             0, 8, self.rdzv_handler._name
         )
-        store = self.rdzv_handler._get_store(round=0, group=1)
+        store = self.rdzv_handler._get_store(round=1, group=0)
         store.set("MASTER_ADDR", "127.0.0.1".encode())
         store.set("MASTER_PORT", "12345".encode())
         agent._rendezvous(agent._worker_group)
@@ -370,7 +370,7 @@ class MasterRendezvousHandlerTest(unittest.TestCase):
         )
         rdzv_handler._join_rendezvous = mock.MagicMock(return_value=0)
         rdzv_handler._client.get_comm_world = mock.MagicMock(
-            return_value=(0, {1: 8})
+            return_value=(0, 0, {1: 8})
         )
         with self.assertRaises(TimeoutError):
             rdzv_handler.next_rendezvous()

--- a/dlrover/python/tests/test_master.py
+++ b/dlrover/python/tests/test_master.py
@@ -129,8 +129,9 @@ class LocalJobMasterTest(unittest.TestCase):
         self.master_client.join_rendezvous(
             0, 8, RendezvousName.ELASTIC_TRAINING
         )
-        group, world = self.master_client.get_comm_world(
+        round, group, world = self.master_client.get_comm_world(
             RendezvousName.ELASTIC_TRAINING, 0
         )
-        self.assertEqual(group, 1)
+        self.assertEqual(round, 1)
+        self.assertEqual(group, 0)
         self.assertEqual(world[0], 8)

--- a/dlrover/python/tests/test_rdzv_manager.py
+++ b/dlrover/python/tests/test_rdzv_manager.py
@@ -65,7 +65,8 @@ class ElasticTrainingRendezvousManagerTest(unittest.TestCase):
         self.assertEqual(len(rdzv_manager._waiting_nodes), 2)
         self.assertEqual(len(rdzv_manager._rdzv_nodes), 0)
         rdzv_manager.join_rendezvous(2, 8)
-        _, world = rdzv_manager.get_comm_world(0)
+        round, _, world = rdzv_manager.get_comm_world(0)
+        self.assertEqual(round, 1)
         self.assertEqual(len(rdzv_manager._waiting_nodes), 0)
         self.assertEqual(len(rdzv_manager._rdzv_nodes), 3)
         self.assertDictEqual(world, {0: 8, 1: 8, 2: 8})
@@ -86,7 +87,8 @@ class ElasticTrainingRendezvousManagerTest(unittest.TestCase):
         self.assertEqual(len(rdzv_manager._waiting_nodes), 2)
         self.assertEqual(len(rdzv_manager._rdzv_nodes), 0)
         time.sleep(0.2)
-        _, world = rdzv_manager.get_comm_world(1)
+        round, _, world = rdzv_manager.get_comm_world(1)
+        self.assertEqual(round, 1)
         self.assertEqual(len(rdzv_manager._waiting_nodes), 0)
         self.assertEqual(len(rdzv_manager._rdzv_nodes), 2)
         self.assertDictEqual(world, {0: 8, 1: 8})
@@ -102,12 +104,14 @@ class ElasticTrainingRendezvousManagerTest(unittest.TestCase):
         self.assertEqual(len(rdzv_manager._waiting_nodes), 10)
         self.assertEqual(len(rdzv_manager._rdzv_nodes), 0)
         time.sleep(0.2)
-        _, world = rdzv_manager.get_comm_world(1)
+        round, _, world = rdzv_manager.get_comm_world(1)
+        self.assertEqual(round, 1)
         self.assertEqual(len(rdzv_manager._waiting_nodes), 2)
         self.assertEqual(len(rdzv_manager._rdzv_nodes), 8)
         expected_world = {i: 8 for i in range(8)}
         self.assertDictEqual(expected_world, world)
-        _, world = rdzv_manager.get_comm_world(9)
+        round, _, world = rdzv_manager.get_comm_world(9)
+        self.assertEqual(round, 1)
         self.assertFalse(9 in world)
 
         # Test the number of waiting nodes is less than the node unit.
@@ -145,13 +149,15 @@ class NetworkCheckRendezvousManagerTest(unittest.TestCase):
         for i in range(4):
             round = rdzv_manager.join_rendezvous(i, 8)
         self.assertEqual(round, 0)
-        group, world = rdzv_manager.get_comm_world(0)
+        round, group, world = rdzv_manager.get_comm_world(0)
+        self.assertEqual(round, 1)
         self.assertEqual(group, 0)
         self.assertEqual(len(rdzv_manager._waiting_nodes), 0)
         self.assertEqual(len(rdzv_manager._rdzv_nodes), 4)
         self.assertDictEqual(world, {0: 8, 1: 8})
         self.assertEqual(group, 0)
-        group, world = rdzv_manager.get_comm_world(2)
+        round, group, world = rdzv_manager.get_comm_world(2)
+        self.assertEqual(round, 1)
         self.assertDictEqual(world, {2: 8, 3: 8})
         self.assertEqual(group, 1)
         for i in range(3):
@@ -161,9 +167,11 @@ class NetworkCheckRendezvousManagerTest(unittest.TestCase):
         for i in range(4):
             round = rdzv_manager.join_rendezvous(i, 8)
         self.assertEqual(round, 1)
-        group, world = rdzv_manager.get_comm_world(0)
+        round, group, world = rdzv_manager.get_comm_world(0)
+        self.assertEqual(round, 2)
         self.assertDictEqual(world, {3: 8, 0: 8})
-        group, world = rdzv_manager.get_comm_world(1)
+        round, group, world = rdzv_manager.get_comm_world(1)
+        self.assertEqual(round, 2)
         self.assertDictEqual(world, {1: 8, 2: 8})
         self.assertEqual(group, 1)
         success, _ = rdzv_manager.check_fault_node()
@@ -172,7 +180,8 @@ class NetworkCheckRendezvousManagerTest(unittest.TestCase):
         for i in range(4):
             round = rdzv_manager.join_rendezvous(i, 8)
         self.assertEqual(round, 2)
-        group, world = rdzv_manager.get_comm_world(3)
+        round, group, world = rdzv_manager.get_comm_world(3)
+        self.assertEqual(round, 3)
         self.assertDictEqual(world, {2: 8, 3: 8})
         _, reason = rdzv_manager.check_fault_node()
         self.assertEqual(reason, NetworkFailureReason.WAITING_NODE)
@@ -188,7 +197,8 @@ class NetworkCheckRendezvousManagerTest(unittest.TestCase):
         rdzv_manager._alive_nodes = [0]
         round = rdzv_manager.join_rendezvous(0, 8)
         self.assertEqual(round, 0)
-        _, world = rdzv_manager.get_comm_world(0)
+        round, _, world = rdzv_manager.get_comm_world(0)
+        self.assertEqual(round, 1)
         self.assertDictEqual(world, {0: 8})
         rdzv_manager.report_network_check_result(0, True, 0.0)
         nodes, _ = rdzv_manager.check_fault_node()
@@ -204,9 +214,11 @@ class NetworkCheckRendezvousManagerTest(unittest.TestCase):
         for i in range(6):
             round = rdzv_manager.join_rendezvous(i, 8)
         self.assertEqual(round, 0)
-        group, world = rdzv_manager.get_comm_world(0)
+        round, group, world = rdzv_manager.get_comm_world(0)
+        self.assertEqual(round, 1)
         self.assertEqual(group, 0)
-        group, world = rdzv_manager.get_comm_world(2)
+        round, group, world = rdzv_manager.get_comm_world(2)
+        self.assertEqual(round, 1)
         self.assertDictEqual(world, {2: 8, 3: 8})
         self.assertEqual(group, 1)
         for i in range(4):
@@ -219,7 +231,8 @@ class NetworkCheckRendezvousManagerTest(unittest.TestCase):
         for i in range(6):
             round = rdzv_manager.join_rendezvous(i, 8)
         self.assertEqual(round, 1)
-        group, world = rdzv_manager.get_comm_world(5)
+        round, group, world = rdzv_manager.get_comm_world(5)
+        self.assertEqual(round, 2)
         self.assertDictEqual(world, {0: 8, 5: 8})
 
         for i in [1, 2, 3, 4]:
@@ -236,9 +249,11 @@ class NetworkCheckRendezvousManagerTest(unittest.TestCase):
         for i in range(5):
             round = rdzv_manager.join_rendezvous(i, 8)
         self.assertEqual(round, 0)
-        group, world = rdzv_manager.get_comm_world(0)
+        round, group, world = rdzv_manager.get_comm_world(0)
+        self.assertEqual(round, 1)
         self.assertEqual(group, 0)
-        group, world = rdzv_manager.get_comm_world(2)
+        round, group, world = rdzv_manager.get_comm_world(2)
+        self.assertEqual(round, 1)
         self.assertDictEqual(world, {2: 8, 3: 8, 4: 8})
         self.assertEqual(group, 1)
         for i in range(2):
@@ -251,7 +266,8 @@ class NetworkCheckRendezvousManagerTest(unittest.TestCase):
         for i in range(5):
             round = rdzv_manager.join_rendezvous(i, 8)
         self.assertEqual(round, 1)
-        group, world = rdzv_manager.get_comm_world(1)
+        round, group, world = rdzv_manager.get_comm_world(1)
+        self.assertEqual(round, 2)
         self.assertDictEqual(world, {1: 8, 2: 8})
 
         for i in [1, 2]:


### PR DESCRIPTION
### What changes were proposed in this pull request?

Get the round index of rendezvous when getting the comm world.

### Why are the changes needed?

The round index may change if the worker waits for others.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

UT.