### PR TITLE
Customization of the SharedMemory without ResourceTracker.

### DIFF
--- a/dlrover/python/common/shared_obj.py
+++ b/dlrover/python/common/shared_obj.py
@@ -17,6 +17,9 @@ import queue
 import socket
 import threading
 import time
+import mmap
+import _posixshmem
+from multiprocessing import shared_memory
 from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass
 from typing import Dict
@@ -445,3 +448,78 @@ class SharedDict(object):
         while not self._shared_queue.empty():
             time.sleep(0.1)
         return self._dict
+
+
+class SharedMemory(shared_memory.SharedMemory):
+    """
+    Customization of the SharedMemory is necessary, as the
+    'resource.tracker.ResourceTracker' in Python will unlink and remove the
+    file if one process fails. Our objective is to ensure that the training
+    process does not unlink the shared memory upon failure, 
+    hereby allowing a new training process to commence utilizing
+    the existing shared memory to load checkpoint.
+
+    Note: We must explicitly unlink the SharedMemory to avoid memory leak.
+    """
+
+    # Defaults; enables close() and unlink() to run without errors.
+    _name = None
+    _fd = -1
+    _mmap = None
+    _buf = None
+    _flags = os.O_RDWR
+    _mode = 0o600
+    _prepend_leading_slash = True
+
+    def __init__(self, name=None, create=False, size=0):
+        if not size >= 0:
+            raise ValueError("'size' must be a positive integer")
+        if create:
+            self._flags = os.O_CREAT | os.O_EXCL | os.O_RDWR
+            if size == 0:
+                raise ValueError("'size' must be a positive number different from zero")
+        if name is None and not self._flags & os.O_EXCL:
+            raise ValueError("'name' can only be None if create=True")
+
+        if name is None:
+            while True:
+                name = shared_memory._make_filename()
+                try:
+                    self._fd = _posixshmem.shm_open(
+                        name,
+                        self._flags,
+                        mode=self._mode
+                    )
+                except FileExistsError:
+                    continue
+                self._name = name
+                break
+        else:
+            name = "/" + name if self._prepend_leading_slash else name
+            self._fd = _posixshmem.shm_open(
+                name,
+                self._flags,
+                mode=self._mode
+            )
+            self._name = name
+        try:
+            if create and size:
+                os.ftruncate(self._fd, size)
+            stats = os.fstat(self._fd)
+            size = stats.st_size
+            self._mmap = mmap.mmap(self._fd, size)
+        except OSError:
+            self.unlink()
+            raise
+
+        self._size = size
+        self._buf = memoryview(self._mmap)
+
+    def unlink(self):
+        """Requests that the underlying shared memory block be destroyed.
+
+        In order to ensure proper cleanup of resources, unlink should be
+        called once (and only once) across all processes which have access
+        to the shared memory block."""
+        if self._name:
+            _posixshmem.shm_unlink(self._name)

--- a/dlrover/python/common/shared_obj.py
+++ b/dlrover/python/common/shared_obj.py
@@ -453,7 +453,7 @@ class SharedDict(object):
 class SharedMemory(shared_memory.SharedMemory):
     """
     Customization of the SharedMemory is necessary, as the
-    'resource.tracker.ResourceTracker' in Python will unlink and remove the
+    'resource_tracker.ResourceTracker' in Python will unlink and remove the
     file if one process fails. Our objective is to ensure that the training
     process does not unlink the shared memory upon failure, 
     hereby allowing a new training process to commence utilizing

--- a/dlrover/python/common/shared_obj.py
+++ b/dlrover/python/common/shared_obj.py
@@ -459,7 +459,7 @@ class SharedMemory(shared_memory.SharedMemory):
     hereby allowing a new training process to commence utilizing
     the existing shared memory to load checkpoint.
 
-    Note: We must explicitly unlink the SharedMemory to avoid memory leak.
+    Note:: We must explicitly unlink the SharedMemory to avoid memory leak.
     """
 
     # Defaults; enables close() and unlink() to run without errors.

--- a/dlrover/python/tests/test_shared_obj.py
+++ b/dlrover/python/tests/test_shared_obj.py
@@ -11,12 +11,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import unittest
 
 from dlrover.python.common.shared_obj import (
     SharedDict,
     SharedLock,
     SharedQueue,
+    SharedMemory,
 )
 
 
@@ -61,3 +63,14 @@ class SharedLockTest(unittest.TestCase):
         write_dict.update(new_dict=new_dict)
         d = read_dict.get()
         self.assertDictEqual(d, new_dict)
+
+
+class SharedMemoryTest(unittest.TestCase):
+    def test_unlink(self):
+        fanme = "test-shm"
+        shm = SharedMemory(name=fanme, create=True, size=1024)
+        shm.buf[0:4] = b"abcd"
+        shm.close()
+        shm.unlink()
+        with self.assertRaises(FileNotFoundError):
+            shm = SharedMemory(name=fanme, create=False)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Customize the sharedMemory.

### Why are the changes needed?

Customization of the SharedMemory is necessary, as the 'resource.tracker.ResourceTracker' in Python will unlink and remove the file if one process fails. Our objective is to ensure that the training process does not unlink the shared memory upon failure,  hereby allowing a new training process to commence utilizing the existing shared memory to load checkpoint

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

UT.