### PR TITLE
Async save checkpont without dlrover-run.

### DIFF
--- a/.github/actions/dlrover-python-test/action.yml
+++ b/.github/actions/dlrover-python-test/action.yml
@@ -13,5 +13,6 @@ runs:
 https://download.pytorch.org/whl/torch_stable.html \
 && python -m grpc_tools.protoc -I. \
 dlrover/proto/*.proto --python_out=. --grpc_python_out=. \
-&& ROLE_NAME=dlrover-trainer python -m pytest dlrover/python/tests dlrover/trainer/tests \
+&& ROLE_NAME=dlrover-trainer \
+python -m pytest dlrover/python/tests dlrover/trainer/tests \
 --cov-report xml --cov=dlrover "

--- a/.github/actions/dlrover-python-test/action.yml
+++ b/.github/actions/dlrover-python-test/action.yml
@@ -13,5 +13,5 @@ runs:
 https://download.pytorch.org/whl/torch_stable.html \
 && python -m grpc_tools.protoc -I. \
 dlrover/proto/*.proto --python_out=. --grpc_python_out=. \
-&& python -m pytest dlrover/python/tests dlrover/trainer/tests \
+&& ROLE_NAME=dlrover-trainer python -m pytest dlrover/python/tests dlrover/trainer/tests \
 --cov-report xml --cov=dlrover "

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ training job. The actions to restore training in DLRover are:
 3. Restart the failed nodes due to hardward errors.
 
 For detail, we can see [experiments](docs/tech_report/fault_tolerance_exps.md)
-of fault-tolerance and elasticity. With fault tolerance, the goodput of GLM-65B training
+of fault-tolerance and elasticity. **With fault tolerance, the goodput of GLM-65B training
 on thousands of GPUs increased from 69% to 95%**. The goodput is the time spent computing
 useful new steps over the elapsed time of the training job.
 The downtime details are shown:

--- a/dlrover/trainer/tests/torch/checkpoint_egine_test.py
+++ b/dlrover/trainer/tests/torch/checkpoint_egine_test.py
@@ -35,6 +35,7 @@ from dlrover.trainer.torch.flash_checkpoint.ddp_engine import (
 from dlrover.trainer.torch.flash_checkpoint.deepspeed_engine import (
     DeepSpeedCheckpointEngine,
 )
+from dlrover.trainer.torch.flash_checkpoint.engine import start_saver_process
 from dlrover.trainer.torch.flash_checkpoint.megatron_engine import (
     MegatronCheckpointEngine,
 )
@@ -96,6 +97,15 @@ class ShardingCheckpointEngineTest(unittest.TestCase):
         os.environ.pop(NodeEnv.NODE_RANK, None)
         if AsyncCheckpointSaver._saver_instance:
             AsyncCheckpointSaver._saver_instance.close()
+
+    def test_start_saver_proc(self):
+        proc = start_saver_process()
+        self.assertIsNone(proc)
+        os.environ["ROLE_NAME"] = "default"
+        proc = start_saver_process()
+        self.assertIsNotNone(proc)
+        proc.kill()
+        os.environ["ROLE_NAME"] = "dlrover-trainer"
 
     def test_save_to_storage(self):
         model = SimpleNet()

--- a/dlrover/trainer/torch/elastic_run.py
+++ b/dlrover/trainer/torch/elastic_run.py
@@ -278,6 +278,7 @@ def run(args):
 
     config, cmd, cmd_args = _elastic_config_from_args(args)
     config.run_id = job_name
+    config.role = "dlrover-trainer"
     try:
         elastic_launch(
             config=config,

--- a/docs/blogs/flash_checkpoint.md
+++ b/docs/blogs/flash_checkpoint.md
@@ -272,8 +272,9 @@ if args.save and iteration % save_memory_interval == 0:
                     opt_param_scheduler, storage_type=StorageType.MEMORY,)
 ```
 
-Note: To use the Flash Checkpoint APIs, the training script needs to be launched with dlrover-run.
-The usage of dlrover-run is consistent with torchrun. The following example demonstrates
+**Note**: To use the Flash Checkpoint, the training script needs to be launched with dlrover-run.
+If we launch the training process by other command like `torchrun`, the training can only
+use the asynchronously persistence. The usage of dlrover-run is consistent with torchrun. The following example demonstrates
 how to start single-node multi-GPU training:
 
 ```bash

--- a/docs/blogs/flash_checkpoint_cn.md
+++ b/docs/blogs/flash_checkpoint_cn.md
@@ -237,8 +237,8 @@ if args.save and iteration % save_memory_interval == 0:
                     opt_param_scheduler, storage_type=StorageType.MEMORY,)
 ```
 
-**注意**：Flash Checkpoint 的 API 需要使用 dlrover-run来启动训练脚本,
-dlrover-run的使用方法与 torchrun保持一致，如下所示启动单机多卡训练：
+**注意**：Flash Checkpoint 的断点续存和内容热加载需要使用`dlrover-run`来启动训练脚本。如果使用其他的方式例如`torchrun`来启动，
+则只能使用异步持久化功能。`dlrover-run` 的使用方法与`torchrun`保持一致，如下所示启动单机多卡训练：
 
 ```bash
 dlrover-run --nnodes=1 --max_restarts=2 --nproc_per_node=2 train.py 

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ extra_require = {
 
 setup(
     name="dlrover",
-    version="0.3.0rc1",
+    version="0.3.1rc0",
     description="An Automatic Distributed Deep Learning Framework",
     long_description="DLRover helps model developers focus on model algorithm"
     " itself, without taking care of any engineering stuff,"


### PR DESCRIPTION
### What changes were proposed in this pull request?

Start a process to save the checkpoint by the local rank 0 if the training process is not launched by `dlrover-run`.

### Why are the changes needed?

Fix #926 

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

UT.