### PR TITLE
Skip migrating the critical workers.

### DIFF
--- a/dlrover/python/master/node/worker.py
+++ b/dlrover/python/master/node/worker.py
@@ -230,11 +230,11 @@ class WorkerManager(TrainingNodeManager):
         for name, resource in workers.items():
             old_node_id = int(name.split("-")[-1])
             old_node = self._nodes[old_node_id]
+            if old_node.critical:
+                continue
             old_node.migrated = True
             old_node.relaunchable = False
             old_node.is_released = True
-            if old_node.critical:
-                continue
             node_id = next(self._node_id_iter)
             task_id = old_node.rank_index
             new_node = Node(

--- a/dlrover/python/master/node/worker.py
+++ b/dlrover/python/master/node/worker.py
@@ -232,6 +232,8 @@ class WorkerManager(TrainingNodeManager):
             old_node = self._nodes[old_node_id]
             old_node.migrated = True
             old_node.is_released = True
+            if old_node.critical:
+                continue
             node_id = next(self._node_id_iter)
             task_id = old_node.rank_index
             new_node = Node(

--- a/dlrover/python/master/node/worker.py
+++ b/dlrover/python/master/node/worker.py
@@ -231,6 +231,7 @@ class WorkerManager(TrainingNodeManager):
             old_node_id = int(name.split("-")[-1])
             old_node = self._nodes[old_node_id]
             old_node.migrated = True
+            old_node.relaunchable = False
             old_node.is_released = True
             if old_node.critical:
                 continue

--- a/dlrover/python/tests/test_job_auto_scaler.py
+++ b/dlrover/python/tests/test_job_auto_scaler.py
@@ -61,8 +61,10 @@ class JobAutoScalerTest(unittest.TestCase):
             6, NodeResource(4, 4096)
         )
         plan.node_resources["test-edljob-worker-0"] = NodeResource(8, 8192)
+        plan.node_resources["test-edljob-worker-1"] = NodeResource(8, 8192)
         plan.node_resources["test-edljob-ps-1"] = NodeResource(8, 8192)
         auto_scaler._ps_manager._nodes[1].status = NodeStatus.RUNNING
+        auto_scaler._worker_manager._nodes[0].critical = True
         scale_plan = auto_scaler.execute_job_optimization_plan(plan)
         self.assertEqual(len(manager._ps_manager._nodes), 4)
         self.assertEqual(len(manager._worker_manager._nodes), 7)
@@ -71,6 +73,7 @@ class JobAutoScalerTest(unittest.TestCase):
         remove_node = scale_plan.remove_nodes[0]
         self.assertTrue(remove_node.migrated)
         self.assertTrue(remove_node.is_released)
+        self.assertEqual(remove_node.name, "test-edljob-worker-1")
 
         ps_addrs = []
         for i in [0, 3, 2]:

--- a/dlrover/python/tests/test_job_auto_scaler.py
+++ b/dlrover/python/tests/test_job_auto_scaler.py
@@ -73,6 +73,7 @@ class JobAutoScalerTest(unittest.TestCase):
         remove_node = scale_plan.remove_nodes[0]
         self.assertTrue(remove_node.migrated)
         self.assertTrue(remove_node.is_released)
+        self.assertFalse(remove_node.relaunchable)
         self.assertEqual(remove_node.name, "test-edljob-worker-1")
 
         ps_addrs = []


### PR DESCRIPTION
### What changes were proposed in this pull request?

The job master does not migrate the critical worker when reducing the worker resource.

### Why are the changes needed?

The job will fail if the critical worker fails.

