### PR TITLE
Replace addCleanUp with tearDown to clean resources.

### DIFF
--- a/atorch/atorch/tests/elastic_dataset_test.py
+++ b/atorch/atorch/tests/elastic_dataset_test.py
@@ -45,7 +45,7 @@ class SimpleElasticDatasetTest(unittest.TestCase):
             num_minibatches_per_shard=10,
         )
 
-    def addCleanup(self):
+    def tearDown(self):
         self._master_proc.kill()
 
     def test_index_sharding_client(self):

--- a/dlrover/python/tests/test_elastic_training_agent.py
+++ b/dlrover/python/tests/test_elastic_training_agent.py
@@ -89,7 +89,7 @@ class ElasticTrainingAgentTest(unittest.TestCase):
             local_addr=self.config.local_addr,
         )
 
-    def addCleanup(self):
+    def tearDown(self):
         self._master.stop()
 
     def test_node_unit(self):
@@ -204,7 +204,7 @@ class ElasticTrainingAgentRunTest(unittest.TestCase):
             local_addr=self.config.local_addr,
         )
 
-    def addCleanup(self):
+    def tearDown(self):
         self._master.stop()
 
     def test_monitor_workers(self):
@@ -307,7 +307,7 @@ class NetworkCheckElasticAgentTest(unittest.TestCase):
             local_addr=self.config.local_addr,
         )
 
-    def addCleanup(self):
+    def tearDown(self):
         self._master.stop()
 
     def test_get_network_check_time(self):

--- a/dlrover/python/tests/test_master.py
+++ b/dlrover/python/tests/test_master.py
@@ -110,7 +110,7 @@ class LocalJobMasterTest(unittest.TestCase):
         self._master, addr = start_local_master()
         self.master_client = build_master_client(addr)
 
-    def addCleanup(self):
+    def tearDown(self):
         self._master.stop()
 
     def test_task_manager(self):

--- a/dlrover/python/tests/test_master_client.py
+++ b/dlrover/python/tests/test_master_client.py
@@ -30,7 +30,7 @@ class MasterClientTest(unittest.TestCase):
         self._master, addr = start_local_master()
         self._master_client = build_master_client(addr)
 
-    def addCleanup(self):
+    def tearDown(self):
         self._master.stop()
 
     def test_open_channel(self):

--- a/dlrover/python/tests/test_rdzv_manager.py
+++ b/dlrover/python/tests/test_rdzv_manager.py
@@ -34,7 +34,7 @@ class MasterKVStoreTest(unittest.TestCase):
         self._master, addr = start_local_master()
         GlobalMasterClient.MASTER_CLIENT = build_master_client(addr)
 
-    def addCleanup(self):
+    def tearDown(self):
         self._master.stop()
 
     def test_kv_store_api(self):

--- a/dlrover/python/tests/test_sharding_client.py
+++ b/dlrover/python/tests/test_sharding_client.py
@@ -31,7 +31,7 @@ class DataShardClientTest(unittest.TestCase):
         self._master, addr = start_local_master()
         GlobalMasterClient.MASTER_CLIENT = build_master_client(addr)
 
-    def addCleanup(self):
+    def tearDown(self):
         self._master.stop()
 
     def test_local_dataset(self):

--- a/dlrover/trainer/tests/torch/checkpoint_manager_test.py
+++ b/dlrover/trainer/tests/torch/checkpoint_manager_test.py
@@ -137,7 +137,7 @@ class AsyncCheckpointEngineTest(unittest.TestCase):
         self.tmp_dir = tempfile.TemporaryDirectory()
         self.engine = AsyncCheckpointEngine(self.tmp_dir, 1, 1)
 
-    def addCleanup(self):
+    def tearDown(self):
         self.tmp_dir.cleanup()
 
     def test_save_memory(self):


### PR DESCRIPTION
### What changes were proposed in this pull request?

Replace addCleanUp with tearDown to clean resources.

### Why are the changes needed?

We have misused `addCleanUp` and should use `tearDown` to clean resources in test cases.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

UT.
