### PR TITLE
Support saving the checkpoint into multiple files.

### DIFF
--- a/dlrover/python/elastic_agent/torch/ckpt_saver.py
+++ b/dlrover/python/elastic_agent/torch/ckpt_saver.py
@@ -78,7 +78,7 @@ class TensorMeta:
 
 
 @dataclass
-class CheckpointShardConfig:
+class CheckpointConfig:
     """
     The configuration of a checkpointing shard on the training process.
 
@@ -86,39 +86,13 @@ class CheckpointShardConfig:
         step (int): the global interation step.
         writing_shm (bool): the flag whether the training process is writing
             the state dict into the shared memory.
+        paths (dict): the key is in ["model_state", "optim_state"] and the
+            value is path.
     """
 
     step: int = 0
     writing_shm: bool = False
-
-
-@dataclass
-class SingleFileCheckpointConfig(CheckpointShardConfig):
-    """
-    The configuration of a checkpointing shard to save the optimizer
-    and model state dict into a file.
-
-    Attributes:
-        path (str): the path to save the checkpoint shard.
-    """
-
-    path: str = ""
-
-
-@dataclass
-class DeepSpeedCheckpointConfig(CheckpointShardConfig):
-    """
-    The configuration of a checkpointing shard to save the DeepSpeed
-    ZERO-0/1/2/3 stage.
-
-    Attributes:
-        model_path (str): the path to save the checkpoint shard of model.
-        optimizer_path (str): the path to save the checkpoint
-            shard of optimizer.
-    """
-
-    model_path: str = ""
-    optimizer_path: str = ""
+    paths: Dict[str, str] = None  # type: ignore
 
 
 def _traverse_state_dict(value: object, visitor: Callable[[object], None]):
@@ -297,7 +271,7 @@ class SharedMemoryHandler(object):
         self._buffer_size += value.numel() * value.element_size()
         return meta
 
-    def save_state_dict(self, state_dict, ckpt_conf: CheckpointShardConfig):
+    def save_state_dict(self, state_dict):
         """
         Copy the state dict from CPU memory buffer into the shared memory.
         """
@@ -308,8 +282,8 @@ class SharedMemoryHandler(object):
             self.init_shared_memory(create=True, size=self._buffer_size)
         else:
             meta_dict = self.metadata.get(local=True)
+        ckpt_conf: CheckpointConfig = meta_dict[DLROVER_CKPT_CONFIG_KEY]
         ckpt_conf.writing_shm = True
-        meta_dict[DLROVER_CKPT_CONFIG_KEY] = ckpt_conf
 
         self.metadata.set(meta_dict)
         assert self.shared_memory is not None
@@ -326,7 +300,7 @@ class SharedMemoryHandler(object):
                 the second value is the state dict.
         """
         meta_dict = self.metadata.get()
-        default_config = CheckpointShardConfig()
+        default_config = CheckpointConfig()
         config = meta_dict.get(DLROVER_CKPT_CONFIG_KEY, default_config)
         if not meta_dict or config.writing_shm:
             return {}
@@ -336,7 +310,6 @@ class SharedMemoryHandler(object):
             return {}
 
         state_dict = _read_state_dict_from_shm(meta_dict, self.shared_memory)
-        state_dict.pop(DLROVER_CKPT_CONFIG_KEY, None)
         return state_dict
 
     def no_checkpint_state(self):
@@ -346,9 +319,7 @@ class SharedMemoryHandler(object):
         device has saved state dict.
         """
         meta_dict = self.metadata.get()
-        config: CheckpointShardConfig = meta_dict.get(
-            DLROVER_CKPT_CONFIG_KEY, None
-        )
+        config: CheckpointConfig = meta_dict.get(DLROVER_CKPT_CONFIG_KEY, None)
         if config is None or config.step == 0:
             return True
         return False
@@ -519,7 +490,7 @@ class AsyncCheckpointSaver(metaclass=ABCMeta):
         self,
         step,
         local_shard_id: int,
-        ckpt_config: CheckpointShardConfig,
+        ckpt_config: CheckpointConfig,
         step_done_dir: str,
     ):
         """Save the shard of state dict into the storage."""
