### PR TITLE
Support saving FSDP shard state dict.

### DIFF
--- a/dlrover/python/elastic_agent/torch/ckpt_saver.py
+++ b/dlrover/python/elastic_agent/torch/ckpt_saver.py
@@ -829,8 +829,7 @@ class AtorchFSDPShardingSaver(CheckpointSaver):
         Args:
             step (int): the iteration step.
         """
-        name = f"{CheckpointConstant.CKPT_NAME_PREFIX}{step}"
-        return os.path.join(self.checkpoint_dir, name)
+        return os.path.join(self.checkpoint_dir, str(step))
 
     def _get_tmp_ckpt_dir(self, step: int):
         """
@@ -1211,7 +1210,7 @@ class NoShardingCheckpointEngine(CheckpointEngine):
             with open(tracker_filename, "r") as f:
                 metastring = f.read().strip()
             iteration = int(metastring)
-            name = f"{CheckpointConstant.CKPT_NAME_PREFIX}{iteration}.pt"
+            name = f"{iteration}.pt"
             path = os.path.join(self.checkpoint_dir, name)
             logger.info(f"Load the state dict from {path}")
             state_dict = torch.load(path, map_location="cpu")

--- a/dlrover/python/tests/test_ckpt_saver.py
+++ b/dlrover/python/tests/test_ckpt_saver.py
@@ -257,7 +257,7 @@ class CheckpointEngineTest(unittest.TestCase):
             engine = NoShardingCheckpointEngine(tmpdirname)
             engine._restart_count = 1
             engine._notify_agent_to_create_saver()
-            path = os.path.join(tmpdirname, "checkpoint-10.pt")
+            path = os.path.join(tmpdirname, "10.pt")
             torch.save(state_dict, path)
             tracer_file = os.path.join(
                 tmpdirname, CheckpointConstant.TRACER_FILE_NAME
@@ -325,7 +325,7 @@ class ShardingCheckpointEngineTest(unittest.TestCase):
             tmp = Path(tmpdir)
             time.sleep(3)
             # list the files in tmpdir recursively
-            saved_file = tmp / "checkpoint-100/checkpoint.pt"
+            saved_file = tmp / "100/checkpoint.pt"
             self.assertTrue(saved_file.exists())
 
             tracker_file = tmp / "tracker.txt"

--- a/dlrover/trainer/torch/elastic/checkpoint.py
+++ b/dlrover/trainer/torch/elastic/checkpoint.py
@@ -21,11 +21,8 @@ import torch.distributed.checkpoint as dist_cp
 from torch.distributed.checkpoint.optimizer import (
     load_sharded_optimizer_state_dict,
 )
-from torch.distributed.fsdp import FullStateDictConfig
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from torch.distributed.fsdp import StateDictType
-from torch.distributed.fsdp.api import FullOptimStateDictConfig
-from torch.distributed.fsdp.fully_sharded_data_parallel import StateDictType
 from torch.nn.parallel import DistributedDataParallel as DDP
 
 from dlrover.python.common.constants import CheckpointConstant

--- a/examples/pytorch/nanogpt/train.py
+++ b/examples/pytorch/nanogpt/train.py
@@ -41,7 +41,7 @@ from dlrover.trainer.torch.elastic.trainer import ElasticTrainer
 os.environ["CUDA_DEVICE_ORDER"] = "PCI_BUS_ID"
 
 # We should use a shared storage to persist the checkpiont.
-checkpoint_dir = "/nas/nanogpt-ckpt/"
+CHEKPOINT_DIR = "/nas/nanogpt-ckpt/"
 
 local_rank = None
 master_process = False
@@ -190,7 +190,7 @@ def train():
     global local_rank
     args = arg_parser()
     setup(args)
-    os.makedirs(checkpoint_dir, exist_ok=True)
+    os.makedirs(CHEKPOINT_DIR, exist_ok=True)
     world_size = int(os.getenv("WORLD_SIZE", 1))
     gradient_accumulation_steps = args.gradient_accumulation_steps
     batch_size = args.batch_size
@@ -308,7 +308,7 @@ def train():
     # if data type is float16
 
     ckpt_manager = CheckpointManger.init_checkpoint_manager(
-        model, optimizer, train_loader, checkpoint_dir
+        model, optimizer, train_loader, CHEKPOINT_DIR
     )
     ckpt_dict = ckpt_manager.load()
     iter_num = ckpt_dict.get("step", 0)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Use `torch.distributed.checkpoint` to save and load the shard FSDP state dict.

### Why are the changes needed?

Fix #840 

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

We can test it by `dlrover-run example/pytorch/nanogpt/train.py`