### PR TITLE
Add the two env vars to keep compatiblity with kubeflow/PytorchJob

### DIFF
--- a/dlrover/python/common/constants.py
+++ b/dlrover/python/common/constants.py
@@ -209,6 +209,10 @@ class NodeEnv(object):
     WORKER_NUM = "WORKER_NUM"
     WORKER_RANK = "WORKER_RANK"
 
+    # The envs are compatibile with kubeflow/PytorchJob.
+    RANK = "RANK"  # It is the rank of node not the rank of process.
+    WORLD_SIZE = "WORLD_SIZE"  # It is the number of nodes.
+
     # process env
     TORCHELASTIC_RUN_ID = "TORCHELASTIC_RUN_ID"
 

--- a/dlrover/python/master/scaler/pod_scaler.py
+++ b/dlrover/python/master/scaler/pod_scaler.py
@@ -411,9 +411,7 @@ class PodScaler(Scaler):
         # The two env vars is compatible with kubeflow/PytorchJob because
         # users may use the scripts of kubeflow/PytorchJob in the ElasticJob.
         env.append(V1EnvVar(name=NodeEnv.WORLD_SIZE, value=str(worker_num)))
-        env.append(
-            V1EnvVar(name=NodeEnv.RANK, value=str(node.rank_index))
-        )
+        env.append(V1EnvVar(name=NodeEnv.RANK, value=str(node.rank_index)))
 
         # Deprecated env vars
         env.append(V1EnvVar(name=NodeEnv.WORKER_TYPE, value=node.type))

--- a/dlrover/python/master/scaler/pod_scaler.py
+++ b/dlrover/python/master/scaler/pod_scaler.py
@@ -408,6 +408,13 @@ class PodScaler(Scaler):
             V1EnvVar(name=NodeEnv.NODE_RANK, value=str(node.rank_index))
         )
 
+        # The two env vars is compatible with kubeflow/PytorchJob because
+        # users may use the scripts of kubeflow/PytorchJob in the ElasticJob.
+        env.append(V1EnvVar(name=NodeEnv.WORLD_SIZE, value=str(worker_num)))
+        env.append(
+            V1EnvVar(name=NodeEnv.RANK, value=str(node.rank_index))
+        )
+
         # Deprecated env vars
         env.append(V1EnvVar(name=NodeEnv.WORKER_TYPE, value=node.type))
         env.append(V1EnvVar(name=NodeEnv.WORKER_ID, value=str(node.id)))


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add the two env vars to keep compatiblity with kubeflow/PytorchJob

### Why are the changes needed?

Users may use the scripts of kubeflow/PytorchJob in the ElasticJob.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

UT.