@@ -530,7 +501,7 @@ class AsyncCheckpointSaver(metaclass=ABCMeta):
                 shm_handler.init_shared_memory(create=False)
 
             shm_lock.acquire()
-            default_config = CheckpointShardConfig()
+            default_config = CheckpointConfig()
             config = shm_handler.get_checkpoint_config(default_config)
             if config.step != step:
                 shm_lock.release()
@@ -607,7 +578,7 @@ class AsyncCheckpointSaver(metaclass=ABCMeta):
             return
         steps = []
         for shm_handler in self._shm_handlers:
-            default_config = CheckpointShardConfig()
+            default_config = CheckpointConfig()
             config = shm_handler.get_checkpoint_config(default_config)
             steps.append(config.step)
         if len(set(steps)) > 1:
@@ -711,7 +682,7 @@ class CommonDirCheckpointSaver(AsyncCheckpointSaver):
         # save to stage path for each local rank
         futures: List[Future] = []
         for i in range(self.local_shard_num):
-            default_config = SingleFileCheckpointConfig()
+            default_config = CheckpointConfig()
             ckpt_config = self._shm_handlers[i].get_checkpoint_config(
                 default_config
             )
@@ -787,6 +758,15 @@ class CommonDirCheckpointSaver(AsyncCheckpointSaver):
 
             time.sleep(2)
         self.storage.commit(step)
+
+    def persist_to_storage(
+        self, local_shard_id: int, ckpt_config: CheckpointConfig
+    ):
+        state_dict = self._shm_handlers[local_shard_id].load_state_dict()
+        for state_name, sd in state_dict.items():
+            if state_name in ckpt_config.paths:
+                path = ckpt_config.paths[state_name]
+                self.storage.write_state_dict(sd, path, torch.save)
 
 
 class TempDirCheckpointSaver(AsyncCheckpointSaver):
@@ -946,17 +926,11 @@ class TempDirCheckpointSaver(AsyncCheckpointSaver):
 class DdpCheckpointSaver(CommonDirCheckpointSaver):
     """Persist the checkpoint from CPU memory buffer into the storage."""
 
-    def persist_to_storage(
-        self,
-        local_shard_id: int,
-        ckpt_config: SingleFileCheckpointConfig,
-    ):
+    def persist_to_storage(self, local_shard_id: int, ckpt_config):
         if self._node_rank != 0:
             logger.info("Skip and only rank 0 saves checkpoint in a DDP job.")
             return
-        state_dict = self._shm_handlers[local_shard_id].load_state_dict()
-        state_dict.pop(DLROVER_CKPT_CONFIG_KEY, None)
-        self.storage.write_state_dict(state_dict, ckpt_config.path, torch.save)
+        super().persist_to_storage(local_shard_id, ckpt_config)
 
 
 class MegatronCheckpointSaver(CommonDirCheckpointSaver):
@@ -978,15 +952,6 @@ class MegatronCheckpointSaver(CommonDirCheckpointSaver):
         )
         self.storage.write(str(step), ds_tracker_filename)
 
-    def persist_to_storage(
-        self,
-        local_shard_id: int,
-        ckpt_config: SingleFileCheckpointConfig,
-    ):
-        state_dict = self._shm_handlers[local_shard_id].load_state_dict()
-        state_dict.pop(DLROVER_CKPT_CONFIG_KEY, None)
-        self.storage.write_state_dict(state_dict, ckpt_config.path, torch.save)
-
 
 class DeepSpeedCheckpointSaver(CommonDirCheckpointSaver):
     TRACER_FILE = "latest"
@@ -1007,26 +972,6 @@ class DeepSpeedCheckpointSaver(CommonDirCheckpointSaver):
         )
         self.storage.write(str(step), ds_tracker_filename)
 
