### PR TITLE
Fix the dependency of atorch.

### DIFF
--- a/atorch/README.md
+++ b/atorch/README.md
@@ -37,7 +37,7 @@ ATorch is an extension library of PyTorch developed by Ant Group's AI Infrastruc
 * Automatic/semi-automatic optimization
   * Acceleration Engine for automatic optimization
   * Semi-automatic optimization supports custom optimization
-* Hybrid parallelism suport (arbitrary combination of fsdp/zero/ddp/tp/sp/pp)
+* Hybrid parallelism support (arbitrary combination of fsdp/zero/ddp/tp/sp/pp)
 * High performance operators
   * Flash attention 2 with custom mask support
   * Transformer ops
@@ -60,7 +60,7 @@ ATorch is an extension library of PyTorch developed by Ant Group's AI Infrastruc
 
 ## Installation
 
-ATorch supports PyTorch with version >= 1.12, and verion 2.1 or above is preferred.
+ATorch supports PyTorch with version >= 1.12, and version 2.1 or above is preferred.
 For example, you can use docker image <code>easydl/atorch:iml_pt210</code> (or aliyun mirror <code>registry.cn-hangzhou.aliyuncs.com/atorch/atorch:iml_pt210</code>) which has PyTorch 2.1 installed.
 
 ### Install From PyPI

--- a/atorch/atorch/requirements.txt
+++ b/atorch/atorch/requirements.txt
@@ -8,7 +8,7 @@ pyomo
 pynvml==11.4.1
 grpcio==1.34.1
 grpcio-tools==1.34.1
-fsspec==2023.1.0
+fsspec==2023.10.0
 pyarrow==12.0.0
 pandas==2.0.1
 tensorboard==2.11.0

--- a/atorch/docs/auto_accelerate_api.md
+++ b/atorch/docs/auto_accelerate_api.md
@@ -6,7 +6,7 @@ The auto_accelerate API provides two ways of usage:
 1. Fully automatic mode: Automatically generates optimization strategy and implements automatic optimization.
 2. Semi-automatic mode: Users specify the method used for optimization strategy through load_strategy, and auto_accelerate automatically configures and implements the optimization strategy.
 
