### PR TITLE
Catch the exception to get the device count by pynvml.

### DIFF
--- a/dlrover/python/elastic_agent/monitor/resource.py
+++ b/dlrover/python/elastic_agent/monitor/resource.py
@@ -58,7 +58,11 @@ def get_used_memory():
 def get_gpu_stats(gpus=[]):
     """ "Get the used gpu info of the container"""
     if not gpus:
-        device_count = pynvml.nvmlDeviceGetCount()
+        try:
+            device_count = pynvml.nvmlDeviceGetCount()
+        except Exception:
+            logger.warning("No GPU is available.")
+            device_count = 0
         gpus = list(range(device_count))
     gpu_stats: list[GPUStats] = []
     for i in gpus:


### PR DESCRIPTION
### What changes were proposed in this pull request?

Catch the exception to get the device count by pynvml.

### Why are the changes needed?

I have seen the trace log in UT.

```
Traceback (most recent call last):
  File "/github/workspace/dlrover/python/elastic_agent/monitor/resource.py", line 160, in report_resource
    self._gpu_stats = get_gpu_stats()
  File "/github/workspace/dlrover/python/elastic_agent/monitor/resource.py", line 61, in get_gpu_stats
    device_count = pynvml.nvmlDeviceGetCount()
  File "/usr/local/lib/python3.8/site-packages/pynvml.py", line 2146, in nvmlDeviceGetCount
    fn = _nvmlGetFunctionPointer("nvmlDeviceGetCount_v2")
  File "/usr/local/lib/python3.8/site-packages/pynvml.py", line 914, in _nvmlGetFunctionPointer
    raise NVMLError(NVML_ERROR_UNINITIALIZED)
pynvml.NVMLError_Uninitialized: Uninitialized
```

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

UT.