### PR TITLE
Print log when the speed monitor removes a running worker.

### DIFF
--- a/dlrover/python/master/monitor/speed_monitor.py
+++ b/dlrover/python/master/monitor/speed_monitor.py
@@ -129,6 +129,15 @@ class SpeedMonitor(object):
     def remove_running_worker(self, type, worker_id):
         if (type, worker_id) in self._workers:
             self._workers.remove((type, worker_id))
+            logger.info(
+                f"Speed monitor removes a worker {type}-{worker_id} and "
+                f"the remaining workers are {self._workers}."
+            )
+        else:
+            logger.info(
+                f"The worker {type}-{worker_id} is not in speed monitor and "
+                f"the remaining workers are {self._workers}."
+            )
 
     @property
     def init_training_time(self):


### PR DESCRIPTION
### What changes were proposed in this pull request?

Print log when the speed monitor removes a running worker.

### Why are the changes needed?

The number of running workers in the speed monitor may be bigger than the real number of workers.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

UT.