-An optimization strategy consists of multiple optimization methods, including parallel training, GPU memory optimization methods, compute optimization, etc. Supported optimization methods are listed in [doc link]. 
+An optimization strategy consists of multiple optimization methods, including parallel training, GPU memory optimization methods, compute optimization, etc. Supported optimization methods are listed in [doc link](#supported-optimization-methods). 
 
 ## Inputs
 auto_accelerate takes model, optim_func, dataset, loss_func, etc as inputs, and generates optimized model, optimizer, dataloader etc as outputs.

--- a/atorch/docs/auto_accelerate_api.md
+++ b/atorch/docs/auto_accelerate_api.md
@@ -107,7 +107,7 @@ Note that strong scaling is used, thus batch_size is the global batch_size in tr
 
   <tr>
     <td>distributed_sampler_cls (type, optional)</td>
-    <td>used-defined distributed sampler with same interafce as torch.utils.data.distributed.DistributedSampler. </td>
+    <td>used-defined distributed sampler with same interface as torch.utils.data.distributed.DistributedSampler. </td>
   </tr>
 
   <tr>
@@ -135,7 +135,7 @@ None: use data as model input.
     <td>load_strategy (optional)</td>
     <td>If None, fully-automatic model.
 
-Not None, semi-automaticl model. Supported formats:
+Not None, semi-automatic model. Supported formats:
 
 1. str: strategy(str)
 
@@ -331,7 +331,7 @@ Pipeline parallel, which would split model in multiple stages automatically. The
 
 ### mixed_parallel
 
-Automatically training model with tensor parallel, pipelin parallel, and daa parallel. parallel_mode configuration would specify the degree of each parallelism. For example, <code>([("tensor", 8), ("pipeline", 2), ("data", 2)]</code> specifies 8, 2, 2 for degrees of tensor parallel, pipeline paralllel, and data parallel respectively.
+Automatically training model with tensor parallel, pipeline parallel, and daa parallel. parallel_mode configuration would specify the degree of each parallelism. For example, <code>([("tensor", 8), ("pipeline", 2), ("data", 2)]</code> specifies 8, 2, 2 for degrees of tensor parallel, pipeline parallel, and data parallel respectively.
 
 ### ds_3d_parallel
 

--- a/atorch/examples/auto_accelerate/README.md
+++ b/atorch/examples/auto_accelerate/README.md
@@ -12,47 +12,34 @@
 ## Usage
 
 ```
-train.py [-h] --model_type MODEL_TYPE [--datasize DATASIZE] [--epoch EPOCH] [--hiddien_size HIDDIEN_SIZE] [--head_num HEAD_NUM] [--layer_num LAYER_NUM] [--seq_length SEQ_LENGTH] [--batchsize BATCHSIZE] [--distributed] [--user_created_dataloader] [--load_strategy] [--optim_grouped_params] [--log_interval LOG_INTERVAL] [--use_fsdp] [--use_amp] [--use_checkpointing] [--use_module_replace]
+train.py [-h] --model_type MODEL_TYPE [--datasize DATASIZE] [--epoch EPOCH] [--hidden_size hidden_size] [--head_num HEAD_NUM] [--layer_num LAYER_NUM] [--seq_length SEQ_LENGTH] [--batchsize BATCHSIZE] [--distributed] [--user_created_dataloader] [--load_strategy] [--optim_grouped_params] [--log_interval LOG_INTERVAL] [--use_fsdp] [--use_amp] [--use_checkpointing] [--use_module_replace]
 ```
 
 model_type: toy, gpt2, or llama
 
 
 - toy: a small model with 8 linear layers.
-- gpt2: GPT2 model, model size is determined by arguments hiddien_size, head_num, layer_num, seq_length.
-- llama: Llama2 model, model size is determined by arguments hiddien_size, head_num, layer_num, seq_length.
+- gpt2: GPT2 model, model size is determined by arguments hidden_size, head_num, layer_num, seq_length.
+- llama: Llama2 model, model size is determined by arguments hidden_size, head_num, layer_num, seq_length.
 
-datasize: fake dataset size for training, default 200.
+Optional args:
 
-epoch: training epoch, default 2.
-
-hiddien_size: for llm (gpt2, llama) model, default 32.
-
-head_num: for llm (gpt2, llama) model, default 32.
-
-layer_num: for llm (gpt2, llama) model, default 32.
-
-seq_length: for llm (gpt2, llama) model, default 32.
-
-batchsize: total batchsize in one training iteration, default 8.
-
-user_created_dataloader: if set, auto_accelerate will not create dataloader, and user is responsible to provide dataloader. Default False.
-
-distributed: if set, running distributed training, default False.
-
-load_strategy: if set, set load_strategy to use semi-automatic mode, default False.
-
-optim_grouped_params: if set, use grouped params for optimizer, default False.
-
-log_interval: log print interval in training, default 10.
-
-use_fsdp: if set, add fsdp optimization method in load_strategy. Default False.
-
-use_amp: if set, add amp_native optimization method in load_strategy. Default False.
-
-use_checkpointing: if set, add checkpoint optimization method in load_strategy. Default False.
-
-use_module_replace: if set, add module_replace optimization method in load_strategy. Default False.
++ datasize: fake dataset size for training, default 200.
++ epoch: training epoch, default 2.
++ hidden_size: for llm (gpt2, llama) model, default 32.
++ head_num: for llm (gpt2, llama) model, default 32.
++ layer_num: for llm (gpt2, llama) model, default 32.
++ seq_length: for llm (gpt2, llama) model, default 32.
++ batchsize: total batchsize in one training iteration, default 8.
++ user_created_dataloader: if set, auto_accelerate will not create dataloader, and user is responsible to provide dataloader. Default False.
++ distributed: if set, running distributed training, default False.
++ load_strategy: if set, set load_strategy to use semi-automatic mode, default False.
++ optim_grouped_params: if set, use grouped params for optimizer, default False.
++ log_interval: log print interval in training, default 10.
++ use_fsdp: if set, add fsdp optimization method in load_strategy. Default False.
++ use_amp: if set, add amp_native optimization method in load_strategy. Default False.
++ use_checkpointing: if set, add checkpoint optimization method in load_strategy. Default False.
++ use_module_replace: if set, add module_replace optimization method in load_strategy. Default False.
 
 To launch distributed training, such as 8 process per node training for llama,  run:
 
@@ -75,10 +62,10 @@ python -m atorch.distributed.run --nproc_per_node 2 train.py --model_type toy --
 Train gpt2 model in semi-automatic mode, using (fsdp, amp_native, module_replace) optimization strategy.
 
 ```
-python -m atorch.distributed.run --nproc_per_node 8  train.py --model_type gpt2 --distributed --hiddien_size 64 --head_num 4 --layer_num 4 --seq_length 32 --load_strategy --use_fsdp --use_amp --use_module_replace
+python -m atorch.distributed.run --nproc_per_node 8  train.py --model_type gpt2 --distributed --hidden_size 64 --head_num 4 --layer_num 4 --seq_length 32 --load_strategy --use_fsdp --use_amp --use_module_replace
 ```
 
 Train llama model in semi-automatic mode, using (fsdp, amp_native, module_replace, checkpoint) optimization strategy, and user provides dataloader.
 ```
-python -m atorch.distributed.run  --nproc_per_node 8  train.py --model_type llama --distributed --hiddien_size 64 --head_num 4 --layer_num 4 --seq_length 32 --load_strategy --use_fsdp --use_amp --use_module_replace --use_checkpointing --user_created_dataloader
+python -m atorch.distributed.run  --nproc_per_node 8  train.py --model_type llama --distributed --hidden_size 64 --head_num 4 --layer_num 4 --seq_length 32 --load_strategy --use_fsdp --use_amp --use_module_replace --use_checkpointing --user_created_dataloader
 ```

--- a/atorch/examples/auto_accelerate/README.md
+++ b/atorch/examples/auto_accelerate/README.md
@@ -12,7 +12,7 @@
 ## Usage
 
 ```
-train.py [-h] --model_type MODEL_TYPE [--datasize DATASIZE] [--epoch EPOCH] [--hidden_size hidden_size] [--head_num HEAD_NUM] [--layer_num LAYER_NUM] [--seq_length SEQ_LENGTH] [--batchsize BATCHSIZE] [--distributed] [--user_created_dataloader] [--load_strategy] [--optim_grouped_params] [--log_interval LOG_INTERVAL] [--use_fsdp] [--use_amp] [--use_checkpointing] [--use_module_replace]
+train.py [-h] --model_type MODEL_TYPE [--datasize DATASIZE] [--epoch EPOCH] [--hidden_size HIDDEN_SIZE] [--head_num HEAD_NUM] [--layer_num LAYER_NUM] [--seq_length SEQ_LENGTH] [--batchsize BATCHSIZE] [--distributed] [--user_created_dataloader] [--load_strategy] [--optim_grouped_params] [--log_interval LOG_INTERVAL] [--use_fsdp] [--use_amp] [--use_checkpointing] [--use_module_replace]
 ```
 
 model_type: toy, gpt2, or llama

--- a/atorch/examples/auto_accelerate/README.md
+++ b/atorch/examples/auto_accelerate/README.md
@@ -23,20 +23,35 @@ model_type: toy, gpt2, or llama
 - llama: Llama2 model, model size is determined by arguments hiddien_size, head_num, layer_num, seq_length.
 
 datasize: fake dataset size for training, default 200.
+
 epoch: training epoch, default 2.
+
 hiddien_size: for llm (gpt2, llama) model, default 32.
+
 head_num: for llm (gpt2, llama) model, default 32.
+
 layer_num: for llm (gpt2, llama) model, default 32.
+
 seq_length: for llm (gpt2, llama) model, default 32.
+
 batchsize: total batchsize in one training iteration, default 8.
+
 user_created_dataloader: if set, auto_accelerate will not create dataloader, and user is responsible to provide dataloader. Default False.
+
 distributed: if set, running distributed training, default False.
+
 load_strategy: if set, set load_strategy to use semi-automatic mode, default False.
+
 optim_grouped_params: if set, use grouped params for optimizer, default False.
+
 log_interval: log print interval in training, default 10.
+
 use_fsdp: if set, add fsdp optimization method in load_strategy. Default False.
+
 use_amp: if set, add amp_native optimization method in load_strategy. Default False.
+
 use_checkpointing: if set, add checkpoint optimization method in load_strategy. Default False.
+
 use_module_replace: if set, add module_replace optimization method in load_strategy. Default False.
 
 To launch distributed training, such as 8 process per node training for llama,  run:

--- a/atorch/examples/auto_accelerate/modeling.py
+++ b/atorch/examples/auto_accelerate/modeling.py
@@ -112,7 +112,7 @@ def get_model(model_type, config):
         return model
 
     # llms
-    hidden_size = config["hiddien_size"]
+    hidden_size = config["hidden_size"]
     head_num = config["head_num"]
     layer_num = config["layer_num"]
     seq_length = config["seq_length"]

--- a/atorch/examples/auto_accelerate/train.py
+++ b/atorch/examples/auto_accelerate/train.py
@@ -28,12 +28,12 @@ def optim_grouped_param_func(model):
     return parameters
 
 
-def argsparse_():
+def parse_args():
     parser = argparse.ArgumentParser(description="Process arguments")
     parser.add_argument("--model_type", type=str, required=True)
     parser.add_argument("--datasize", type=int, default=200, required=False)
     parser.add_argument("--epoch", type=int, default=2, required=False)
-    parser.add_argument("--hidden_size", type=int, default=32, required=False)
+    parser.add_argument("--hiddien_size", type=int, default=32, required=False)
     parser.add_argument("--head_num", type=int, default=4, required=False)
     parser.add_argument("--layer_num", type=int, default=3, required=False)
     parser.add_argument("--seq_length", type=int, default=16, required=False)
@@ -69,7 +69,7 @@ def train(args):
 
     # get model, loss_func,
     model_config = {
-        "hidden_size": args.hidden_size,
+        "hiddien_size": args.hiddien_size,
         "head_num": args.head_num,
         "layer_num": args.layer_num,
         "seq_length": args.seq_length,

--- a/atorch/examples/auto_accelerate/train.py
+++ b/atorch/examples/auto_accelerate/train.py
@@ -28,12 +28,12 @@ def optim_grouped_param_func(model):
     return parameters
 
 
-def parse_args():
+def argsparse_():
     parser = argparse.ArgumentParser(description="Process arguments")
     parser.add_argument("--model_type", type=str, required=True)
     parser.add_argument("--datasize", type=int, default=200, required=False)
     parser.add_argument("--epoch", type=int, default=2, required=False)
-    parser.add_argument("--hiddien_size", type=int, default=32, required=False)
+    parser.add_argument("--hidden_size", type=int, default=32, required=False)
     parser.add_argument("--head_num", type=int, default=4, required=False)
     parser.add_argument("--layer_num", type=int, default=3, required=False)
     parser.add_argument("--seq_length", type=int, default=16, required=False)
@@ -69,7 +69,7 @@ def train(args):
 
     # get model, loss_func,
     model_config = {
-        "hiddien_size": args.hiddien_size,
+        "hidden_size": args.hidden_size,
         "head_num": args.head_num,
         "layer_num": args.layer_num,
         "seq_length": args.seq_length,


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix the dependency of atorch.

### Why are the changes needed?

When I executed `pip install -r requirements.txt` before pretraining Llama2. I received an error message:

ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
atorch 0.1.5 requires fsspec==2023.1.0, but you have fsspec 2023.10.0 which is incompatible.

### Does this PR introduce any user-facing change?

NO.

### How was this patch tested?

UT.