-    def persist_to_storage(  # type: ignore
-        self,
-        local_shard_id: int,
-        ckpt_config: DeepSpeedCheckpointConfig,
-    ):
-        """Persist the checkpoint from CPU memory buffer into the storage."""
-        state_dict = self._shm_handlers[local_shard_id].load_state_dict()
-        state_dict.pop(DLROVER_CKPT_CONFIG_KEY, None)
-        model_sd = state_dict.get(CheckpointConstant.MODEL_STATES_NAME, {})
-        if model_sd and ckpt_config.model_path:
-            self.storage.write_state_dict(
-                model_sd, ckpt_config.model_path, torch.save
-            )
-
-        optimizer_sd = state_dict.get(CheckpointConstant.OPTIM_STATES_NAME, {})
-        if optimizer_sd and ckpt_config.optimizer_path:
-            self.storage.write_state_dict(
-                optimizer_sd, ckpt_config.optimizer_path, torch.save
-            )
-
 
 class FsdpDcpSaver(CommonDirCheckpointSaver):
     """The saver saves the distributed checkpoint of FSDP into the storage."""
@@ -1034,7 +979,7 @@ class FsdpDcpSaver(CommonDirCheckpointSaver):
     def persist_to_storage(
         self,
         local_shard_id: int,
-        ckpt_config: SingleFileCheckpointConfig,
+        ckpt_config: CheckpointConfig,
     ):
         """
         Persist the state dict to a storage path.
@@ -1045,12 +990,13 @@ class FsdpDcpSaver(CommonDirCheckpointSaver):
                 save the storage.
         """
         shm_handler = self._shm_handlers[local_shard_id]
-        checkpoint_dir = os.path.dirname(ckpt_config.path)
+        path = ckpt_config.paths[CheckpointConstant.MODEL_STATES_NAME]
+        checkpoint_dir = os.path.dirname(path)
         self.storage.safe_makedirs(checkpoint_dir)
         assert shm_handler.shared_memory is not None
-        self.storage.write(shm_handler.shared_memory.buf, ckpt_config.path)
+        self.storage.write(shm_handler.shared_memory.buf, path)
         if self._is_agent_rank_0 and local_shard_id == 0:
-            parent_path = Path(os.path.dirname(ckpt_config.path))
+            parent_path = Path(os.path.dirname(path))
             meta_dict = shm_handler.metadata.get()
             dcp_metadata = meta_dict.get("dcp_metadata", {})
             if dcp_metadata:

--- a/dlrover/trainer/tests/torch/deepspeed_ckpt_test.py
+++ b/dlrover/trainer/tests/torch/deepspeed_ckpt_test.py
@@ -121,10 +121,6 @@ class DeepSpeedCheckpointTest(unittest.TestCase):
             )
             ds_ckpt_config = tensor_meta["_DLORVER_CKPT_CONFIG"]
             self.assertEqual(ds_ckpt_config.step, str(step))
-            model_path = os.path.join(tmpdirname, str(step), "model_states.pt")
-            self.assertEqual(ds_ckpt_config.model_path, model_path)
-            optim_path = os.path.join(tmpdirname, str(step), "optim_states.pt")
-            self.assertEqual(ds_ckpt_config.optimizer_path, optim_path)
             self.assertIsNotNone(tensor_meta["model_states"])
             tracer_file = os.path.join(tmpdirname, "latest")
             self.assertFalse(os.path.exists(tracer_file))

--- a/dlrover/trainer/tests/torch/fsdp_ckpt_test.py
+++ b/dlrover/trainer/tests/torch/fsdp_ckpt_test.py
@@ -47,6 +47,7 @@ from torch.distributed.checkpoint.planner import (
 )
 
 from dlrover.python.common import grpc
