### PR TITLE
Start a thread to save the checkpoint before restarting the training.

### DIFF
--- a/dlrover/python/elastic_agent/torch/training.py
+++ b/dlrover/python/elastic_agent/torch/training.py
@@ -614,7 +614,7 @@ class ElasticTrainingAgent(LocalElasticAgent):
         if self._save_ckpt_future:
             # Waiting the thread to save checkpoint finishes.
             self._save_ckpt_future.result(timeout=600)
-        super()._start_workers(worker_group)
+        return super()._start_workers(worker_group)
 
     def _membership_changed(self, role, rdzv_handler: RendezvousHandler):
         # Timeout may happen when to query TCPStore.

--- a/dlrover/python/elastic_agent/torch/training.py
+++ b/dlrover/python/elastic_agent/torch/training.py
@@ -18,6 +18,7 @@ import socket
 import tempfile
 import time
 import uuid
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Any, Callable, Dict, List, Optional, Union
@@ -69,7 +70,6 @@ from dlrover.python.elastic_agent.master_client import MasterClient
 from dlrover.python.elastic_agent.monitor.training import TorchTrainingMonitor
 from dlrover.python.elastic_agent.torch.ckpt_saver import CheckpointSaver
 from dlrover.python.elastic_agent.torch.master_kv_store import MasterKVStore
-from concurrent.futures import ThreadPoolExecutor
 
 __all__ = ["launch_agent"]
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Start a thread to save the checkpoint before restarting the training.

### Why are the changes needed?

Fix #878

Avoid the agent blocks too long time when saving the checkpoint.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

UT.