### PR TITLE
Initialize the shared memory before calling unlink.

### DIFF
--- a/dlrover/python/elastic_agent/torch/ckpt_saver.py
+++ b/dlrover/python/elastic_agent/torch/ckpt_saver.py
@@ -263,8 +263,12 @@ class SharedMemoryHandler(object):
             self.shared_memory.close()
 
     def unlink(self):
+        if not self.shared_memory:
+            # The shared memory may be created by other processes.
+            self.init_shared_memory()
         if self.shared_memory:
             self.shared_memory.unlink()
+            logger.info(f"Unlink the shared memory {self._shm_name}")
         if self.metadata:
             self.metadata.unlink()
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Initialize the shared memory before calling unlink.

### Why are the changes needed?

Avoid memory leak.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

UT.