### PR TITLE
Rename WORKER_NUM to NODE_NUM.

### DIFF
--- a/docs/blogs/stabilize_llm_training_cn.md
+++ b/docs/blogs/stabilize_llm_training_cn.md
@@ -328,7 +328,7 @@ spec:
               command:
                 - /bin/bash
                 - -c
-                - "dlrover-run --nnodes=1:$WORKER_NUM \
+                - "dlrover-run --nnodes=1:$NODE_NUM \
                   --nproc_per_node=1 --max_restarts=1  \
                   examples/pytorch/nanogpt/train.py \
                   --data_dir '/data/nanogpt/'"

--- a/docs/design/straggler-detection.md
+++ b/docs/design/straggler-detection.md
@@ -120,7 +120,7 @@ spec:
               command:
                 - /bin/bash
                 - -c
-                - "dlrover-run --straggler-detection --nnodes=$WORKER_NUM \
+                - "dlrover-run --straggler-detection --nnodes=$NODE_NUM \
                   --nproc_per_node=2 --max_restarts=3  \
                   examples/pytorch/mnist/cnn_train.py --num_epochs 2 \
                   --training_data /data/mnist_png/training/ \

--- a/docs/tech_report/fault_tolerance_exps.md
+++ b/docs/tech_report/fault_tolerance_exps.md
@@ -29,7 +29,7 @@ and the command in the worker spec is
   command:
     - /bin/bash
     - -c
-    - "dlrover-run --network-check --exclude-straggler --nnodes=3:$WORKER_NUM \
+    - "dlrover-run --network-check --exclude-straggler --nnodes=3:$NODE_NUM \
         --nproc_per_node=2 --max_restarts=3  --rdzv_conf pend_timeout=600 \
         examples/pytorch/mnist/cnn_train.py --num_epochs 5 \
         --training_data /data/mnist_png/training/ \
