### PR TITLE
Set grpcio-tools==1.58.0 support Python > 3.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@
 from setuptools import find_packages, setup
 
 install_requires = [
-    "grpcio-tools==1.60.0",
+    "grpcio-tools>=1.58.0",
     "psutil",
     "pynvml",
     "urllib3<1.27,>=1.21.1",

--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,7 @@
 from setuptools import find_packages, setup
 
 install_requires = [
-    "grpcio-tools==1.34.1",
-    "protobuf>=3.15.3,<4.0dev",
+    "grpcio-tools==1.60.0",
     "psutil",
     "pynvml",
     "urllib3<1.27,>=1.21.1",


### PR DESCRIPTION
### What changes were proposed in this pull request?
Set grpcio-tools==1.16.0 

### Why are the changes needed?

Python 3.10 cannot install  grpcio-tools==1.34.1.
### Does this PR introduce any user-facing change?

No.
### How was this patch tested?

Python setup.py bdist_wheel and pip install.