### PR TITLE
Find a free port if the port == 0

### DIFF
--- a/dlrover/python/common/global_context.py
+++ b/dlrover/python/common/global_context.py
@@ -153,10 +153,10 @@ class Context(object):
             DefaultValues.HANG_CPU_USAGE_RATE,
         )
 
-    def config_master_port(self, port=None):
+    def config_master_port(self, port=0):
         host_ports_env = os.getenv("HOST_PORTS", "")
         self.master_port = None
-        if port is not None:
+        if port > 0:
             self.master_port = port
         elif host_ports_env:
             ports = []

--- a/dlrover/python/tests/test_global_context.py
+++ b/dlrover/python/tests/test_global_context.py
@@ -23,11 +23,11 @@ class GlobalContextTest(unittest.TestCase):
         ctx.config_master_port(50001)
         self.assertEqual(ctx.master_port, 50001)
         os.environ["HOST_PORTS"] = "20000,20001,20002,20003"
-        ctx.config_master_port()
+        ctx.config_master_port(0)
         self.assertTrue(ctx.master_port in [20000, 20001, 20002, 20003])
         ctx.master_port = None
         os.environ["HOST_PORTS"] = ""
-        ctx.config_master_port()
+        ctx.config_master_port(0)
         self.assertTrue(ctx.master_port > 20000)
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Find a free port if the port == 0

### Why are the changes needed?

The default port is  0 which is invalid.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

UT.