@@ -102,7 +102,7 @@ and set the command in the yaml of elasticjob like the [example](../../examples/
     - /bin/bash
     - -c
     - "(bash examples/pytorch/mnist/start_chaos.sh cpu-overload &) && \
-        dlrover-run --network-check --exclude-straggler --nnodes=3:$WORKER_NUM \
+        dlrover-run --network-check --exclude-straggler --nnodes=3:$NODE_NUM \
         --nproc_per_node=2 --max_restarts=3  --rdzv_conf pend_timeout=600 \
         examples/pytorch/mnist/cnn_train.py --num_epochs 5 \
         --training_data /data/mnist_png/training/ \
@@ -169,7 +169,7 @@ command:
     - /bin/bash
     - -c
     - "(bash examples/pytorch/mnist/start_chaos.sh kill-process &) && \
-        dlrover-run --network-check --exclude-straggler --nnodes=3:$WORKER_NUM \
+        dlrover-run --network-check --exclude-straggler --nnodes=3:$NODE_NUM \
         --nproc_per_node=2 --max_restarts=3  --rdzv_conf pend_timeout=600 \
         examples/pytorch/mnist/cnn_train.py --num_epochs 5 \
         --training_data /data/mnist_png/training/ \
@@ -270,8 +270,8 @@ elasticjob-chaos-test-dlrover-master          1/1     Running   0             3m
 
 In the experiment, we use the [example](../../examples/pytorch/mnist/elastic_job.yaml)
 to submit an elastic training job. In the job, we set the `min_node=3` and
-`max_node=$WORKER_NUM` as the number of replicas. The ElasticJob will set the replicas
-into the environment `WORKER_NUM`.
+`max_node=$NODE_NUM` as the number of replicas. The ElasticJob will set the replicas
+into the environment `NODE_NUM`.
 
 At first, there are 3 running workers and 1 pending worker due to the insufficient resource.
 
@@ -343,8 +343,8 @@ loss = 0.6941334009170532, step = 100
 
 In the experiment, we use the [example](../../examples/pytorch/mnist/elastic_job.yaml)
 to submit an elastic training job. In the job, we set the `min_node=3` and
-`max_node=$WORKER_NUM` as the number of replicas. The ElasticJob will set the replicas
-into the environment `WORKER_NUM`.
+`max_node=$NODE_NUM` as the number of replicas. The ElasticJob will set the replicas
+into the environment `NODE_NUM`.
 
 At first, there are 4 running workers.
 

--- a/docs/tutorial/check_node_health.md
+++ b/docs/tutorial/check_node_health.md
@@ -103,7 +103,7 @@ into environments. We can run `dlrover-run` like
 
 ```bash
 NODE_RANK=$RANK DLROVER_MASTER_ADDR=$MASTER_ADDR:$MASTER_PORT \
-dlrover-run --standalone --network-check --nnodes=$NODE_NUM --nproc_per_node=$NUM_TRAINERS  train_script.py
+dlrover-run --network-check --nnodes=$NODE_NUM --nproc_per_node=$NUM_TRAINERS  train_script.py
 ```
 
 Then, we can search the execution time on the master Pod of PyTorchJob.

--- a/docs/tutorial/elastic_torch_training.md
+++ b/docs/tutorial/elastic_torch_training.md
@@ -156,7 +156,7 @@ spec:
               command:
                 - /bin/bash
                 - -c
-                - "dlrover-run --nnodes=1:$WORKER_NUM --nproc_per_node=1
+                - "dlrover-run --nnodes=1:$NODE_NUM --nproc_per_node=1
                   --max_restarts=3 \
                   examples/pytorch/mnist_cnn.py \
                   --training_data /data/mnist_png/training/elastic_ds.txt \

--- a/examples/pytorch/llama2/README.md
+++ b/examples/pytorch/llama2/README.md
@@ -23,7 +23,7 @@ pip install -r examples/pytorch/llama2/requirements.txt
 Then, we can use `dlrover-run` to start the training by
 
 ```bash
-dlrover-run --standalone --nproc_per_node=${GPU_NUM} examples/pytorch/llama2/llama_ft.py 
+dlrover-run --nproc_per_node=${GPU_NUM} examples/pytorch/llama2/llama_ft.py 
 ```
 
 `GPU_NUM` is the number of GPUs on the node.

--- a/examples/pytorch/llama2/elastic_job.yaml
+++ b/examples/pytorch/llama2/elastic_job.yaml
@@ -20,7 +20,7 @@ spec:
               command:
                 - /bin/bash
                 - -c
-                - "dlrover-run --nnodes=$WORKER_NUM \
+                - "dlrover-run --nnodes=$NODE_NUM \
                   --nproc_per_node=1 --max_restarts=1  \
                   ./examples/pytorch/llama2/fine_tuning.py  \
                   ./examples/pytorch/llama2/btc_tweets_sentiment.json"

--- a/examples/pytorch/mnist/README.md
+++ b/examples/pytorch/mnist/README.md
@@ -72,7 +72,7 @@ We can use the FSDP strategy to pretrain when we have GPUs and only
 use the command in the containers of worker.
 
 ```bash
-dlrover-run --network-check --nnodes=3:$WORKER_NUM \
+dlrover-run --network-check --nnodes=3:$NODE_NUM\
     --nproc_per_node=2 --max_restarts=3  \
     examples/pytorch/mnist/cnn_train.py --use_fsdp --num_epochs 5 \
     --training_data /data/mnist_png/training/ \

--- a/examples/pytorch/mnist/chaos_test_job.yaml
+++ b/examples/pytorch/mnist/chaos_test_job.yaml
@@ -24,7 +24,7 @@ spec:
                 - -c
                 - "(bash examples/pytorch/mnist/start_chaos.sh cpu-overload &)
                   && dlrover-run --network-check --exclude-straggler \
-                  --nnodes=3:$WORKER_NUM --nproc_per_node=2 \
+                  --nnodes=3:$NODE_NUM--nproc_per_node=2 \
                   --max_restarts=3  --rdzv_conf pend_timeout=600 \
                   examples/pytorch/mnist/cnn_train.py --num_epochs 5 \
                   --training_data /data/mnist_png/training/ \

--- a/examples/pytorch/mnist/elastic_job.yaml
+++ b/examples/pytorch/mnist/elastic_job.yaml
@@ -20,8 +20,8 @@ spec:
               command:
                 - /bin/bash
                 - -c
-                # WORKER_NUM is set into env with the value as replicas.
-                - "dlrover-run --network-check --nnodes=3:$WORKER_NUM \
+                # NODE_NUM is set into env with the value as replicas.
+                - "dlrover-run --network-check --nnodes=3:$NODE_NUM \
                   --nproc_per_node=2 --max_restarts=3  \
                   examples/pytorch/mnist/cnn_train.py --num_epochs 5 \
                   --training_data /data/mnist_png/training/ \

--- a/examples/pytorch/nanogpt/README.md
+++ b/examples/pytorch/nanogpt/README.md
@@ -60,7 +60,7 @@ We can use the FSDP strategy to pretrain when we have GPUs and only
 use the command in the containers of worker.
 
 ```bash
-dlrover-run --nnodes=$WORKER_NUM \
+dlrover-run --nnodes=$NODE_NUM \
     --nproc_per_node=${GPU_NUM_PER_NODE} --max_restarts=1  \
     ./examples/pytorch/nanogpt/fsdp_train.py  \
     --data_dir '/data/nanogpt/' --epochs 50 --checkpoint_step 50 \

--- a/examples/pytorch/nanogpt/elastic_job.yaml
+++ b/examples/pytorch/nanogpt/elastic_job.yaml
@@ -20,7 +20,7 @@ spec:
               command:
                 - /bin/bash
                 - -c
-                - "dlrover-run --network-check --nnodes=$WORKER_NUM \
+                - "dlrover-run --network-check --nnodes=$NODE_NUM \
                   --nproc_per_node=1 --max_restarts=1  \
                   ./examples/pytorch/nanogpt/train.py  \
                   --data_dir /data/nanogpt/"


### PR DESCRIPTION
### What changes were proposed in this pull request?

Rename WORKER_NUM to NODE_NUM.

### Why are the changes needed?

NODE_NUM is more accurate than WORKER_NUM because the worker of torch is a training process.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

Just docs.