### PR TITLE
Fix llama2 scripts.

### DIFF
--- a/atorch/examples/llama2/README.md
+++ b/atorch/examples/llama2/README.md
@@ -23,10 +23,10 @@ cd dlrover/atorch/examples/Llama2
 pip install -r requirements.txt
 
 # Configurable environment variable: DATASET_PATH, MODEL_NAME_OR_PATH, PER_DEVICE_TRAIN_BATCH_SIZE, etc.
-sh fsdp_llama2_entry.sh
+bash fsdp_llama2_entry.sh
 
 # use lora
-USE_LORA=1 sh fsdp_llama2_entry.sh
+USE_LORA=1 bash fsdp_llama2_entry.sh
 ```
 
 ### Fine-tuning or Pre-training
@@ -401,8 +401,8 @@ pip install -r requirements.txt
 # Configurable environment variable: 
 # DATASET_PATH, MODEL_NAME_OR_PATH, PIPELINE_PARALLEL_SIZE, MODEL_PARALLEL_SIZE, etc.
 # e.x. in a 8-gpu system, to run mp-2 dp-2 pp-2, 
-# use `PIPELINE_PARALLEL_SIZE=2 MODEL_PARALLEL_SIZE=2 sh ds_3d_llama2_entry.sh`
-sh ds_3d_llama2_entry.sh
+# use `PIPELINE_PARALLEL_SIZE=2 MODEL_PARALLEL_SIZE=2 bash ds_3d_llama2_entry.sh`
+bash ds_3d_llama2_entry.sh
 ```
 
 ### Performance
@@ -446,7 +446,7 @@ cd dlrover/atorch/examples/Llama2
 
 # Configurable environment variable: DATASET_PATH, MODEL_NAME_OR_PATH, PER_DEVICE_TRAIN_BATCH_SIZE, etc.
 # Change BO_SG_MAX_IETR(the maximum search rounds of the BO), RANDOM_SAMPLE(the initial sampling steps of BO) if needed.
-sh bayes_opt_sg_llama2_entry.sh
+bash bayes_opt_sg_llama2_entry.sh
 
 ```
 

--- a/atorch/examples/llama2/dataset_model.sh
+++ b/atorch/examples/llama2/dataset_model.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 HOME=$(echo ~)
 
 # Dataset path, would download in `example_utils.py` if not exist
@@ -17,7 +19,7 @@ if ! [[ -d $MODEL_NAME_OR_PATH && \
   git clone https://github.com/shawwn/llama-dl.git
   pushd llama-dl
   sed 's/MODEL_SIZE="7B,13B,30B,65B"/MODEL_SIZE="'$MODEL_SIZE'"/g' llama.sh > llama$MODEL_SIZE.sh
-  sh llama$MODEL_SIZE.sh
+  bash llama$MODEL_SIZE.sh
   pip install transformers sentencepiece
   python -m transformers.models.llama.convert_llama_weights_to_hf --input_dir=. --model_size=$MODEL_SIZE --output_dir=$MODEL_NAME_OR_PATH
   popd

--- a/atorch/examples/llama2/ds_3d_llama2_entry.sh
+++ b/atorch/examples/llama2/ds_3d_llama2_entry.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 set -x
 
 source ./dataset_model.sh

--- a/atorch/examples/llama2/fsdp_llama2_entry.sh
+++ b/atorch/examples/llama2/fsdp_llama2_entry.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 set -x
 
 source ./dataset_model.sh


### PR DESCRIPTION
### What changes were proposed in this pull request?

Change sh to bash.

### Why are the changes needed?

When I execute `sh fsdp_llama2_entry.sh`, I get many errors, for example : 
+ fsdp_llama2_entry.sh: 3: source: not found
+ [[: not found

Because some shells (such as sh, dash, etc.) may not support these commands.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

Execute `bash fsdp_llama2_entry.sh`.