+from dlrover.python.common.constants import CheckpointConstant
 from dlrover.python.common.multi_process import SharedMemory
 from dlrover.python.common.storage import PosixDiskStorage
 from dlrover.python.elastic_agent.torch.ckpt_saver import (
@@ -336,11 +337,12 @@ class FsdpCheckpointTest(unittest.TestCase):
             tmpdir = Path(tmpdir)
             engine = tmpdir
             path = tmpdir / str(step)
+            paths = {CheckpointConstant.MODEL_STATES_NAME: path}
             engine = FsdpCheckpointEngine(tmpdir, storage)
             engine.save_to_storage(
                 step,
                 state_dict,
-                path=path,
+                paths=paths,
             )
             self.assertEqual(engine._cached_step, 100)
             time.sleep(1)

--- a/dlrover/trainer/torch/flash_checkpoint/ddp.py
+++ b/dlrover/trainer/torch/flash_checkpoint/ddp.py
@@ -57,14 +57,16 @@ class DdpCheckpointer(Checkpointer):
         if path == "":
             ckpt_name = f"{CheckpointConstant.CKPT_NAME_PREFIX}{step}.pt"
             path = os.path.join(self.checkpoint_dir, ckpt_name)
+        state_dict = {CheckpointConstant.MODEL_STATES_NAME: state_dict}
+        paths = {CheckpointConstant.MODEL_STATES_NAME: path}
         if storage_type == StorageType.MEMORY:
-            self._engine.save_to_memory(step, state_dict, path)
+            self._engine.save_to_memory(step, state_dict, paths)
         elif storage_type == StorageType.DISK:
             if not path:
                 raise ValueError(
                     "path cannot be empty if storage type is disk!"
                 )
-            self._engine.save_to_storage(step, state_dict, path)
+            self._engine.save_to_storage(step, state_dict, paths)
         else:
             raise ValueError(f"No support storage type {storage_type}")
 

--- a/dlrover/trainer/torch/flash_checkpoint/ddp_engine.py
+++ b/dlrover/trainer/torch/flash_checkpoint/ddp_engine.py
@@ -13,6 +13,7 @@
 
 import os
 from datetime import timedelta
+from typing import Dict
 
 import torch
 import torch.distributed as dist
@@ -21,7 +22,7 @@ from dlrover.python.common import env_utils
 from dlrover.python.common.constants import CheckpointConstant
 from dlrover.python.common.log import default_logger as logger
 from dlrover.python.elastic_agent.torch.ckpt_saver import (
-    DLROVER_CKPT_CONFIG_KEY,
+    CheckpointConfig,
     CheckpointEvent,
     CheckpointEventType,
     DdpCheckpointSaver,
@@ -87,7 +88,26 @@ class DdpCheckpointEngine(CheckpointEngine):
         return DdpCheckpointSaver
 
     @timer
-    def save_to_storage(self, step, state_dict, path=""):
+    def save_to_memory(self, step, state_dict, paths: Dict[str, str]):
+        """
+        Synchronously Saves the state dict into the shared memory with the main
+        process. If the agent in the main process is saving the shared memory
+        into the storage, the method will skip to write the shared memory.
+        Only local rank 0 save the state dict into the memory because the
+        state dict is replicated across all ranks.
+
+        Args:
+            step (int): the global iteration step.
+            state_dict (dict): the state dict of model and optimizer to save.
+            paths (dict): the key is a category in
+                ["model_states", "optim_states"] of the state dict and
+                the value is the path of storage to save.
+        """
+        conf = CheckpointConfig(step=step, paths=paths)
+        self.save_state_dict_to_memory(state_dict, conf)
+
+    @timer
+    def save_to_storage(self, step, state_dict, paths):
         """
         Asynchronously saves the state dict into the storage. It synchronously
         saves the state dict into the shared memory and put the path
@@ -96,19 +116,16 @@ class DdpCheckpointEngine(CheckpointEngine):
         Only rank 0 saves the state dict into the storage.
 
         Args:
-            step (int): the iteration step.
+            step (int): the global iteration step.
             state_dict (dict): the state dict of model and optimizer to save.
-            path (str): the storage path to save the state dict.
-                Note, the ckpt_name is used to save the state dict to storage
-                only if the training process fails.
+            paths (dict): the key is a category in
+                ["model_states", "optim_states"] of the state dict and
+                the value is the path of storage to save.
         """
         if self._local_rank != 0:
             return
-        if not path:
-            name = f"{CheckpointConstant.CKPT_NAME_PREFIX}{step}.pt"
-            path = os.path.join(self.checkpoint_dir, name)
         if step > self._cached_step:
-            self.save_to_memory(step, state_dict, path)
+            self.save_to_memory(step, state_dict, paths)
         event = CheckpointEvent(type=CheckpointEventType.SAVE, step=step)
 
         # Only rank 0 persist the checkpoint to the storage.
@@ -126,8 +143,14 @@ class DdpCheckpointEngine(CheckpointEngine):
         state_dict = self.get_state_dict_from_memory()
         if state_dict:
             logger.info("Load the state dict from the CPU memory buffer.")
-            state_dict.pop(DLROVER_CKPT_CONFIG_KEY, None)
-            return state_dict
+            paths = list(state_dict.keys())
+            if len(paths) > 1:
+                raise ValueError(
+                    "The checkpoint shared memory must has only the"
+                    f"state dict of one path. Now, paths are {paths}"
+                )
+            path = paths[0]
+            return state_dict[path]
         state_dict = self._load_from_storage(resume_path)
         return state_dict
 

--- a/dlrover/trainer/torch/flash_checkpoint/deepspeed_engine.py
+++ b/dlrover/trainer/torch/flash_checkpoint/deepspeed_engine.py
@@ -51,7 +51,7 @@ class DeepSpeedCheckpointEngine(CheckpointEngine):
         super().__init__(checkpoint_dir, storage)
         if dist.is_initialized():
             saver_ranks = self._get_saver_ranks()
-            logger.info(f"Saver ranks of DeepSpeed is {saver_ranks}")
+            logger.info(f"Saver ranks of DeepSpeed are {saver_ranks}")
             self._saver_group = dist.new_group(
                 ranks=saver_ranks,
                 backend="gloo",

--- a/dlrover/trainer/torch/flash_checkpoint/deepspeed_engine.py
+++ b/dlrover/trainer/torch/flash_checkpoint/deepspeed_engine.py
@@ -20,9 +20,9 @@ from dlrover.python.common import env_utils
 from dlrover.python.common.constants import CheckpointConstant
 from dlrover.python.common.log import default_logger as logger
 from dlrover.python.elastic_agent.torch.ckpt_saver import (
+    CheckpointConfig,
     CheckpointEvent,
     CheckpointEventType,
-    DeepSpeedCheckpointConfig,
     DeepSpeedCheckpointSaver,
     SharedMemoryHandler,
 )
@@ -74,9 +74,7 @@ class DeepSpeedCheckpointEngine(CheckpointEngine):
         return save_ranks
 
     @timer
-    def save_to_memory(
-        self, step, state_dict, model_path="", optimizer_path=""
-    ):
+    def save_to_memory(self, step, state_dict, paths):
         """
         Synchronously Saves the state dict into the shared memory with the main
         process. If the agent in the main process is saving the shared memory
@@ -87,21 +85,15 @@ class DeepSpeedCheckpointEngine(CheckpointEngine):
         Args:
             step (int): the global iteration step.
             state_dict (dict): the state dict of model and optimizer to save.
-            model_path (str): the storage path to save the model state dict.
-            optimizer_path (str): the storage path to save the optimizer
-                state dict.
+            paths (dict): the key is a category in
+                ["model_states", "optim_states"] of the state dict and
+                the value is the path of storage to save.
         """
-        conf = DeepSpeedCheckpointConfig(
-            step=step,
-            model_path=model_path,
-            optimizer_path=optimizer_path,
-        )
+        conf = CheckpointConfig(step=step, paths=paths)
         self.save_state_dict_to_memory(state_dict, conf)
 
     @timer
-    def save_to_storage(
-        self, step, state_dict, model_path="", optimizer_path=""
-    ):
+    def save_to_storage(self, step, state_dict, paths):
         """
         Asynchonously saves the state dict into the storage. It synchonously
         saves the state dict into the shared memory and put the path
@@ -112,17 +104,17 @@ class DeepSpeedCheckpointEngine(CheckpointEngine):
         Args:
             step (int): the global iteration step.
             state_dict (dict): the state dict of model and optimizer to save.
-            model_path (str): the storage path to save the model state dict.
-            optimizer_path (str): the storage path to save the optimizer
-                state dict.
+            paths (dict): the key is a category in
+                ["model_states", "optim_states"] of the state dict and
+                the value is the path of storage to save.
         """
         if step > self._cached_step:
-            self.save_to_memory(step, state_dict, model_path, optimizer_path)
+            self.save_to_memory(step, state_dict, paths)
 
         # Only local rank 0 to notify the saving event to the agent.
         if self._local_rank != 0:
             return
-        if model_path or optimizer_path:
+        if state_dict:
             event = CheckpointEvent(type=CheckpointEventType.SAVE, step=step)
             self._event_queue.put(event)
 

--- a/dlrover/trainer/torch/flash_checkpoint/engine.py
+++ b/dlrover/trainer/torch/flash_checkpoint/engine.py
@@ -15,10 +15,10 @@ import os
 import time
 from abc import ABCMeta, abstractmethod
 from multiprocessing import Process
+from typing import Dict
 
 import torch
 import torch.distributed as dist
-from typing import Dict
 
 from dlrover.python.common import env_utils
 from dlrover.python.common.log import default_logger as logger

--- a/dlrover/trainer/torch/flash_checkpoint/engine.py
+++ b/dlrover/trainer/torch/flash_checkpoint/engine.py
@@ -206,6 +206,12 @@ class CheckpointEngine(metaclass=ABCMeta):
                 raise ValueError(
                     "The event queue cannot be None on local rank 0."
                 )
+            for _ in range(3):
+                try:
+                    self._event_queue.put(event)
+                    return
+                except FileNotFoundError:
+                    time.sleep(3)
             self._event_queue.put(event)
 
     def save_state_dict_to_memory(self, state_dict, conf: CheckpointConfig):

--- a/dlrover/trainer/torch/flash_checkpoint/fsdp.py
+++ b/dlrover/trainer/torch/flash_checkpoint/fsdp.py
@@ -11,6 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from dlrover.python.common.constants import CheckpointConstant
 from dlrover.python.common.storage import PosixDiskStorage
 
 from .checkpointer import Checkpointer, StorageType
@@ -70,8 +71,9 @@ class FsdpCheckpointer(Checkpointer):
     def save_checkpoint(
         self, step, state_dict, path, storage_type=StorageType.DISK
     ):
+        paths = {CheckpointConstant.MODEL_STATES_NAME: path}
         if storage_type == StorageType.MEMORY:
-            self._engine.save_to_memory(step, state_dict, path)
+            self._engine.save_to_memory(step, state_dict, paths)
         elif storage_type == StorageType.DISK:
             if not path:
                 raise ValueError(

--- a/dlrover/trainer/torch/flash_checkpoint/fsdp_engine.py
+++ b/dlrover/trainer/torch/flash_checkpoint/fsdp_engine.py
@@ -17,7 +17,7 @@ import os
 import pickle
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Tuple, Union
+from typing import Any, Dict, List, Tuple, Union
 
 import torch
 import torch.distributed as dist
@@ -51,11 +51,11 @@ from dlrover.python.common.log import default_logger as logger
 from dlrover.python.common.multi_process import SharedMemory
 from dlrover.python.elastic_agent.torch.ckpt_saver import (
     DLROVER_CKPT_CONFIG_KEY,
+    CheckpointConfig,
     CheckpointEvent,
     CheckpointEventType,
     FsdpDcpSaver,
     SharedMemoryHandler,
-    SingleFileCheckpointConfig,
 )
 
 from .engine import (
@@ -170,7 +170,7 @@ class SharedMemoryWriter(StorageWriter):
         super().__init__()
         self.file_name = ""
         self.shm_handler = shm_handler
-        self.metadata: Dict[str, object] = {}
+        self.metadata: Dict[str, Any] = {}
 
     def set_up_storage_writer(self, is_coordinator: bool) -> None:
         pass
@@ -425,7 +425,7 @@ class FsdpCheckpointEngine(CheckpointEngine):
         self._shm_reader = SharedMemoryReader(self._shm_handler)
 
     @timer
-    def save_to_memory(self, step, state_dict, path=""):
+    def save_to_memory(self, step, state_dict, paths: Dict[str, str]):
         """
         Synchronously Saves the state dict into the shared memory with the main
         process. If the agent in the main process is saving the shared memory
@@ -443,11 +443,6 @@ class FsdpCheckpointEngine(CheckpointEngine):
         if self._local_rank != self.local_shard_id:
             return
 
-        conf = SingleFileCheckpointConfig(
-            step=step,
-            path=path,
-        )
-
         acquired = self._shm_lock.acquire(blocking=False)
         all_rank_ready = check_all_rank_ready(self._saver_group, acquired)
         if not all_rank_ready:
@@ -460,6 +455,7 @@ class FsdpCheckpointEngine(CheckpointEngine):
                 self._shm_lock.release()
             return
 
+        conf = CheckpointConfig(step=step)
         conf.writing_shm = True
         dist_cp.save_state_dict(
             state_dict=state_dict,
@@ -469,12 +465,13 @@ class FsdpCheckpointEngine(CheckpointEngine):
         # Broadcast dcp metadata and no sharding data to all ranks
         # and all ranks can restore the state dict from the CPU
         # memory with those metada.
-
         bcast_list = [self._shm_writer.metadata]
         dist.broadcast_object_list(bcast_list, src=0)
         self._shm_writer.metadata = bcast_list[0]
 
-        conf.path = os.path.join(path, self._shm_writer.file_name)
+        model_sd_name = CheckpointConstant.MODEL_STATES_NAME
+        path = os.path.join(paths[model_sd_name], self._shm_writer.file_name)
+        conf.paths = {model_sd_name: path}
         meta_dict = {DLROVER_CKPT_CONFIG_KEY: conf}
         meta_dict.update(self._shm_writer.metadata)
         self._shm_handler.metadata.set(meta_dict)
@@ -485,24 +482,21 @@ class FsdpCheckpointEngine(CheckpointEngine):
         if dist.is_initialized():
             dist.barrier(group=self._saver_group)
 
-    def save_to_storage(self, step, state_dict, path):
+    def save_to_storage(self, step, state_dict, paths: Dict[str, str]):
         """
         Save the state_dict into the path of storage.
 
         Args:
             step (int): the iteration step.
             state_dict (dict): the state dict of model and optimizer to save.
-            path (str): optional, the file path to save the checkpoint. If the
-                path is not defined, the engine will save the state dict into
-                the shared memory not the storage.
         """
         if step > self._cached_step:
-            self.save_to_memory(step, state_dict, path)
+            self.save_to_memory(step, state_dict, paths)
 
         # Only local rank 0 on each node notifies the event to save.
         if self._local_rank != 0:
             return
-        if path:
+        if paths:
             logger.info(
                 "Put a save event to notify the agent persists checkpoint."
             )
@@ -534,7 +528,7 @@ class FsdpCheckpointEngine(CheckpointEngine):
             resume_path (str): the resuming path to load the
                 checkpointing state dict from the storage.
         """
-        default_config = SingleFileCheckpointConfig()
+        default_config = CheckpointConfig()
         config = self._shm_handler.get_checkpoint_config(default_config)
         step = config.step
         passed = verify_all_rank_step_consistent(self._saver_group, step)

--- a/dlrover/trainer/torch/flash_checkpoint/megatron_engine.py
+++ b/dlrover/trainer/torch/flash_checkpoint/megatron_engine.py
@@ -63,7 +63,7 @@ class MegatronCheckpointEngine(CheckpointEngine):
         super().__init__(checkpoint_dir, storage)
         if dist.is_initialized():
             saver_ranks = self._get_saver_ranks()
-            logger.info(f"Saver ranks of Megatron-LM is {saver_ranks}")
+            logger.info(f"Saver ranks of Megatron-LM are {saver_ranks}")
             self._saver_group = dist.new_group(
                 ranks=saver_ranks,
                 backend="gloo",

--- a/dlrover/trainer/torch/flash_checkpoint/megatron_engine.py
+++ b/dlrover/trainer/torch/flash_checkpoint/megatron_engine.py
@@ -42,7 +42,11 @@ class MegatronCheckpointEngine(CheckpointEngine):
 
     def __init__(self, checkpoint_dir, storage):
         if dist.is_initialized():
-            from megatron import mpu
+            try:
+                from megatron.core import mpu
+            except ImportError:
+                #  Keep back compatibility.
+                from megatron import mpu
 
             self._tp_rank = mpu.get_tensor_model_parallel_rank()
             self._pp_rank = mpu.get_pipeline_model_parallel_rank()


### PR DESCRIPTION
### What changes were proposed in this pull request?
Support saving the checkpoint into multiple files.

### Why are the changes needed?

Some DL frameworks like DeepSpeed, Megatron-LM saves the model and optimizer state dict into separate files.

Fix #949 

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

UT.