### PR TITLE
Add RLHF 

### DIFF
--- a/atorch/atorch/__init__.py
+++ b/atorch/atorch/__init__.py
@@ -1,13 +1,7 @@
 import logging
 import os
-from importlib.metadata import version
 
 from .distributed.distributed import coworker_size, init_distributed, local_rank, rank, reset_distributed, world_size
-
-try:
-    __version__ = version("atorch")
-except ImportError:
-    __version__ = "0.0.1dev"
 
 os.environ["PIPPY_PIN_DEVICE"] = "0"
 

--- a/atorch/atorch/auto/accelerate.py
+++ b/atorch/atorch/auto/accelerate.py
@@ -12,6 +12,8 @@ from atorch.auto.analyser.analyser import get_analyser
 from atorch.auto.auto_accelerate_context import AutoAccelerateContext
 from atorch.auto.device_context import get_device_context
 from atorch.auto.dry_runner.dry_runner import get_dryrunner
+from atorch.auto.engine.acceleration_engine import AccelerationEngine
+from atorch.auto.engine_client import EngineClient
 from atorch.auto.model_context import ModelContext
 from atorch.auto.opt_lib.ds_3d_parallel_optimization import get_ds_dtype
 from atorch.auto.opt_lib.optimization_library import SEMIAUTO_STRATEGIES, OptimizationLibrary
@@ -580,8 +582,6 @@ def auto_accelerate(
         if strategy is not None:
             strategy = strategy.convert_strategy_to_easydl_format()
         # create AccelerationEngine instance
-        from atorch.auto.engine.acceleration_engine import AccelerationEngine
-
         engine = AccelerationEngine(
             device_context.context,
             included_opts=included,
@@ -600,8 +600,6 @@ def auto_accelerate(
         torch.distributed.broadcast(bcast_port, src=0)
         engine_port = bcast_port.item()
     engine_addr = os.getenv("MASTER_ADDR", "localhost")
-    from atorch.auto.engine_client import EngineClient
-
     engine_client = EngineClient(engine_addr, str(engine_port))
 
     while True:

--- a/atorch/atorch/auto/model_context.py
+++ b/atorch/atorch/auto/model_context.py
@@ -383,8 +383,8 @@ class ModelContext(object):
 
         # model must on cuda device before calling OSS (zero2)
         if "zero2" in self.post_wrappers or "ds_zero" in self.post_wrappers:
-            is_cuda = next(self.model.parameters()).is_cuda
-            if torch.cuda.is_available() and not is_cuda:
+            model_device = next(self.model.parameters()).device
+            if torch.cuda.is_available() and model_device.type != "cuda":
                 if local_rank() is not None:
                     device = torch.device(type="cuda", index=local_rank())
                 else:
@@ -430,9 +430,9 @@ class ModelContext(object):
             and "fsdp" not in self.pre_wrappers
             and "ds_3d_parallel" not in self.post_wrappers
         ):
-            is_cuda = next(self.model.parameters()).is_cuda
+            model_device = next(self.model.parameters()).device
             # model must on cuda device before calling BF16Optimizer
-            if torch.cuda.is_available() and not is_cuda:
+            if torch.cuda.is_available() and model_device.type != "cuda":
                 if local_rank() is not None:
                     device = torch.device(type="cuda", index=local_rank())
                 else:
@@ -480,26 +480,11 @@ class ModelContext(object):
         else:
             self.post_wrapper_applied = True
 
+    # Order of execution:
+    # Pipe (with amp, to graph only) -> TP -> Checkpoint (if not Pipe)
+    # -> module replace -> amp (if no Pipe) -> Pipe (to driver)
     def adjust_wrappers(self):
-        """Adjust wrappers, remove incompatible wrappers.
-        pre-wrapper order:
-         - half
-         - module_replace
-         - fp8
-         - fsdp
-         - native_dynamo (if not moved to post-wrapper)
-         post-wrapper list (no order):
-         - zero2
-         - ds_zero
-         - amp_native (ignored if half exists)
-         - checkpoint
-         - ds_3d_parallel
-         - ddp
-        """
-        if "amp_native" in self.post_wrappers and "half" in self.pre_wrappers:
-            logger.info("Both half and amp_native are used, amp_native is removed.")
-            self.post_wrappers.pop("amp_native")
-
+        """Adjust wrappers, remove incompatible wrappers"""
         # Pipeline parallelism is conditionally compatible with tensor parallel compilation.
         # To mix pipe and tp, use MixedParallelOptimization instead.
         # We assume MP does not coexists with Pipe/TP
@@ -509,6 +494,8 @@ class ModelContext(object):
             logger.info("Found pipe wrapper, remove all ddp related wrappers")
             if "zero2" in self.pre_wrappers:
                 self.pre_wrappers.pop("zero2")
+            if "zero1" in self.pre_wrappers:
+                self.pre_wrappers.pop("zero1")
             if "fsdp" in self.pre_wrappers:
                 self.pre_wrappers.pop("fsdp")
 
@@ -517,9 +504,6 @@ class ModelContext(object):
                 self.post_wrappers.pop("ddp")
 
         if pipe_wrapper_exist:
-            # Order of execution:
-            # Pipe (with amp, to graph only) -> TP -> Checkpoint (if not Pipe)
-            # -> module replace -> amp (if no Pipe) -> Pipe (to driver)
             if "checkpoint" in self.post_wrappers:
                 ckpt_wrapper = self.post_wrappers.pop("checkpoint")
                 pipe_config = self.pre_wrappers["pipe"][1] or {}
@@ -613,20 +597,36 @@ class ModelContext(object):
                 config,
             )
 
-        # move dynamo_native wrapper behind ddp or fsdp (fsdp will adjusted later)
+        # move dynamo_native wrapper behind ddp or fsdp
         # Note that dynamo_native wrapper and fsdp wrapper are pre-wrappers while ddp wrapper is a post-wrapper.
-        if native_dynamo_wrapper_exist and ddp_wrapper_exist and not fsdp_wrapper_exist:
-            # ddp wrapper is a post-wrapper. Popping dynamo_native wrapper from pre-wrappers
-            # then insert it after ddp wrapper.
-            post_wrappers_list = []
-            ddp_wrapper_index = -1
-            for i, (wrapper_name, v) in enumerate(self.post_wrappers.items()):
-                post_wrappers_list.append((wrapper_name, v))
-                if wrapper_name == "ddp":
-                    ddp_wrapper_index = i
-                native_dynamo_wrapper = self.pre_wrappers.pop("native_dynamo")
-                post_wrappers_list.insert(ddp_wrapper_index + 1, ("native_dynamo", native_dynamo_wrapper))
-            self.post_wrappers = dict(post_wrappers_list)
+        if native_dynamo_wrapper_exist:
+            if fsdp_wrapper_exist:
+                # both dynamo_native wrapper and fsdp wrapper are pre-wrappers
+                native_dynamo_wrapper_index, fsdp_wrapper_index = -1, -1
+                pre_wrappers_list = []
+                for i, (wrapper_name, v) in enumerate(self.pre_wrappers.items()):
+                    pre_wrappers_list.append((wrapper_name, v))
+                    if wrapper_name == "fsdp":
+                        fsdp_wrapper_index = i
+                    elif wrapper_name == "native_dynamo":
+                        native_dynamo_wrapper_index = i
+                if native_dynamo_wrapper_index < fsdp_wrapper_index:
+                    native_dynamo_wrapper = pre_wrappers_list[native_dynamo_wrapper_index]
+                    pre_wrappers_list.insert(fsdp_wrapper_index + 1, native_dynamo_wrapper)
+                    pre_wrappers_list.pop(native_dynamo_wrapper_index)
+                self.pre_wrappers = dict(pre_wrappers_list)
+            elif ddp_wrapper_exist:
+                # ddp wrapper is a post-wrapper. Popping dynamo_native wrapper from pre-wrappers
+                # then insert it after ddp wrapper.
+                post_wrappers_list = []
+                ddp_wrapper_index = -1
+                for i, (wrapper_name, v) in enumerate(self.post_wrappers.items()):
+                    post_wrappers_list.append((wrapper_name, v))
+                    if wrapper_name == "ddp":
+                        ddp_wrapper_index = i
+                    native_dynamo_wrapper = self.pre_wrappers.pop("native_dynamo")
+                    post_wrappers_list.insert(ddp_wrapper_index + 1, ("native_dynamo", native_dynamo_wrapper))
+                self.post_wrappers = dict(post_wrappers_list)
 
         if tensor_parallel_wrapper_exist:
             wrap_cls = None
@@ -700,24 +700,6 @@ class ModelContext(object):
 
                 _insert_amp_config_for_tp_ckpt(amp_config)
 
-        # adjust pre_wrapper order
-        order_wrapper_name = ["half", "module_replace", "fp8", "fsdp", "native_dynamo"]
-        match_names = []
-        for name in self.pre_wrappers:
-            if name in order_wrapper_name:
-                match_names.append(name)
-        if len(order_wrapper_name) > 1:
-            ordered_wrappers = {}
-            for name in self.pre_wrappers:
-                if name not in match_names:
-                    ordered_wrappers[name] = self.pre_wrappers[name]
-                else:
-                    for wrapper_name in order_wrapper_name:
-                        if wrapper_name in match_names:
-                            match_names.remove(wrapper_name)
-                            ordered_wrappers[wrapper_name] = self.pre_wrappers[wrapper_name]
-            self.pre_wrappers = ordered_wrappers
-
     def add_wrapper(self, wrapper_name, wrapper_func, wrapper_config=None, is_pre_wrapper=True):
         """
         wrapper_name: name of the wrapper
@@ -749,7 +731,7 @@ class ModelContext(object):
         if self.check_pipe_model():
             return True
         for p in self.model.parameters():
-            if p.is_cuda:
+            if p.device.type == "cuda":
                 return True
         return False
 

--- a/atorch/atorch/auto/opt_lib/amp_optimization.py
+++ b/atorch/atorch/auto/opt_lib/amp_optimization.py
@@ -1,6 +1,5 @@
 import collections
 import copy
-import types
 from functools import partialmethod, wraps
 
 import torch
@@ -8,7 +7,6 @@ from fairscale.nn.data_parallel import ShardedDataParallel as ShardedDDP
 from torch.cuda.amp import GradScaler, autocast
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 
-import atorch
 from atorch.distributed.distributed import parallel_group
 from atorch.utils.grad_scaler import BF16GradScaler, BF16ShardedGradScaler
 from atorch.utils.version import torch_version
@@ -18,6 +16,7 @@ if torch_version() >= (1, 12, 0):
 
 else:
     from fairscale.optim.grad_scaler import ShardedGradScaler
+
 
 from atorch.auto.auto_accelerate_context import AutoAccelerateContext
 from atorch.auto.opt_lib.optimization import Optimization
@@ -167,202 +166,3 @@ class AmpNativeOptimizer(torch.optim.Optimizer):
 
     def __setstate__(self, state):
         return self.optimizer.__setstate__(state)
-
-
-# RNG tracker object with lazy init.
-_CUDA_RNG_STATE_TRACKER = None
-
-
-def get_cuda_rng_tracker():
-    global _CUDA_RNG_STATE_TRACKER
-    if _CUDA_RNG_STATE_TRACKER is None:
-        from transformer_engine.pytorch.distributed import CudaRNGStatesTracker
-
-        _CUDA_RNG_STATE_TRACKER = CudaRNGStatesTracker()
-    return _CUDA_RNG_STATE_TRACKER
-
-
-def is_fp8_available():
-    if not torch.cuda.is_available():
-        return False
-    # GPU sm version >= 8.9 (Ada, Hopper, etc)
-    device_capability = torch.cuda.get_device_capability()
-    return isinstance(device_capability, tuple) and device_capability >= (8, 9)
-
-
-class Fp8Optimization(Optimization):
-    def __init__(self):
-        super().__init__("fp8", "amp", False)
-
-    def tune(self, model_context, config=None, strategy=None, apply_transform=True, time_limit=None):
-        if apply_transform:
-            model_context = self.transform(model_context, config)
-        return True, config, model_context
-
-    def transform(self, model_context, config=None):
-        if not is_fp8_available():
-            logger.warning("No fp8-capable devices available, fp8 optimization is ignored!")
-            return model_context
-
-        model_context.add_wrapper("fp8", Fp8Optimization.apply_wrapper, config, is_pre_wrapper=True)
-        return model_context
-
-    @staticmethod
-    def apply_wrapper(model_context, wrapper_name, wrapper_config=None):
-        """config:
-        include: List[str], default None.
-            If None, all nn.Linear module would use te.
-            If not None, nn.Linear module's name should have at least one substring equals to items in include.
-        exclude: List[str], default None.
-            If None, all modules that passing include test would use te.
-            If not None, if a nn.Linear module's name has at least one substring matches exclude, it will not use te.
-        recipe.DelayedScaling's parameter:
-            margin: default 0
-            interval: default 1
-            fp8_format: "HYBRID" (default) or "E4M3"
-            amax_history_len: default 1024
-            amax_compute_algo: “max” (default) or “most_recent”
-            reduce_amax: default True
-        """
-        import transformer_engine.pytorch as te
-        from transformer_engine.common import recipe
-        from transformer_engine.pytorch.utils import check_dim_for_fp8_exec
-
-        config = {} if wrapper_config is None else wrapper_config
-        include = config.get("include", None)
-        exclude = config.get("exclude", None)
-        margin = config.get("margin", 0)
-        interval = config.get("interval", 1)
-        fp8_format = config.get("fp8_format", "HYBRID").upper()
-        amax_history_len = config.get("amax_history_len", 1024)
-        amax_compute_algo = config.get("amax_compute_algo", "max")
-        reduce_amax = config.get("reduce_amax", True)
-        if fp8_format == "HYBRID":
-            fp8_format_type = recipe.Format.HYBRID
-        elif fp8_format == "E4M3":
-            fp8_format_type = recipe.Format.E4M3
-        else:
-            raise f"fp8_format only supports HYBRID and E4M3, not {fp8_format}"
-        verbose = config.get("verbose", False)
-
-        def check_if_replace(key, module, m_include, m_exclude):
-            # return (if_replace, if_excluded, if_shape_incompatible)
-            if not isinstance(module, torch.nn.Linear):
-                return False, False, False
-            pass_check = False
-            if m_exclude is not None:
-                for name in m_exclude:
-                    if name in key:
-                        return False, True, False
-            if m_include is not None:
-                for name in m_include:
-                    if name in key:
-                        pass_check = True
-                        break
-                if not pass_check:
-                    return False, False, False
-            # Backward computation would use transposed weight, so also check transposed weight shape.
-            transposed_shape = torch.Size(
-                [module.weight.shape[1], module.weight.shape[0]] + list(module.weight.shape[2:])
-            )
-            backward_weight = torch.empty(transposed_shape, device="meta")
-            if check_dim_for_fp8_exec(module.weight) and check_dim_for_fp8_exec(backward_weight):
-                return True, False, False
-            else:
-                return False, False, True
-
-        def get_te_module(module):
-            config = {}
-            new_module = None
-            if isinstance(module, torch.nn.Linear):
-                config["in_features"] = module.in_features
-                config["out_features"] = module.out_features
-                config["bias"] = hasattr(module, "bias") and module.bias is not None
-                config["params_dtype"] = module.weight.dtype
-                config["device"] = module.weight.device
-                new_module = te.Linear(**config)
-                with torch.no_grad():
-                    new_module.weight.copy_(module.weight)
-                    if hasattr(module.weight, "checkpoint_name"):
-                        value = getattr(module.weight, "checkpoint_name")
-                        setattr(new_module.weight, "checkpoint_name", value)
-                    if config["bias"]:
-                        new_module.bias.copy_(module.bias)
-                        if hasattr(module.bias, "checkpoint_name"):
-                            value = getattr(module.bias, "checkpoint_name")
-                            setattr(new_module.bias, "checkpoint_name", value)
-            return new_module
-
-        def replace_module_with_te(model, m_include, m_exclude):
-            replaced_num = 0
-            exclude_num = 0
-            shape_incompatible_num = 0
-            for key, module in model.named_modules():
-                if_replace, if_exclude, if_shape_incompatible = check_if_replace(key, module, m_include, m_exclude)
-                if if_replace:
-                    new_module = get_te_module(module)
-                    parent = model.get_submodule(".".join(key.split(".")[:-1]))
-                    target_name = key.split(".")[-1]
-                    setattr(parent, target_name, new_module)
-                    replaced_num += 1
-                    if verbose and atorch.local_rank() in (0, None):
-                        logger.info(f"Replacing {key} with te.Linear.")
-                if if_exclude:
-                    exclude_num += 1
-                if if_shape_incompatible:
-                    shape_incompatible_num += 1
-            return replaced_num, exclude_num, shape_incompatible_num
-
-        # step 1: replace linear with te.Linear
-        te_module_num, te_exclude_num, te_shape_incompatible_num = replace_module_with_te(
-            model_context.model, include, exclude
-        )
-        if te_module_num == 0:
-            logger.warning(
-                "No modules are using fp8, {} excluded, {} shape incompatible".format(
-                    te_exclude_num, te_shape_incompatible_num
-                )
-            )
-            return model_context
-        else:
-            logger.info(
-                "[fp8] {} modules replaced by te.Linear, {} excluded, {} shape incompatible".format(
-                    te_module_num, te_exclude_num, te_shape_incompatible_num
-                )
-            )
-
-        # step 2: fp8_autocast forward, loss_func
-        fp8_recipe = recipe.DelayedScaling(
-            margin=margin,
-            interval=interval,
-            fp8_format=fp8_format_type,
-            amax_history_len=amax_history_len,
-            amax_compute_algo=amax_compute_algo,
-            reduce_amax=reduce_amax,
-        )
-
-        ori_forward_func = model_context.model.forward
-
-        def fp8_run_method(self, *args, **kargs):
-            # TODO: set fp8_group properly if reduce_amax is True and tp is used
-            with te.fp8_autocast(enabled=True, fp8_recipe=fp8_recipe):
-                return ori_forward_func(*args, **kargs)
-
-        model_context.model.forward = types.MethodType(fp8_run_method, model_context.model)
-
-        if model_context.loss_func is not None:
-            old_loss_func = model_context.loss_func
-
-            def fp8_run(*args, **kargs):
-                with te.fp8_autocast(enabled=True, fp8_recipe=fp8_recipe):
-                    return old_loss_func(*args, **kargs)
-
-            model_context.loss_func = fp8_run
-
-        # step 3: record fp8_enabled for checkpoint optimization
-        if hasattr(AutoAccelerateContext, "fp8_enabled"):
-            AutoAccelerateContext.fp8_enabled.update({AutoAccelerateContext.counter: True})
-        else:
-            AutoAccelerateContext.add_ac_attr("fp8_enabled", {AutoAccelerateContext.counter: True})
-
-        return model_context

--- a/atorch/atorch/auto/opt_lib/checkpoint_optimization.py
+++ b/atorch/atorch/auto/opt_lib/checkpoint_optimization.py
@@ -113,64 +113,37 @@ class CheckpointOptimization(Optimization):
                     checkpoint_wrapper,
                 )
 
-                fp8_enabled = hasattr(AutoAccelerateContext, "fp8_enabled") and AutoAccelerateContext.fp8_enabled.get(
-                    AutoAccelerateContext.counter, False
+                # check by signature of func
+                params = inspect.signature(checkpoint_wrapper).parameters
+                need_patch = params["checkpoint_impl"].default != CheckpointImpl.NO_REENTRANT
+
+                assert other_config is not None  # for mypy
+                # default to `need_patch`
+                no_reentrant = other_config.pop("no_reentrant", need_patch)
+                selective_offload = other_config.pop("selective_offload", None)
+                checkpoint_impl = CheckpointImpl.NO_REENTRANT if no_reentrant else CheckpointImpl.REENTRANT
+                checkpoint_wrapper_fn_kwargs = {"checkpoint_impl": checkpoint_impl}
+                if selective_offload is not None:
+                    if checkpoint_impl == CheckpointImpl.REENTRANT:
+                        raise ValueError("selective offloading don't support `CheckpointImpl.REENTRANT`")
+                    if "offload_args" not in selective_offload or "num_layers" not in selective_offload:
+                        raise ValueError("`offload_args` or `num_layers` is not passed")
+
+                    from .selective_offloading_checkpoint import (
+                        OffloadOpManagerArgs,
+                        get_selective_offloading_checkpoint_modes,
+                    )
+
+                    args = [OffloadOpManagerArgs(*arg) for arg in selective_offload["offload_args"]]
+                    num_layers = selective_offload["num_layers"]
+                    context_fn = get_selective_offloading_checkpoint_modes(args, num_layers)
+                    checkpoint_wrapper_fn_kwargs["context_fn"] = context_fn
+                    logger.info(f"selective_offloading_checkpoint is on, {selective_offload}")
+
+                checkpoint_wrapper_fn = partial(checkpoint_wrapper, **checkpoint_wrapper_fn_kwargs)
+                apply_activation_checkpointing = partial(
+                    apply_activation_checkpointing, checkpoint_wrapper_fn=checkpoint_wrapper_fn
                 )
-
-                if fp8_enabled:
-                    # use te checkpoint
-                    from transformer_engine.pytorch.distributed import CudaRNGStatesTracker
-                    from transformer_engine.pytorch.distributed import checkpoint as te_checkpoint
-
-                    # patch te checkpoint to support non-tensor inputs/outputs
-                    from atorch.utils.patch_te import patch_te
-
-                    patch_te()
-
-                    _CUDA_RNG_STATE_TRACKER = CudaRNGStatesTracker()
-
-                    def get_cuda_rng_tracker():
-                        return _CUDA_RNG_STATE_TRACKER
-
-                    def te_checkpoint_func(m, *args, **kargs):
-                        return te_checkpoint(m, False, get_cuda_rng_tracker, None, *args, **kargs)
-
-                    checkpoint_wrapper_fn = partial(checkpoint_wrapper, checkpoint_fn=te_checkpoint_func)
-                    apply_activation_checkpointing = partial(
-                        apply_activation_checkpointing, checkpoint_wrapper_fn=checkpoint_wrapper_fn
-                    )
-                else:
-                    # check by signature of func
-                    params = inspect.signature(checkpoint_wrapper).parameters
-                    need_patch = params["checkpoint_impl"].default != CheckpointImpl.NO_REENTRANT
-
-                    assert other_config is not None  # for mypy
-                    # default to `need_patch`
-                    no_reentrant = other_config.pop("no_reentrant", need_patch)
-                    selective_offload = other_config.pop("selective_offload", None)
-                    checkpoint_impl = CheckpointImpl.NO_REENTRANT if no_reentrant else CheckpointImpl.REENTRANT
-                    checkpoint_wrapper_fn_kwargs = {"checkpoint_impl": checkpoint_impl}
-                    if selective_offload is not None:
-                        if checkpoint_impl == CheckpointImpl.REENTRANT:
-                            raise ValueError("selective offloading don't support `CheckpointImpl.REENTRANT`")
-                        if "offload_args" not in selective_offload or "num_layers" not in selective_offload:
-                            raise ValueError("`offload_args` or `num_layers` is not passed")
-
-                        from .selective_offloading_checkpoint import (
-                            OffloadOpManagerArgs,
-                            get_selective_offloading_checkpoint_modes,
-                        )
-
-                        args = [OffloadOpManagerArgs(*arg) for arg in selective_offload["offload_args"]]
-                        num_layers = selective_offload["num_layers"]
-                        context_fn = get_selective_offloading_checkpoint_modes(args, num_layers)
-                        checkpoint_wrapper_fn_kwargs["context_fn"] = context_fn
-                        logger.info(f"selective_offloading_checkpoint is on, {selective_offload}")
-
-                    checkpoint_wrapper_fn = partial(checkpoint_wrapper, **checkpoint_wrapper_fn_kwargs)
-                    apply_activation_checkpointing = partial(
-                        apply_activation_checkpointing, checkpoint_wrapper_fn=checkpoint_wrapper_fn
-                    )
             except ImportError:
                 logger.warning("Checkpoint not supported, thus ignored!")
                 return model_context

--- a/atorch/atorch/auto/opt_lib/module_replace_optimization.py
+++ b/atorch/atorch/auto/opt_lib/module_replace_optimization.py
@@ -85,7 +85,7 @@ def _enable_flash_attn_by_attr(model):
     model.apply(lambda m: setattr(m, "use_fa", True) if hasattr(m, "use_fa") else None)
 
 
-def _replace_by_config(model, config=None, gpu_used=False, verbose=True):
+def _replace_by_config(model, config=None, gpu_used=False):
     global REPLACEMENT_PAIRS
     cur_dtype = (
         AutoAccelerateContext.half_precision_dtype[AutoAccelerateContext.counter]
@@ -104,7 +104,7 @@ def _replace_by_config(model, config=None, gpu_used=False, verbose=True):
     for pair_name in config:
         src_module_cls, tgt_module_cls, default_kwargs, _ = REPLACEMENT_PAIRS[pair_name]
         kwargs = default_kwargs if config[pair_name] is None else config[pair_name]
-        model = replace_module(model, src_module_cls, tgt_module_cls, verbose=verbose, **kwargs)
+        model = replace_module(model, src_module_cls, tgt_module_cls, **kwargs)
     # Handles device placement mismatch
     # In case modules are on meta, do nothing and assume defer init is enabled
     if (
@@ -155,8 +155,7 @@ class ModuleReplaceOptimization(Optimization):
         wrapper_config (Dict[str, Dict], optional): {pair_name: replace_config}
             if None, replace all supported pairs with default replace_config
         """
-        verbose = True if wrapper_config is None else wrapper_config.pop("verbose", True)
-        if wrapper_config is None or len(wrapper_config) == 0:
+        if wrapper_config is None:
             wrapper_config = _get_default_replace_config()
 
         tie_weights = {}
@@ -167,7 +166,7 @@ class ModuleReplaceOptimization(Optimization):
             model_context.model = model_context.model.to("meta")
 
         model_context.model = _replace_by_config(
-            model_context.model, config=wrapper_config, gpu_used=model_context.gpu_used, verbose=verbose
+            model_context.model, config=wrapper_config, gpu_used=model_context.gpu_used
         )
         _retie_weights(model_context.model, tie_weights)
         model = model_context.model

--- a/atorch/atorch/auto/opt_lib/optimization_library.py
+++ b/atorch/atorch/auto/opt_lib/optimization_library.py
@@ -1,4 +1,4 @@
-from atorch.auto.opt_lib.amp_optimization import AmpNativeOptimization, Fp8Optimization
+from atorch.auto.opt_lib.amp_optimization import AmpNativeOptimization
 from atorch.auto.opt_lib.checkpoint_optimization import CheckpointOptimization
 from atorch.auto.opt_lib.ds_3d_parallel_optimization import DeepSpeed3DParallelOptimization
 from atorch.auto.opt_lib.dynamo_optimization import NativeDynamoOptimization
@@ -9,7 +9,6 @@ from atorch.auto.opt_lib.parallel_mode_optimization import ParallelModeOptimizat
 from atorch.auto.opt_lib.pipeline_parallel_optimization import PipelineParallelOptimization
 from atorch.auto.opt_lib.tensor_parallel_optimization import TensorParallelOptimization
 from atorch.auto.opt_lib.zero_optimization import FSDPOptimization, Zero1Optimization, Zero2Optimization
-from atorch.common.log_utils import default_logger as logger
 
 SEMIAUTO_STRATEGIES = ("tensor_parallel", "mixed_parallel", "pipeline_parallel")
 
@@ -43,7 +42,6 @@ class OptimizationLibrary(object):
             FSDPOptimization,
             ParallelModeOptimization,
             AmpNativeOptimization,
-            Fp8Optimization,
             TensorParallelOptimization,
             ModuleReplaceOptimization,
             CheckpointOptimization,
@@ -67,6 +65,5 @@ class OptimizationLibrary(object):
                 or (opt.is_tunable is True and tunable is False and config is None)
             ):
                 valid = False
-                logger.error(f"Invalid optimization method: {name}")
                 break
         return valid

--- a/atorch/atorch/auto/opt_lib/selective_offloading_checkpoint.py
+++ b/atorch/atorch/auto/opt_lib/selective_offloading_checkpoint.py
@@ -121,7 +121,7 @@ class OffloadOpManager:
             return x
 
         def _detach_to_cpu(x):
-            if isinstance(x, torch.Tensor) and x.is_cuda:
+            if isinstance(x, torch.Tensor) and x.device.type == "cuda":
                 offload_event_queue.deque_event_and_synchronize()
                 tensor = x.detach()
                 copy_stream.wait_stream(current_stream)

--- a/atorch/atorch/data/__init__.py
+++ b/atorch/atorch/data/__init__.py
@@ -1,12 +1,6 @@
 from .coworker_dataset import build_coworker_dataloader
 from .data_utils import expand_batch_dim, get_sample_batch
-
-try:
-    from .elastic_dataloader import build_coworker_dataloader_with_elasticdl, get_elastic_dataloader
-except TypeError:
-    print("protobuf version mismatch. elastic_dataloader cannot be used")
-    build_coworker_dataloader_with_elasticdl = None
-    get_elastic_dataloader = None
+from .elastic_dataloader import build_coworker_dataloader_with_elasticdl, get_elastic_dataloader
 from .preloader import GpuPreLoader, data_to_device
 from .shm_context import ShmData, create_coworker_shm_context
 from .shm_dataloader import ShmDataloader, create_shm_dataloader

--- a/atorch/atorch/modules/transformer/inject.py
+++ b/atorch/atorch/modules/transformer/inject.py
@@ -3,7 +3,6 @@ import inspect
 import torch
 from deepspeed import DeepSpeedTransformerConfig
 
-import atorch
 from atorch.common.log_utils import default_logger as logger
 from atorch.modules.transformer.layers import MixPrecisionTransformerLayer
 from atorch.utils.meta_model_utils import empty_param, is_meta, recursive_empty_param, reload_meta_module
@@ -124,14 +123,7 @@ def replace_with_deepspeed_transformer(
 
 
 def replace_module(
-    model,
-    src_module_cls,
-    tgt_module_cls,
-    verbose=True,
-    config=None,
-    need_src_module=False,
-    init_from_attr=False,
-    bkup_ori=False,
+    model, src_module_cls, tgt_module_cls, config=None, need_src_module=False, init_from_attr=False, bkup_ori=False
 ):
     r"""replace model's src_module to tgt_module.
 
@@ -176,8 +168,7 @@ def replace_module(
         for name, child in model.named_children():
             child_name = cur_name + "." + name
             if isinstance(child, src_module_cls) and not isinstance(child, tgt_module_cls):
-                if verbose and atorch.local_rank() in (0, None):
-                    logger.info(f"REPLACING {src_module_cls} '{child_name}' to {tgt_module_cls}")
+                logger.info(f"REPLACING {src_module_cls} '{child_name}' to {tgt_module_cls}")
                 if need_src_module:
                     kwargs["src_module"] = child
                 if init_from_attr:

--- a/atorch/atorch/normalization/layernorm.py
+++ b/atorch/atorch/normalization/layernorm.py
@@ -203,7 +203,7 @@ class AtorchLayerNormFunc(torch.autograd.Function):
         # TODO: dtype=x.dtype will loss precision; but dtype=torch.float32 will be slow
         _dw = torch.empty((GROUP_SIZE_M, w.shape[0]), dtype=x.dtype, device=w.device)
 
-        # need store fp32 to keep acc
+        ## need store fp32 to keep acc
         dw = torch.empty((w.shape[0],), dtype=w.dtype, device=w.device)
         # db = torch.zeros((w.shape[0],), dtype=x.dtype, device=w.device)
         dx = torch.empty_like(dy)

--- a/atorch/atorch/npu/__init__.py
+++ b/atorch/atorch/npu/__init__.py
@@ -1,5 +1,4 @@
 import traceback
-from typing import Optional, Union
 
 from atorch.common.log_utils import default_logger as logger
 
@@ -11,33 +10,14 @@ except (ModuleNotFoundError, ImportError):
     logger.error(f"{traceback.format_exc()}")
 import torch
 
-_device_t = Union[torch.device, str, int, None]
 old_device_capability = torch.cuda.get_device_capability
 
 
-def new_device_capability(device: Optional[_device_t] = None):
-    """
-
-    Args:
-        device (torch.device or int, optional): device for which to return the
-            device capability. This function is a no-op if this argument is
-            a negative integer. It uses the current device, given by
-            :func:`~torch.cuda.current_device`, if :attr:`device` is ``None``
-            (default).
-    Returns:
-        tuple(int, int): the major and minor cuda capability of the device
-        (8, 0) for npu
-    """
-
-    if isinstance(device, (int, str)) or device is None:
-        return (8, 0)
-    if isinstance(device, torch.device) and device.type != "cpu":
+def new_device_capability(device):
+    if device.type != "cpu":
         return (8, 0)
     else:
         return old_device_capability(device)
-
-
-new_device_capability.__doc__ = old_device_capability.__doc__
 
 
 def npu_profile_context(*args, **kwargs):

--- a/atorch/atorch/requirements.txt
+++ b/atorch/atorch/requirements.txt
@@ -8,11 +8,11 @@ pyomo
 pynvml==11.4.1
 grpcio==1.34.1
 grpcio-tools==1.34.1
-fsspec==2023.10.0
+fsspec==2023.1.0
 pyarrow==12.0.0
 pandas==2.0.1
 tensorboard==2.11.0
-dlrover[torch]
+dlrover[torch]==0.3.5
 protobuf==3.20.3
 safetensors
 GPy

--- a/atorch/atorch/rl/config.md
+++ b/atorch/atorch/rl/config.md
@@ -1,0 +1,49 @@
+# Config file items
+
+Config contains three sections: model, tokenizer and train. 
+Below are items can be defined in these sections. More will be added.
+
+## train
+
+```
+epochs: <int> # default 1, train epoch for prompt data
+eg_batch_size: <int> # experience generation  batchsize
+rl_epochs: <int> # default 1, rl training epoch number
+rl_batch_size: <int> # rl training batchsize
+experience_buffer_size: <int> # the number of experience to collect before rl training.
+mode: <str> # sequential(default) or concurrent. If sequential, experience_generation followed by rl_training on same devices. If concurrent, experience_generation and rl_training running concurrently on different devices.
+trainer: <str> # default PPOTrainer
+strategy_file: <str> a python file defines optimization strategies for all models.
+
+```
+
+
+## model
+
+Model section contains a list of models, which defines 4 models, actor, critic, ref\_model and reward\_model, their optimization strategies, optimizers. Also supports weight sharing, so the model list is a subset of (actor, critic, ref_model, reward\_model, actor\_critic, actor\_criti\c_ref, reward\_critic, actor\_critic\_ref\_reward). If weight shared, the model class should provide corresponding forward funtions for each model forward, and multiple outputs in one forward function.
+
+
+```
+model:
+  actor:
+      model_path: <str> # Name of hf model to load or a directory of hf model, or a python file including the model definition.
+      model_cls: <str> # optional, if set, a class/function in the python file specified by model_path. Init/call this class/function would return a nn.Module.
+      model_params: # list of (key, value) for model params.
+      train_strategy: a function in train.strategy_file for training optimization strategy.
+      inference_strategy: a function in train.strategy_file for inference optimization strategy.
+      optimizer: 
+         name: <str>
+         kwargs: # list of 
+
+      
+```
+
+
+## tokenizer
+
+```
+tokenizer_path: <str> # path to tokenizer
+params: #list of (key, value) for tokenizer params. such as
+#  truncation_side: right
+      
+```

--- a/atorch/atorch/rl/config.py
+++ b/atorch/atorch/rl/config.py
@@ -1,0 +1,290 @@
+import copy
+from dataclasses import dataclass
+from typing import Any
+
+import yaml  # type: ignore[import]
+
+from atorch.rl.model_utils.model_util import is_trainable_model
+
+
+def recursive_transform_to_dict(value):
+    new_value = value
+    if hasattr(value, "to_dict"):
+        value = value.to_dict()
+
+    if isinstance(value, dict):
+        new_value = copy.deepcopy(value)
+        for k, v in value.items():
+            new_value[k] = recursive_transform_to_dict(v)
+    return new_value
+
+
+class Base:
+    def to_dict(self):
+        new_attr = {}
+        attr = self.__dict__
+        for k, v in attr.items():
+            v = recursive_transform_to_dict(v)
+            if not k.startswith("__") and not isinstance(v, classmethod):
+                new_attr[k] = v
+        return new_attr
+
+
+@dataclass
+class Optimizer(Base):
+    name: str
+    kwargs: dict
+
+    @classmethod
+    def from_dict(cls, config):
+        return cls(**config)
+
+
+@dataclass
+class GeneratationConfig(Base):
+    batch_size: int
+    gen_kwargs: dict
+    gen_experience_kwargs: dict
+
+    @classmethod
+    def update_config_with_default_value(cls, config):
+
+        default_value = {
+            "batch_size": 4,
+            "gen_kwargs": {"max_new_tokens": 512, "top_k": 0, "top_p": 1.0, "do_sample": False},
+            "gen_experience_kwargs": {
+                "max_new_tokens": 512,
+                "do_sample": False,
+                "temperature": 1.0,
+                "top_k": 50,
+                "top_p": 0.95,
+            },
+        }
+        for k, v in default_value.items():
+            if config.get(k) is None:
+                config[k] = v
+
+        return config
+
+    @classmethod
+    def from_dict(cls, config):
+        config = cls.update_config_with_default_value(config)
+        return cls(
+            batch_size=config["batch_size"],
+            gen_kwargs=config["gen_kwargs"],
+            gen_experience_kwargs=config["gen_experience_kwargs"],
+        )
+
+
+@dataclass
+class TrainConfig(Base):
+    seq_length: int
+    batch_size: int
+    epoch: int
+    num_rollouts: int
+    mode: str
+    trainer: str
+    logdir: str
+    scheduler: dict
+    eval_interval: int
+    checkpoint_interval: int
+    checkpoint_dir: str
+    gradient_accumulation_steps: int
+    max_grad_norm: Any
+
+    @classmethod
+    def update_config_with_default_value(cls, config):
+        default_value = {
+            "trainer": "PPOTrainer",
+            "logdir": "./tensorboard",
+            "mode": "Concurrent",
+            "seq_length": 1024,
+            "num_rollouts": 2048,
+            "batch_size": 1024,
+            "epoch": 100,
+            "scheduler": {
+                "name": "cosine_warmup",
+                "kwargs": {"num_warmup_steps": 640, "num_training_steps": 6400},
+            },
+            "eval_interval": 100,
+            "checkpoint_interval": 100,
+            "checkpoint_dir": "./checkpoint",
+            "gradient_accumulation_steps": 1,
+            "max_grad_norm": None,
+        }
+
+        for k, v in default_value.items():
+            if config.get(k) is None:
+                config[k] = v
+        return config
+
+    @classmethod
+    def from_dict(cls, config):
+        config = cls.update_config_with_default_value(config)
+        return cls(**config)
+
+
+@dataclass
+class TokenizerConfig(Base):
+    params: dict
+    tokenizer_path: str
+
+    @classmethod
+    def from_dict(cls, config):
+        return cls(**config)
+
+
+@dataclass
+class ModelConfig(Base):
+    model_path: str
+    model_cls: str
+    model_params: dict
+    train_strategy: str
+    inference_strategy: str
+    lazy_load: bool
+    peft_config: Any
+
+    @classmethod
+    def update_config_with_default_value(cls, config):
+        default_value = {
+            "model_params": {},
+            "train_strategy": "torch_native",
+            "lazy_load": False,
+            "inference_strategy": "torch_native",
+            "peft_config": None,
+        }
+        for k, v in default_value.items():
+            if config.get(k) is None:
+                config[k] = v
+        return config
+
+    @classmethod
+    def from_dict(cls, config):
+        config = cls.update_config_with_default_value(config)
+        return cls(**config)
+
+
+@dataclass
+class TrainableModelConfig(Base):
+    optimizer: Optimizer
+    model_path: str
+    model_cls: str
+    model_params: dict
+    peft_config: Any
+    train_strategy: str
+    inference_strategy: str
+    lazy_load: bool
+    loss: str
+
+    @classmethod
+    def update_config_with_default_value(cls, config):
+        default_value = {
+            "optimizer": {"name": "torch.optim.adam", "kwargs": {"betas": (0.9, 0.999)}},
+            "train_strategy": "torch_native",
+            "inference_strategy": "torch_native",
+            "lazy_load": False,
+            "model_params": {},
+            "loss": "",
+            "peft_config": None,
+        }
+        for k, v in default_value.items():
+            if config.get(k) is None:
+                config[k] = v
+        return config
+
+    @classmethod
+    def from_dict(cls, config):
+        config = cls.update_config_with_default_value(config)
+        optimizer = config["optimizer"]
+        optimizer = Optimizer.from_dict(optimizer)
+        config["optimizer"] = optimizer
+        return cls(**config)
+
+
+@dataclass
+class Model(Base):
+    model: dict
+
+    def __getattr__(cls, key):
+        return cls.model[key]
+
+
+@dataclass
+class PPOConfig(Base):
+    ppo_epoch: int
+    init_kl_coef: float
+    gamma: float
+    lam: float
+    cliprange: float
+    cliprange_value: float
+    vf_coef: float
+    cliprange_reward: float
+    ent_coef: float
+    horizon: float
+    clip_ratio: bool
+    scale_reward: str
+    ref_mean: Any
+    ref_std: Any
+
+    @classmethod
+    def update_config_with_default_value(self, config):
+        default_value = {"scale_reward": "running", "horizon": 10000.0}
+        for k, v in default_value.items():
+            if config.get(k) is None:
+                config[k] = v
+
+    @classmethod
+    def from_dict(cls, config):
+        cls.update_config_with_default_value(config["PPOConfig"])
+        return cls(**config["PPOConfig"])
+
+
+@dataclass
+class AtorchRLConfig(Base):
+    """
+    Top level config for atorch rlhf. Loads configs and can be converted to dictionary.
+    """
+
+    model: dict
+    ppo_config: PPOConfig
+    train: TrainConfig
+    generation: GeneratationConfig
+    model_keys: list
+    tokenizer: TokenizerConfig
+
+    @classmethod
+    def load_yaml(cls, yml_fp: str):
+        """
+        Load yaml file as ArorchRLConfig.
+        :param yml_fp: Path to yaml file
+        :type yml_fp: str
+        """
+        with open(yml_fp, mode="r") as file:
+            config = yaml.safe_load(file)
+        return cls.from_dict(config)
+
+    @classmethod
+    def update_config_with_default_value(cls, config):
+        return config
+
+    @classmethod
+    def from_dict(cls, config):
+        """
+        Convert dictionary to TRLConfig.
+        """
+        cls.update_config_with_default_value(config)
+        model_keys = [i for i in config["model"].keys()]
+        model = {}
+        for m in model_keys:
+            if is_trainable_model(m):
+                model.update({m: TrainableModelConfig.from_dict(config["model"].get(m))})
+            else:
+                model.update({m: ModelConfig.from_dict(config["model"].get(m))})
+        return cls(
+            model=Model(model=model),
+            ppo_config=PPOConfig.from_dict(config["method"]),
+            tokenizer=TokenizerConfig.from_dict(config["tokenizer"]),
+            train=TrainConfig.from_dict(config["train"]),
+            generation=GeneratationConfig.from_dict(config["generation"]),
+            model_keys=model_keys,
+        )

--- a/atorch/atorch/rl/data/__init__.py
+++ b/atorch/atorch/rl/data/__init__.py
@@ -1,0 +1,1 @@
+from .data_utils import create_dataset

--- a/atorch/atorch/rl/data/data_utils.py
+++ b/atorch/atorch/rl/data/data_utils.py
@@ -1,0 +1,205 @@
+from dataclasses import dataclass
+
+import torch
+from torch.nn.utils.rnn import pad_sequence
+from torch.utils.data import DataLoader
+from transformers import DataCollatorWithPadding
+
+
+def create_dataset(config):
+    pass
+
+
+class BaseDataSet:
+    def __init__(self, prompts, max_prompt_length, tokenizer, padding=False, truncation=True, add_special_tokens=False):
+        self.tokenizer = tokenizer
+        self.prompts = prompts
+        self.max_prompt_length = max_prompt_length
+        self.padding = padding
+        self.trunction = truncation
+        self.add_special_tokens = add_special_tokens
+        self.gen_prompts = []
+        self.encode_prompts()
+        self.generate_prompts(self.model_inputs)
+
+    def encode_prompts(self):
+        self.model_inputs = self.tokenizer(
+            self.prompts,
+            truncation=self.trunction,
+            padding=self.padding,
+            max_length=self.max_prompt_length,
+            add_special_tokens=self.add_special_tokens,
+        )
+
+    def generate_prompts(self):
+        pass
+
+    def __getitem__(self, ix: int):
+        return self.gen_prompts[ix]
+
+    def __len__(self) -> int:
+        return len(self.gen_prompts)
+
+    def collate_fn(self):
+        return DataCollatorWithPadding(self.tokenizer) if self.tokenizer else torch.vstack
+
+    def create_loader(self, batch_size: int, shuffle=False) -> DataLoader:
+        collate_fn = self.collate_fn()
+        dataloader = DataLoader(self, batch_size=batch_size, collate_fn=collate_fn, shuffle=shuffle)
+        return dataloader
+
+
+class PromptDataset(BaseDataSet):
+    """
+    Tokenizes prompts, unless they are already tokenized,
+    and truncates them to `max_prompt_length` from the right
+    """
+
+    def __init__(
+        self,
+        prompts,
+        max_prompt_length,
+        tokenizer,
+        padding=False,
+        truncation=True,
+        add_special_tokens=False,
+    ):
+        super().__init__(
+            prompts,
+            max_prompt_length,
+            tokenizer,
+            padding=padding,
+            truncation=truncation,
+            add_special_tokens=add_special_tokens,
+        )
+
+    def generate_prompts(self, model_inputs):
+        prompts_tokens = model_inputs["input_ids"]
+        attention_mask = model_inputs["attention_mask"]
+
+        self.gen_prompts = [
+            {"input_ids": tokens[:-1], "attention_mask": mask[:-1]}
+            for tokens, mask in zip(prompts_tokens, attention_mask)
+        ]
+
+
+class GLMPromptDataset(BaseDataSet):
+    """
+    Tokenizes prompts, unless they are already tokenized, and truncates them to `max_prompt_length` from the right
+    """
+
+    def __init__(self, prompts, max_prompt_length, tokenizer, padding=False, truncation=True, add_special_tokens=False):
+        super().__init__(
+            prompts,
+            max_prompt_length,
+            tokenizer,
+            padding=padding,
+            truncation=truncation,
+            add_special_tokens=add_special_tokens,
+        )
+
+    def generate_prompts(self, model_inputs):
+        prompts_tokens = model_inputs["input_ids"]
+        attention_mask = model_inputs["attention_mask"]
+        self.gen_prompts = [
+            {"input_ids": tokens[:-1], "attention_mask": mask[:-1], "idx": idx}
+            for idx, (tokens, mask) in enumerate(zip(prompts_tokens, attention_mask))
+        ]
+
+
+@dataclass
+class PPORLElement:
+
+    query_tensor: torch.tensor
+    response_tensor: torch.tensor
+    logprobs: torch.tensor
+    values: torch.tensor
+    rewards: torch.tensor
+
+
+@dataclass
+class PPORLBatch:
+    query_tensors: torch.tensor
+    response_tensors: torch.tensor
+    logprobs: torch.tensor
+    values: torch.tensor
+    rewards: torch.tensor
+
+
+PPORLElement_KEY = [k for k in PPORLElement.__annotations__.keys()]
+
+
+class RLTrainingDataset:
+    def __init__(self, replay_buffer):
+        self.pad_token_id = None
+        self.sop_token_id = None
+        data = replay_buffer.data
+        query_tensor = data["query_tensor"]
+        response_tensor = data["response_tensor"]
+        logprobs = data["logprobs"]
+        values = data["values"]
+        rewards = data["rewards"]
+        self.ppo_rl_elements = [
+            PPORLElement(
+                query_tensor=i,
+                response_tensor=j,
+                logprobs=k,
+                values=l,
+                rewards=m,
+            )
+            for i, j, k, l, m in zip(query_tensor, response_tensor, logprobs, values, rewards)
+        ]
+
+    def __getitem__(self, ix: int):
+        return self.ppo_rl_elements[ix]
+
+    def __len__(self) -> int:
+        return len(self.ppo_rl_elements)
+
+    def set_tokenizer(self, tokenizer):
+        self.pad_token_id = tokenizer.pad_token_id
+        self.sop_token_id = tokenizer.sop_token_id
+
+    def collate_fn(self):
+        def collate_fn(elems):
+            assert self.pad_token_id is not None
+            assert self.sop_token_id is not None
+            remove_sop_pad = pad_sequence(
+                [elem.query_tensor[:-1] for elem in elems],
+                padding_value=self.pad_token_id,
+                batch_first=True,
+            )
+            sops = torch.full((remove_sop_pad.size(0), 1), self.sop_token_id).to(remove_sop_pad.device)
+            query_padded = torch.cat((remove_sop_pad, sops), -1)
+
+            return PPORLBatch(
+                # right padding of already right-padded queries
+                query_padded,
+                # Right pad the rest, to have a single horizontal query/response split
+                pad_sequence(
+                    [elem.response_tensor for elem in elems],
+                    padding_value=self.pad_token_id,
+                    batch_first=True,
+                ),
+                pad_sequence(
+                    [elem.logprobs for elem in elems],
+                    padding_value=0.0,
+                    batch_first=True,
+                ),
+                pad_sequence([elem.values for elem in elems], padding_value=0.0, batch_first=True),
+                pad_sequence(
+                    [elem.rewards for elem in elems],
+                    padding_value=0.0,
+                    batch_first=True,
+                ),
+            )
+
+        return collate_fn
+
+    def create_dataloader(
+        self,
+        batch_size: int,
+        shuffle=False,
+    ) -> DataLoader:
+
+        return DataLoader(self, batch_size=batch_size, shuffle=shuffle, collate_fn=self.collate_fn())

--- a/atorch/atorch/rl/deepspeed/ds_module_hook.py
+++ b/atorch/atorch/rl/deepspeed/ds_module_hook.py
@@ -1,0 +1,428 @@
+import math
+import os
+
+import torch
+import torch.nn.functional as F
+from deepspeed import comm as dist
+from deepspeed.inference.config import DeepSpeedInferenceConfig  # NOQA
+from deepspeed.model_implementations.transformers.ds_transformer import DeepSpeedTransformerInference  # NOQA
+from deepspeed.module_inject import ReplaceWithTensorSlicing
+from deepspeed.module_inject.containers.base import BaseTransformerContainer
+from deepspeed.module_inject.containers.features import HybridSplitQKVContainer
+from deepspeed.module_inject.containers.features.gated_mlp import HybridGatedMLPContainer
+from deepspeed.module_inject.containers.features.hybrid_engine import HybridEngineContainer
+from deepspeed.ops.transformer.inference.ds_attention import DeepSpeedSelfAttention
+from deepspeed.ops.transformer.inference.ds_mlp import DeepSpeedMLP
+from torch import nn
+from trasformers.models.modeling_llama import LlamaRotaryEmbedding, apply_rotary_pos_emb, repeat_kv
+
+
+def attention_qkv_mp_hybrid(self, mp_replace, reversed_dim=False):
+    # Only need to alter
+    if self.module.attention.attn_qkvw is None:
+        # self.module.attention.attn_qw type is torch.nn.Parameter
+        reversed_dim = True
+        self.module.attention.attn_qw = mp_replace.copy(self.module.attention.attn_qw, self.qw, int8=reversed_dim)
+        if self.qb is not None:
+            self.module.attention.attn_qb = mp_replace.copy(self.module.attention.attn_qb, self.qb, int8=reversed_dim)
+        else:
+            self.module.attention.attn_qb = None
+        self.module.attention.attn_kw = mp_replace.copy(self.module.attention.attn_kw, self.kw, int8=reversed_dim)
+
+        if self.kb is not None:
+            self.module.attention.attn_kb = mp_replace.copy(self.module.attention.attn_kb, self.kb, int8=reversed_dim)
+        else:
+            self.module.attention.attn_kb = None
+
+        self.module.attention.attn_vw = mp_replace.copy(self.module.attention.attn_vw, self.vw, int8=reversed_dim)
+
+        if self.vb is not None:
+            self.module.attention.attn_vb = mp_replace.copy(self.module.attention.attn_vb, self.vb, int8=reversed_dim)
+        else:
+            self.module.attention.attn_vb = None
+
+    else:
+        super(HybridEngineContainer, self).attention_qkv_mp(mp_replace)
+
+
+HybridSplitQKVContainer.attention_qkv_mp = attention_qkv_mp_hybrid
+
+
+def attention_qkv_mp(self, mp_replace, reversed_dim=False):
+    reversed_dim = True
+    self.module.attention.attn_qkvw = mp_replace.strided_copy(
+        self.module.attention.attn_qkvw, self.qkvw, num_splits=3, int8=reversed_dim
+    )
+    reversed_dim = True
+    self.module.attention.attn_qkvb = mp_replace.strided_copy(
+        self.module.attention.attn_qkvb, self.qkvb, num_splits=3, int8=reversed_dim
+    )
+
+
+def attention_o_mp(self, mp_replace, reversed_dim=False):
+    reversed_dim = False
+    self.module.attention.attn_ow = mp_replace.copy(self.module.attention.attn_ow, self.dense_w, int8=reversed_dim)
+    if self.dense_b is not None:
+        self.module.attention.attn_ob = torch.nn.Parameter(self.dense_b.clone())
+    else:
+        self.module.attention.attn_ob = None
+
+
+def mlp_inter_mp(self, mp_replace, reversed_dim=False):
+    reversed_dim = True
+    self.module.mlp.inter_w = mp_replace.copy(self.module.mlp.inter_w, self._h4h_w, int8=reversed_dim)
+    if self._h4h_b is not None:
+        self.module.mlp.inter_b = mp_replace.copy(self.module.mlp.inter_b, self._h4h_b, int8=reversed_dim)
+    else:
+        self._h4h_b = None
+
+
+def mlp_output_mp(self, mp_replace, reversed_dim=False):
+    reversed_dim = False
+    self.module.mlp.output_w = mp_replace.copy(self.module.mlp.output_w, self._4hh_w, int8=reversed_dim)
+    if self._4hh_b is not None:
+        self.module.mlp.output_b = torch.nn.Parameter(self._4hh_b.clone())
+    else:
+        self.module.mlp.output_b = None
+
+
+def divide(numerator, denominator):
+    """Ensure that numerator is divisible by the denominator and return
+    the division value.
+    """
+    assert numerator % denominator == 0, "{} is not divisible by {}".format(numerator, denominator)
+    return numerator // denominator
+
+
+def strided_copy(self, dst, src, num_splits: int, int8: bool = False, allocate_tensor: bool = False):
+    rank = self.gpu_index
+    world_size = self.mp_size
+
+    shape = src.shape
+    if int8:
+        per_partition_size = divide(shape[0], world_size)
+        int8 = False
+    else:
+        int8 = True
+        per_partition_size = divide(shape[1], world_size)
+
+    # clone master weight, becase master weight
+    # would be partitioned
+    # in hybrid engine, master weight is not None
+    src = torch.clone(src)
+
+    if world_size == 1:
+        return torch.nn.Parameter(src)
+
+    stride = num_splits
+    # Split and copy
+    per_partition_per_stride_size = divide(per_partition_size, stride)
+    weight_list = torch.split(src, per_partition_per_stride_size, int8)
+    my_weight_list = weight_list[rank::world_size]
+
+    with torch.no_grad():
+        dst = torch.nn.Parameter(torch.cat(my_weight_list, int8))
+    return dst
+
+
+def copy(self, dst, src, int8=False, allocate_tensor=False):
+    rank = self.gpu_index
+    world_size = self.mp_size
+
+    shape = src.shape
+    if int8:
+        per_partition_size = divide(shape[0], world_size)
+        int8 = 0
+    else:
+        int8 = 1
+        per_partition_size = divide(shape[1], world_size)
+
+    # clone master weight, becase master weight
+    # would be partitioned
+    # in hybrid engine, master weight is not None
+    src = torch.clone(src)
+
+    if world_size == 1:
+        return torch.nn.Parameter(src)
+
+    stride = 1
+    # Split and copy
+    per_partition_per_stride_size = divide(per_partition_size, stride)
+
+    weight_list = torch.split(src, per_partition_per_stride_size, int8)
+    my_weight_list = weight_list[rank::world_size]
+
+    with torch.no_grad():
+        dst = torch.nn.Parameter(torch.cat(my_weight_list, int8))
+    return dst
+
+
+# hook deepspeed's function
+BaseTransformerContainer.attention_o_mp = attention_o_mp
+BaseTransformerContainer.mlp_inter_mp = mlp_inter_mp
+BaseTransformerContainer.mlp_output_mp = mlp_output_mp
+BaseTransformerContainer.attention_qkv_mp = attention_qkv_mp
+HybridGatedMLPContainer.mlp_inter_mp = mlp_inter_mp
+
+
+ReplaceWithTensorSlicing.copy = copy
+ReplaceWithTensorSlicing.strided_copy = strided_copy
+
+
+def split_tensor_along_last_dim(tensor, num_partitions, contiguous_split_chunks=False):
+    """Split a tensor along its last dimension.
+    Arguments:
+        tensor: input tensor.
+        num_partitions: number of partitions to split the tensor
+        contiguous_split_chunks: If True, make each chunk contiguous
+                                 in memory.
+    """
+    # Get the size and dimension.
+    last_dim = tensor.dim() - 1
+    last_dim_size = divide(tensor.size()[last_dim], num_partitions)
+    # Split.
+    tensor_list = torch.split(tensor, last_dim_size, dim=last_dim)
+    # Note: torch.split does not create contiguous tensors by default.
+    if contiguous_split_chunks:
+        return tuple(chunk.contiguous() for chunk in tensor_list)
+
+    return tensor_list
+
+
+def glm_transpose_for_scores(self, tensor):
+    """Transpose a 3D tensor [b, s, np*hn] into a 4D tensor with
+    size [b, np, s, hn].
+    """
+    new_tensor_shape = tensor.size()[:-1] + (
+        self.num_attention_heads,
+        self.hidden_size_per_attention_head,
+    )
+    tensor = tensor.view(*new_tensor_shape)
+    return tensor.permute(0, 2, 1, 3)
+
+
+def llama2_mlp_forward(self, attention_output, input, inp_norm, bias):
+    gate = F.linear(attention_output, self.inter_gate_w)
+    up = F.linear(attention_output, self.inter_up_w)
+    gate_up = F.silu(gate) * up
+
+    outputs = F.linear(gate_up, self.output_w)
+    if self.mp_group is not None and dist.get_world_size(group=self.mp_group) > 1:
+        dist.all_reduce(outputs, group=self.mp_group)
+    return outputs
+
+
+def llama2_decoder_layer_forward(
+    self,
+    input=None,
+    input_mask=None,
+    attention_mask=None,
+    attn_mask=None,
+    head_mask=None,
+    layer_past=None,
+    get_key_value=False,
+    get_present=False,
+    encoder_output=None,
+    enc_dec_attn_mask=None,
+    x=None,
+    encoder_hidden_states=None,
+    encoder_attention_mask=None,
+    use_cache=False,
+    alibi=None,
+    output_attentions=False,
+    # TODO(arashb): 'layer_head_mask' and 'past_key_value' are only added to satisfy the OPT models API.
+    # This needs to be redesigned later!
+    layer_head_mask=None,
+    past_key_value=None,
+    **kwargs,
+):
+
+    head_mask = input_mask
+    if x is not None:
+        input = x
+    if "hidden_states" in kwargs:
+        input = kwargs["hidden_states"]
+
+    input_mask = (input_mask if attn_mask is None else attn_mask) if attention_mask is None else attention_mask
+
+    head_mask = kwargs["position_ids"]
+
+    get_present = get_present or get_key_value or use_cache
+    input_mask = input_mask if attention_mask is None else attention_mask
+
+    # We set the prev key/value to None when there is a prompt
+    if input.shape[1] > 1:
+        self.layer_past = None
+    # layer_past = layer_past if layer_past is not None else self.layer_past
+    layer_past = past_key_value
+
+    head_mask = layer_head_mask if layer_head_mask is not None else head_mask
+
+    attn_mask = None
+    if isinstance(input, tuple):
+        attn_mask = input[1]
+        input = input[0]
+
+    # RMS NORM
+    residual = input
+    input_dtype = input.dtype
+    hidden_states = input.to(torch.float32)
+    variance = hidden_states.pow(2).mean(-1, keepdim=True)
+    hidden_states = hidden_states * torch.rsqrt(variance + 1e-6)
+    hidden_states = self.norm_w * hidden_states.to(input_dtype)
+
+    with torch.no_grad():
+        attention_output, past_key_value, _, context_outputtn_ctx, inp_norm = self.attention(
+            hidden_states,
+            input_mask,
+            head_mask,
+            layer_past,
+            get_present,
+            encoder_hidden_states,
+            encoder_attention_mask,
+            output_attentions,
+            self.norm_w,
+            self.norm_b,
+            alibi,
+        )
+    hidden_states = residual + attention_output
+    residual = hidden_states
+
+    # RMS NORM
+    input_dtype = hidden_states.dtype
+    hidden_states = hidden_states.to(torch.float32)
+    variance = hidden_states.pow(2).mean(-1, keepdim=True)
+    hidden_states = hidden_states * torch.rsqrt(variance + 1e-6)
+    hidden_states = self.mlp.attn_nw * hidden_states.to(input_dtype)
+
+    hidden_states = self.mlp(hidden_states, None, None, None)
+    hidden_states = residual + hidden_states
+
+    return hidden_states, past_key_value, None
+
+
+def llama2_attention_forward(
+    self,
+    input,
+    input_mask,
+    head_mask=None,
+    layer_past=None,
+    get_present=False,
+    encoder_hidden_states=None,
+    encoder_attention_mask=None,
+    output_attentions=False,
+    norm_w=None,
+    norm_b=None,
+    alibi=None,
+):
+    """
+    Forward pass of the attention module.
+
+    Args:
+        x (torch.Tensor): Input tensor.
+        start_pos (int): Starting position for caching.
+        freqs_cis (torch.Tensor): Precomputed frequency tensor.
+        mask (torch.Tensor, optional): Attention mask tensor.
+
+    Returns:
+        torch.Tensor: Output tensor after attention.
+
+    """
+
+    bsz, q_len, _ = input.size()
+
+    hidden_states = input
+    position_ids = head_mask
+    attention_mask = input_mask
+    # query_states = self.q_proj(hidden_states)
+    query_states = F.linear(hidden_states, self.attn_qw)
+    # key_states = self.k_proj(hidden_states)
+    key_states = F.linear(hidden_states, self.attn_kw)
+    # value_states = self.v_proj(hidden_states)
+    value_states = F.linear(hidden_states, self.attn_vw)
+
+    self.num_heads = self.config.llama.num_attention_heads
+    self.num_key_value_heads = self.config.llama.num_key_value_heads
+    self.head_dim = self.config.hidden_size // self.num_heads
+    self.num_key_value_groups = self.num_heads // self.num_key_value_heads
+
+    # for tp
+
+    self.hidden_size_per_partition = self.config.hidden_size // self.config.mp_size
+    self.hidden_size_per_attention_head = self.config.hidden_size // self.num_heads
+    self.num_attention_heads_per_partition = self.num_heads // self.config.mp_size
+    self.num_key_value_heads_per_partition = self.config.llama.num_key_value_heads // self.config.mp_size
+
+    if not hasattr(self, "rotary_emb"):
+        self.rotary_emb = LlamaRotaryEmbedding(
+            self.head_dim, max_position_embeddings=self.config.llama.max_position_embeddings
+        ).to(int(os.environ.get("LOCAL_RANK", 0)))
+
+    past_key_value = layer_past
+
+    query_states = query_states.view(bsz, q_len, self.num_attention_heads_per_partition, self.head_dim).transpose(1, 2)
+    key_states = key_states.view(bsz, q_len, self.num_key_value_heads_per_partition, self.head_dim).transpose(1, 2)
+    value_states = value_states.view(bsz, q_len, self.num_key_value_heads_per_partition, self.head_dim).transpose(1, 2)
+
+    kv_seq_len = key_states.shape[-2]
+    if past_key_value is not None:
+        kv_seq_len += past_key_value[0].shape[-2]
+    cos, sin = self.rotary_emb(value_states, seq_len=kv_seq_len)
+    query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin, position_ids)
+
+    if past_key_value is not None:
+        # reuse k, v, self_attention
+        key_states = torch.cat([past_key_value[0], key_states], dim=2)
+        value_states = torch.cat([past_key_value[1], value_states], dim=2)
+
+    past_key_value = (key_states, value_states)
+
+    # repeat k/v heads if n_kv_heads < n_heads
+    key_states = repeat_kv(key_states, self.num_key_value_groups)
+    value_states = repeat_kv(value_states, self.num_key_value_groups)
+
+    attn_weights = torch.matmul(query_states, key_states.transpose(2, 3)) / math.sqrt(self.head_dim)
+
+    if attn_weights.size() != (bsz, self.num_attention_heads_per_partition, q_len, kv_seq_len):
+        raise ValueError(
+            f"Attention weights should be of size "
+            f" {(bsz,self.num_attention_heads_per_partition , q_len, kv_seq_len)}, but is"
+            f" {attn_weights.size()}"
+        )
+
+    if attention_mask is not None:
+        if attention_mask.size() != (bsz, 1, q_len, kv_seq_len):
+            raise ValueError(
+                f"Attention mask should be of size {(bsz, 1, q_len, kv_seq_len)}, but is {attention_mask.size()}"
+            )
+        attn_weights = attn_weights + input_mask
+
+    # upcast attention to fp32
+    attn_weights = nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32).to(query_states.dtype)
+    attn_output = torch.matmul(attn_weights, value_states)
+
+    if attn_output.size() != (bsz, self.num_attention_heads_per_partition, q_len, self.head_dim):
+        raise ValueError(
+            f"`attn_output` should be of size "
+            f" {(bsz, self.num_attention_heads_per_partition, q_len, self.head_dim)}, but is"
+            f" {attn_output.size()}"
+        )
+
+    attn_output = attn_output.transpose(1, 2).contiguous()
+    attn_output = attn_output.reshape(bsz, q_len, self.hidden_size_per_partition)
+
+    attn_output = F.linear(attn_output, self.attn_ow)
+
+    if self.mp_group is not None and dist.get_world_size(group=self.mp_group) > 1:
+        dist.all_reduce(attn_output, group=self.mp_group)
+
+    if not output_attentions:
+        attn_weights = None
+    return attn_output, past_key_value, _, None, None
+
+
+# DeepSpeedTransformerInference.forward = opt_decoder_layer_forward
+# glm_block_forward
+DeepSpeedTransformerInference.forward = llama2_decoder_layer_forward
+DeepSpeedSelfAttention.forward = llama2_attention_forward
+DeepSpeedMLP.forward = llama2_mlp_forward

--- a/atorch/atorch/rl/ds_hybrid_engine/ds_hook.py
+++ b/atorch/atorch/rl/ds_hybrid_engine/ds_hook.py
@@ -1,0 +1,422 @@
+import math
+import os
+
+import torch
+import torch.nn.functional as F
+from deepspeed import comm as dist
+from deepspeed.inference.config import DeepSpeedInferenceConfig  # NOQA
+from deepspeed.model_implementations.transformers.ds_transformer import DeepSpeedTransformerInference  # NOQA
+from deepspeed.module_inject import ReplaceWithTensorSlicing
+from deepspeed.module_inject.containers.base import BaseTransformerContainer
+from deepspeed.module_inject.containers.features import HybridSplitQKVContainer
+from deepspeed.module_inject.containers.features.gated_mlp import HybridGatedMLPContainer
+from deepspeed.module_inject.containers.features.hybrid_engine import HybridEngineContainer
+from deepspeed.ops.transformer.inference.ds_attention import DeepSpeedSelfAttention
+from deepspeed.ops.transformer.inference.ds_mlp import DeepSpeedMLP
+from torch import nn
+from transformers.models.llama.modeling_llama import LlamaRotaryEmbedding, apply_rotary_pos_emb, repeat_kv
+
+
+def mlp_inter_mp(self, mp_replace, reversed_dim=False):
+    # Only need to alter behavior if we can't do the normal destructive copy
+    if self.module.mlp.inter_w is None:
+
+        reversed_dim = True
+        self.module.mlp.inter_up_w = mp_replace.copy(
+            self.module.mlp.inter_up_w, self.inter_up_w, int8=reversed_dim, allocate_tensor=reversed_dim
+        )
+
+        self.module.mlp.inter_gate_w = mp_replace.copy(
+            self.module.mlp.inter_gate_w, self.inter_gate_w, int8=reversed_dim, allocate_tensor=reversed_dim
+        )
+
+    else:
+        self.module.mlp.inter_w = mp_replace.strided_copy(
+            self.module.mlp.inter_w, self._h4h_w, num_splits=2, int8=reversed_dim
+        )
+        self.module.mlp.inter_b = mp_replace.strided_copy(
+            self.module.mlp.inter_b, self._h4h_b, num_splits=2, int8=reversed_dim
+        )
+
+
+HybridGatedMLPContainer.mlp_inter_mp = mlp_inter_mp
+
+
+def attention_qkv_mp_hybrid(self, mp_replace, reversed_dim=False):
+    # Only need to alter
+    if self.module.attention.attn_qkvw is None:
+        # self.module.attention.attn_qw type is torch.nn.Parameter
+        reversed_dim = True
+        self.module.attention.attn_qw = mp_replace.copy(self.module.attention.attn_qw, self.qw, int8=reversed_dim)
+        if self.qb is not None:
+            self.module.attention.attn_qb = mp_replace.copy(self.module.attention.attn_qb, self.qb, int8=reversed_dim)
+        else:
+            self.module.attention.attn_qb = None
+        self.module.attention.attn_kw = mp_replace.copy(self.module.attention.attn_kw, self.kw, int8=reversed_dim)
+
+        if self.kb is not None:
+            self.module.attention.attn_kb = mp_replace.copy(self.module.attention.attn_kb, self.kb, int8=reversed_dim)
+        else:
+            self.module.attention.attn_kb = None
+
+        self.module.attention.attn_vw = mp_replace.copy(self.module.attention.attn_vw, self.vw, int8=reversed_dim)
+
+        if self.vb is not None:
+            self.module.attention.attn_vb = mp_replace.copy(self.module.attention.attn_vb, self.vb, int8=reversed_dim)
+        else:
+            self.module.attention.attn_vb = None
+
+    else:
+        super(HybridEngineContainer, self).attention_qkv_mp(mp_replace)
+
+
+HybridSplitQKVContainer.attention_qkv_mp = attention_qkv_mp_hybrid
+
+
+def attention_qkv_mp(self, mp_replace, reversed_dim=False):
+    reversed_dim = True
+    self.module.attention.attn_qkvw = mp_replace.strided_copy(
+        self.module.attention.attn_qkvw, self.qkvw, num_splits=3, int8=reversed_dim
+    )
+    reversed_dim = True
+    self.module.attention.attn_qkvb = mp_replace.strided_copy(
+        self.module.attention.attn_qkvb, self.qkvb, num_splits=3, int8=reversed_dim
+    )
+
+
+def attention_o_mp(self, mp_replace, reversed_dim=False):
+    reversed_dim = False
+    self.module.attention.attn_ow = mp_replace.copy(self.module.attention.attn_ow, self.dense_w, int8=reversed_dim)
+    if self.dense_b is not None:
+        self.module.attention.attn_ob = torch.nn.Parameter(self.dense_b.clone())
+    else:
+        self.module.attention.attn_ob = None
+
+
+def mlp_inter_mp_base(self, mp_replace, reversed_dim=False):
+    reversed_dim = True
+    self.module.mlp.inter_w = mp_replace.copy(self.module.mlp.inter_w, self._h4h_w, int8=reversed_dim)
+    if self._h4h_b is not None:
+        self.module.mlp.inter_b = mp_replace.copy(self.module.mlp.inter_b, self._h4h_b, int8=reversed_dim)
+    else:
+        self._h4h_b = None
+
+
+def mlp_output_mp(self, mp_replace, reversed_dim=False):
+    reversed_dim = False
+    self.module.mlp.output_w = mp_replace.copy(self.module.mlp.output_w, self._4hh_w, int8=reversed_dim)
+    if self._4hh_b is not None:
+        self.module.mlp.output_b = torch.nn.Parameter(self._4hh_b.clone())
+    else:
+        self.module.mlp.output_b = None
+
+
+def divide(numerator, denominator):
+    """Ensure that numerator is divisible by the denominator and return
+    the division value.
+    """
+    assert numerator % denominator == 0, "{} is not divisible by {}".format(numerator, denominator)
+    return numerator // denominator
+
+
+def strided_copy(self, dst, src, num_splits: int, int8: bool = False, allocate_tensor: bool = False):
+    rank = self.gpu_index
+    world_size = self.mp_size
+
+    shape = src.shape
+    if int8:
+        per_partition_size = divide(shape[0], world_size)
+        int8 = False
+    else:
+        int8 = True
+        per_partition_size = divide(shape[1], world_size)
+
+    # clone master weight, becase master weight
+    # would be partitioned
+    # in hybrid engine, master weight is not None
+    src = torch.clone(src)
+
+    if world_size == 1:
+        return torch.nn.Parameter(src)
+
+    stride = num_splits
+    # Split and copy
+    per_partition_per_stride_size = divide(per_partition_size, stride)
+    weight_list = torch.split(src, per_partition_per_stride_size, int8)
+    my_weight_list = weight_list[rank::world_size]
+
+    with torch.no_grad():
+        dst = torch.nn.Parameter(torch.cat(my_weight_list, int8))
+    return dst
+
+
+def copy(self, dst, src, int8=False, allocate_tensor=False):
+    # 如果是按行切分
+    rank = self.gpu_index
+    world_size = self.mp_size
+
+    shape = src.shape
+    if int8:
+        per_partition_size = divide(shape[0], world_size)
+        int8 = 0
+    else:
+        int8 = 1
+        per_partition_size = divide(shape[1], world_size)
+
+    # clone master weight, becase master weight
+    # would be partitioned
+    # in hybrid engine, master weight is not None
+    src = torch.clone(src)
+
+    if world_size == 1:
+        return torch.nn.Parameter(src)
+
+    stride = 1
+    # Split and copy
+    per_partition_per_stride_size = divide(per_partition_size, stride)
+
+    weight_list = torch.split(src, per_partition_per_stride_size, int8)
+    my_weight_list = weight_list[rank::world_size]
+
+    with torch.no_grad():
+        dst = torch.nn.Parameter(torch.cat(my_weight_list, int8))
+    return dst
+
+
+# hook deepspeed's function
+BaseTransformerContainer.attention_o_mp = attention_o_mp
+BaseTransformerContainer.mlp_inter_mp = mlp_inter_mp_base
+BaseTransformerContainer.mlp_output_mp = mlp_output_mp
+BaseTransformerContainer.attention_qkv_mp = attention_qkv_mp
+
+
+ReplaceWithTensorSlicing.copy = copy
+ReplaceWithTensorSlicing.strided_copy = strided_copy
+
+
+def llama2_mlp_forward(self, attention_output, input, inp_norm, bias):
+    gate = F.linear(attention_output, self.inter_gate_w)
+    up = F.linear(attention_output, self.inter_up_w)
+    gate_up = F.silu(gate) * up
+
+    outputs = F.linear(gate_up, self.output_w)
+    if self.mp_group is not None and dist.get_world_size(group=self.mp_group) > 1:
+        dist.all_reduce(outputs, group=self.mp_group)
+    return outputs
+
+
+def llama2_decoder_layer_forward(
+    self,
+    input=None,
+    input_mask=None,
+    attention_mask=None,
+    attn_mask=None,
+    head_mask=None,
+    layer_past=None,
+    get_key_value=False,
+    get_present=False,
+    encoder_output=None,
+    enc_dec_attn_mask=None,
+    x=None,
+    encoder_hidden_states=None,
+    encoder_attention_mask=None,
+    use_cache=False,
+    alibi=None,
+    output_attentions=False,
+    # TODO(arashb): 'layer_head_mask' and 'past_key_value' are only added to satisfy the OPT models API.
+    # This needs to be redesigned later!
+    layer_head_mask=None,
+    past_key_value=None,
+    **kwargs,
+):
+
+    head_mask = input_mask
+    if x is not None:
+        input = x
+    if "hidden_states" in kwargs:
+        input = kwargs["hidden_states"]
+
+    input_mask = (input_mask if attn_mask is None else attn_mask) if attention_mask is None else attention_mask
+
+    head_mask = kwargs["position_ids"]
+
+    get_present = get_present or get_key_value or use_cache
+    input_mask = input_mask if attention_mask is None else attention_mask
+
+    # We set the prev key/value to None when there is a prompt
+    if input.shape[1] > 1:
+        self.layer_past = None
+    # layer_past = layer_past if layer_past is not None else self.layer_past
+    layer_past = past_key_value
+
+    head_mask = layer_head_mask if layer_head_mask is not None else head_mask
+
+    attn_mask = None
+    if isinstance(input, tuple):
+        attn_mask = input[1]
+        input = input[0]
+
+    # RMS NORM
+
+    residual = input
+    input_dtype = input.dtype
+    hidden_states = input.to(torch.float32)
+    variance = hidden_states.pow(2).mean(-1, keepdim=True)
+    hidden_states = hidden_states * torch.rsqrt(variance + 1e-6)
+    hidden_states = self.norm_w * hidden_states.to(input_dtype)
+
+    with torch.no_grad():
+        attention_output, past_key_value, _, context_outputtn_ctx, inp_norm = self.attention(
+            hidden_states,
+            input_mask,
+            head_mask,
+            layer_past,
+            get_present,
+            encoder_hidden_states,
+            encoder_attention_mask,
+            output_attentions,
+            self.norm_w,
+            self.norm_b,
+            alibi,
+        )
+    hidden_states = residual + attention_output
+    residual = hidden_states
+
+    # RMS NORM
+    input_dtype = hidden_states.dtype
+    hidden_states = hidden_states.to(torch.float32)
+    variance = hidden_states.pow(2).mean(-1, keepdim=True)
+    hidden_states = hidden_states * torch.rsqrt(variance + 1e-6)
+    hidden_states = self.mlp.attn_nw * hidden_states.to(input_dtype)
+
+    hidden_states = self.mlp(hidden_states, None, None, None)
+    hidden_states = residual + hidden_states
+
+    return hidden_states, past_key_value, None
+
+
+def llama2_attention_forward(
+    self,
+    input,
+    input_mask,
+    head_mask=None,
+    layer_past=None,
+    get_present=False,
+    encoder_hidden_states=None,
+    encoder_attention_mask=None,
+    output_attentions=False,
+    norm_w=None,
+    norm_b=None,
+    alibi=None,
+):
+    """
+    Forward pass of the attention module.
+
+    Args:
+        x (torch.Tensor): Input tensor.
+        start_pos (int): Starting position for caching.
+        freqs_cis (torch.Tensor): Precomputed frequency tensor.
+        mask (torch.Tensor, optional): Attention mask tensor.
+
+    Returns:
+        torch.Tensor: Output tensor after attention.
+
+    """
+
+    bsz, q_len, _ = input.size()
+
+    hidden_states = input
+    position_ids = head_mask
+    attention_mask = input_mask
+    # query_states = self.q_proj(hidden_states)
+    query_states = F.linear(hidden_states, self.attn_qw)
+    # key_states = self.k_proj(hidden_states)
+    key_states = F.linear(hidden_states, self.attn_kw)
+    # value_states = self.v_proj(hidden_states)
+    value_states = F.linear(hidden_states, self.attn_vw)
+
+    self.num_heads = self.config.llama.num_attention_heads
+    self.num_key_value_heads = self.config.llama.num_key_value_heads
+    self.head_dim = self.config.hidden_size // self.num_heads
+    self.num_key_value_groups = self.num_heads // self.num_key_value_heads
+
+    # for tp
+
+    self.hidden_size_per_partition = self.config.hidden_size // self.config.mp_size
+    self.hidden_size_per_attention_head = self.config.hidden_size // self.num_heads
+    self.num_attention_heads_per_partition = self.num_heads // self.config.mp_size
+    self.num_key_value_heads_per_partition = self.config.llama.num_key_value_heads // self.config.mp_size
+
+    if not hasattr(self, "rotary_emb"):
+        self.rotary_emb = LlamaRotaryEmbedding(
+            self.head_dim, max_position_embeddings=self.config.llama.max_position_embeddings
+        ).to(int(os.environ.get("LOCAL_RANK", 0)))
+
+    past_key_value = layer_past
+
+    query_states = query_states.view(bsz, q_len, self.num_attention_heads_per_partition, self.head_dim).transpose(1, 2)
+    key_states = key_states.view(bsz, q_len, self.num_key_value_heads_per_partition, self.head_dim).transpose(1, 2)
+    value_states = value_states.view(bsz, q_len, self.num_key_value_heads_per_partition, self.head_dim).transpose(1, 2)
+
+    kv_seq_len = key_states.shape[-2]
+    if past_key_value is not None:
+        kv_seq_len += past_key_value[0].shape[-2]
+    cos, sin = self.rotary_emb(value_states, seq_len=kv_seq_len)
+    query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin, position_ids)
+
+    if past_key_value is not None:
+        # reuse k, v, self_attention
+        key_states = torch.cat([past_key_value[0], key_states], dim=2)
+        value_states = torch.cat([past_key_value[1], value_states], dim=2)
+
+    past_key_value = (key_states, value_states)
+
+    # repeat k/v heads if n_kv_heads < n_heads
+    key_states = repeat_kv(key_states, self.num_key_value_groups)
+    value_states = repeat_kv(value_states, self.num_key_value_groups)
+
+    attn_weights = torch.matmul(query_states, key_states.transpose(2, 3)) / math.sqrt(self.head_dim)
+
+    if attn_weights.size() != (bsz, self.num_attention_heads_per_partition, q_len, kv_seq_len):
+        raise ValueError(
+            f"Attention weights should be of size"
+            f" {(bsz,self.num_attention_heads_per_partition , q_len, kv_seq_len)}, but is"
+            f" {attn_weights.size()}"
+        )
+
+    if attention_mask is not None:
+        if attention_mask.size() != (bsz, 1, q_len, kv_seq_len):
+            raise ValueError(
+                f"Attention mask should be of size {(bsz, 1, q_len, kv_seq_len)}, but is {attention_mask.size()}"
+            )
+        attn_weights = attn_weights + input_mask
+
+    # upcast attention to fp32
+    attn_weights = nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32).to(query_states.dtype)
+    attn_output = torch.matmul(attn_weights, value_states)
+
+    if attn_output.size() != (bsz, self.num_attention_heads_per_partition, q_len, self.head_dim):
+        raise ValueError(
+            f"`attn_output` should be of size"
+            f" {(bsz, self.num_attention_heads_per_partition, q_len, self.head_dim)}, but is"
+            f" {attn_output.size()}"
+        )
+
+    attn_output = attn_output.transpose(1, 2).contiguous()
+    attn_output = attn_output.reshape(bsz, q_len, self.hidden_size_per_partition)
+
+    attn_output = F.linear(attn_output, self.attn_ow)
+
+    if self.mp_group is not None and dist.get_world_size(group=self.mp_group) > 1:
+        dist.all_reduce(attn_output, group=self.mp_group)
+
+    if not output_attentions:
+        attn_weights = None
+    return attn_output, past_key_value, _, None, None
+
+
+# DeepSpeedTransformerInference.forward = opt_decoder_layer_forward
+# glm_block_forward
+DeepSpeedTransformerInference.forward = llama2_decoder_layer_forward
+DeepSpeedSelfAttention.forward = llama2_attention_forward
+DeepSpeedMLP.forward = llama2_mlp_forward

--- a/atorch/atorch/rl/ds_hybrid_engine/hybrid_engine.py
+++ b/atorch/atorch/rl/ds_hybrid_engine/hybrid_engine.py
@@ -1,0 +1,378 @@
+import os
+
+import deepspeed
+import torch
+from deepspeed.inference.config import DeepSpeedInferenceConfig
+from deepspeed.module_inject.layers import EmbeddingLayer, LinearLayer, Normalize, OPTEmbedding
+from deepspeed.runtime.hybrid_engine import DeepSpeedHybridEngine
+from torch import nn
+
+from .ds_hook import *  # NOQA
+from .module_inject.utils import policy_to_ds_container
+from .replace_policy import replace_policies
+
+try:
+    import transformers
+
+    OPTLearnedPositionalEmbedding = transformers.models.opt.modeling_opt.OPTLearnedPositionalEmbedding
+except ImportError:
+    OPTLearnedPositionalEmbedding = None
+
+
+import gc
+import math
+import time
+
+from deepspeed import comm as dist
+from deepspeed.accelerator import get_accelerator
+from deepspeed.runtime.utils import get_inactive_params
+from deepspeed.runtime.zero import GatheredParameters
+
+
+def atorch_generate(self, *inputs, **kwargs):
+    inputs = inputs[0]
+
+    self._t0 = time.time()
+    if self._total_batch_size is None:
+        bsz = len(inputs)
+        self._total_batch_size = bsz * dist.get_world_size()
+    if self.Z3_enabled:
+        with deepspeed.zero.GatheredParameters(list(self.module.parameters(recurse=True))):
+            self._gather_latency = time.time() - self._t0
+            vllm_backend = getattr(self, "vllm_backend", None)
+            s1 = time.time()
+            vllm_backend.set_train_model_weights(self.module)
+            s2 = time.time()
+            s3 = time.time()
+            res = vllm_backend.generate(inputs)
+            s4 = time.time()
+            import os
+
+            rank = int(os.environ.get("LOCAL_RANK", 0))
+            if rank == 0:
+                print("set weight cost", s2 - s1, "generate cost ", s4 - s3)
+            self._generate_latency = time.time() - self._t0 - self._gather_latency
+    else:
+        self._gather_latency = 0
+        vllm_backend = getattr(self, "vllm_backend", None)
+        vllm_backend.set_train_model_weights(self.module)
+        res = vllm_backend.generate(inputs)
+        self._generate_latency = time.time() - self._t0 - self._gather_latency
+    for param in vllm_backend.llm.llm_engine.workers[0].model.parameters():
+        param.data = torch.empty(0, dtype=param.dtype, device=param.device)
+    torch.cuda.empty_cache()
+    return res
+
+
+def generate(self, *inputs, **kwargs):
+    import os
+
+    rank = int(os.environ.get("LOCAL_RANK", 0))
+    _gather_latency = 0
+
+    if self._total_batch_size is None:
+        bsz = inputs[0].shape[0] if len(inputs) > 0 else kwargs["input_ids"].shape[0]
+        self._total_batch_size = bsz * dist.get_world_size()
+
+    self._t0 = time.time()
+
+    if self.Z3_enabled and self.gather_all_layers:
+        if self._config.hybrid_engine.inference_tp_size > 1:
+            non_tp_params = []
+            for other_layer in self._other_layers:
+                non_tp_params.extend(list(other_layer.parameters()))
+
+            partition_size = self._config.hybrid_engine.tp_gather_partition_size
+
+            layer_groups = math.ceil(len(self.layer_params) / partition_size)
+            for lg in range(layer_groups):
+                non_active_params = []
+                non_active_lora_params = []
+                for layer_id in range(
+                    lg * partition_size,
+                    min(len(self.layer_params), (lg + 1) * partition_size),
+                    1,
+                ):
+                    non_tp_params.extend(self.layer_params[layer_id][:4])
+                    non_active_params.extend(get_inactive_params(self.layer_params[layer_id]))
+                    non_active_params.extend(get_inactive_params(self.layer_lora_params[layer_id]))
+                with GatheredParameters(non_active_params):
+                    for layer_id in range(
+                        lg * partition_size,
+                        min(len(self.layer_params), (lg + 1) * partition_size),
+                        1,
+                    ):
+                        if len(self.all_lora_params) > 0:
+                            self._fuse_lora_layer(layer_id)
+
+                        self._inference_containers[layer_id].apply_tensor_parallelism(
+                            self.mp_replace, reversed_dim=True
+                        )
+
+            # TODO(cmikeh2) Evaluate if this can be deferred when release_inference_cache
+            # is enabled.
+            gc.collect()
+            get_accelerator().empty_cache()
+
+            _gather_latency = time.time() - self._t0
+
+            input_shape = inputs[0].shape if len(inputs) > 0 else kwargs["input_ids"].shape
+            output = torch.zeros(
+                (input_shape[0] * self._config.hybrid_engine.inference_tp_size,) + input_shape[1:],
+                dtype=inputs[0].dtype if len(inputs) > 0 else kwargs["input_ids"].dtype,
+                device=inputs[0].device if len(inputs) > 0 else kwargs["input_ids"].device,
+            )
+            input_cont = inputs[0].contiguous() if len(inputs) > 0 else kwargs["input_ids"].contiguous()
+            dist.all_gather_into_tensor(output, input_cont, group=self.mp_group)
+
+            if kwargs.get("attention_mask", None) is not None:
+                attention_mask = kwargs.get("attention_mask")
+                new_atention_mask = torch.zeros(
+                    (input_shape[0] * self._config.hybrid_engine.inference_tp_size,) + input_shape[1:],
+                    dtype=inputs[0].dtype if len(inputs) > 0 else kwargs["input_ids"].dtype,
+                    device=inputs[0].device if len(inputs) > 0 else kwargs["input_ids"].device,
+                )
+                attention_mask_cont = attention_mask.contiguous()
+                dist.all_gather_into_tensor(new_atention_mask, attention_mask_cont, group=self.mp_group)
+
+                kwargs["attention_mask"] = new_atention_mask.to(rank)
+
+            # broadcast position id
+            # position id is batch_size, 2, seq
+            if kwargs.get("position_ids", None) is not None:
+                glm_position_ids = kwargs.get("position_ids")
+                glm_new_position_ids = torch.zeros(
+                    (input_shape[0] * self._config.hybrid_engine.inference_tp_size,) + glm_position_ids.shape[1:],
+                    dtype=inputs[0].dtype if len(inputs) > 0 else kwargs["input_ids"].dtype,
+                    device=inputs[0].device if len(inputs) > 0 else kwargs["input_ids"].device,
+                )
+                glm_attention_mask_cont = glm_position_ids.contiguous()
+                dist.all_gather_into_tensor(glm_new_position_ids, glm_attention_mask_cont, group=self.mp_group)
+                import os
+
+                rank = int(os.environ.get("LOCAL_RANK", 0))
+                kwargs["position_ids"] = glm_new_position_ids.to(rank)
+
+            # broadcast attention mask
+            # attention maks is batch_size, seq, seq
+            if kwargs.get("generation_attention_mask", None) is not None:
+                glm_attention_mask = kwargs.get("generation_attention_mask")
+                glm_attention_mask = glm_attention_mask.squeeze(1)
+
+                glm_new_atention_mask = torch.zeros(
+                    (input_shape[0] * self._config.hybrid_engine.inference_tp_size,) + glm_attention_mask.shape[1:],
+                    dtype=inputs[0].dtype if len(inputs) > 0 else kwargs["input_ids"].dtype,
+                    device=inputs[0].device if len(inputs) > 0 else kwargs["input_ids"].device,
+                )
+                glm_attention_mask_cont = glm_attention_mask.contiguous()
+                dist.all_gather_into_tensor(glm_new_atention_mask, glm_attention_mask_cont, group=self.mp_group)
+                import os
+
+                rank = int(os.environ.get("LOCAL_RANK", 0))
+                if rank == 0:
+                    print("broad casting  generation_attention_mask")
+                kwargs["generation_attention_mask"] = glm_new_atention_mask.unsqueeze(1).to(rank)
+
+            if len(inputs) > 0:
+                inputs = (output, *inputs[1:])
+            else:
+                kwargs["input_ids"] = output
+
+            self.retake_inference_cache()
+
+            non_active_params = get_inactive_params(non_tp_params)
+            with GatheredParameters(non_active_params):
+                generate_ret_vals = self._generate(*inputs, **kwargs)
+
+            for layer_id in range(len(self.layer_params)):
+                self._inference_containers[layer_id].release_memory()
+
+            rank = dist.get_rank(group=self.mp_group)
+            generate_ret_vals = generate_ret_vals[input_shape[0] * rank : input_shape[0] * (rank + 1)]
+
+        else:
+            non_active_layers = get_inactive_params(self.all_layers_params)
+            non_active_lora_params = get_inactive_params(self.all_lora_params)
+            non_active_layers.extend(non_active_lora_params)
+            with GatheredParameters(non_active_layers):
+                _gather_latency = time.time() - self._t0
+
+                if len(self.all_lora_params) > 0:
+                    self.fuse_lora_weight()
+
+                self.retake_inference_cache()
+                generate_ret_vals = self._generate(*inputs, **kwargs)
+
+                if len(self.all_lora_params) > 0:
+                    self.unfuse_lora_weight()
+    else:
+        if len(self.all_lora_params) > 0 and (not self.Z3_enabled):
+            self.fuse_lora_weight()
+
+        self.retake_inference_cache()
+        generate_ret_vals = self._generate(*inputs, **kwargs)
+
+        if len(self.all_lora_params) > 0:
+            if not self.Z3_enabled:
+                self.unfuse_lora_weight()
+            else:
+                self.unfuse_lora_weight_non_pinned()
+            self.is_lora_fused = False
+
+    if self._config.hybrid_engine.release_inference_cache:
+        inference_cuda_module.release_workspace()  # NOQA
+        gc.collect()
+        get_accelerator().empty_cache()
+
+    self._generate_latency += time.time() - self._t0 - _gather_latency
+    self._gather_latency += _gather_latency
+
+    return generate_ret_vals
+
+
+def eval(self):
+
+    if self._t_start is not None:
+        latency = time.time() - self._t_start
+        self._total_latency = self._total_latency + latency
+        self._iters = self._iters + 1
+        if not dist.is_initialized() or dist.get_rank() == 0:
+            _ = latency - (self._generate_latency + self._training_latency)
+
+        self._t_start = time.time()
+    self._training_latency = 0
+    self._generate_latency = 0
+    self._gather_latency = 0
+    super(DeepSpeedHybridEngine, self).eval()
+    if len(self._inference_containers) > 0 and self.Z3_enabled:
+        for i, (orig_module, inference_container) in enumerate(zip(self._orig_modules, self._inference_containers)):
+            if self.Z3_enabled and not self.gather_all_layers:
+                orig_module.forward = self._zero3_forward(i)
+            else:
+                orig_module.forward = inference_container.module.forward
+
+            inference_container.transform_for_inference()
+
+        if not self.Z3_enabled or self.gather_all_layers:
+            for orig_module, inference_layer in zip(self._orig_modules_others, self._other_layers):
+                orig_module.forward = inference_layer.forward
+    if self.Z3_enabled:
+        gc.collect()
+        get_accelerator().empty_cache()
+    if self._t_start is None:
+        self._t_start = time.time()
+
+
+DeepSpeedHybridEngine.generate = generate
+DeepSpeedHybridEngine.atorch_generate = atorch_generate
+DeepSpeedHybridEngine.eval = eval
+
+
+class NewDeepSpeedHybridEngine(DeepSpeedHybridEngine):
+    def __init__(self, args, model, **kwargs):
+        super().__init__(args, model, **kwargs)
+
+    def sync_weight(self):
+        from atorch.rl.model_utils.llama2_utils import get_llama2_params_offsets, move_weight_to_continuous_buffer
+
+        if not hasattr(self, "vllm_comm") or self.vllm_comm is None:
+            return
+
+        if hasattr(self, "vllm_comm"):
+            # mock get last two layer
+            if not hasattr(self, "trainable_paramters"):
+                trainable_parameters = []
+                trainable_paramter_names = []
+                for name, parameter in self.named_parameters():
+                    if parameter.requires_grad is True:
+                        trainable_parameters.append(parameter)
+                        trainable_paramter_names.append(name)
+                self.trainable_parameters = trainable_parameters
+                self.trainable_paramter_names = trainable_paramter_names
+
+            if self.Z3_enabled:
+                with deepspeed.zero.GatheredParameters(self.trainable_parameters):
+                    state_dict = {}
+                    for name, parameter in zip(self.trainable_paramter_names, self.trainable_parameters):
+                        state_dict[name] = parameter
+                    offsets_info = get_llama2_params_offsets(config=self.module.config, tp_size=1)
+                    param_tensor = move_weight_to_continuous_buffer(state_dict, self.module.config, offsets_info)
+                    rank = int(os.environ.get("RANK", 0))
+                    if rank == 0:
+                        if hasattr(self, "vllm_comm") and self.vllm_comm is not None:
+                            self.vllm_comm.send_data(param_tensor)
+            else:
+                for name, parameter in zip(self.trainable_paramter_names, self.trainable_parameters):
+                    state_dict[name] = parameter
+                    offsets_info = get_llama2_params_offsets(config=self.module.config, tp_size=1)
+                    param_tensor = move_weight_to_continuous_buffer(state_dict, self.module.config, offsets_info)
+                    rank = int(os.environ.get("RANK", 0))
+                    if rank == 0:
+                        if hasattr(self, "vllm_comm") and self.vllm_comm is not None:
+                            self.vllm_comm.send_data(param_tensor)
+
+        return
+
+    def new_inference_container(self, orig_layer, policy_cls, layer_id):
+        policy = policy_cls(orig_layer, inference=True)
+
+        if self._config.fp16_enabled:
+            inference_dtype = torch.float16
+        elif self._config.bfloat16_enabled:
+            inference_dtype = torch.bfloat16
+        else:
+            inference_dtype = torch.float32
+
+        _container = policy_to_ds_container(
+            policy=policy,
+            config=DeepSpeedInferenceConfig(
+                set_empty_params=True,
+                dtype=inference_dtype,
+                max_out_tokens=self._config.hybrid_engine.max_out_tokens,
+                min_out_tokens=self._config.hybrid_engine.max_out_tokens,
+                transposed_mode=True,
+                return_tuple=False,
+            ),
+            model_config=self.module.config if hasattr(self.module, "config") else None,
+            layer_id=layer_id,
+            child=orig_layer,
+        )
+
+        if self.mpu is not None:
+            if hasattr(self.mpu, "get_model_parallel_world_size"):
+                _container.set_tensor_parallel_config(
+                    self.mpu.get_model_parallel_world_size(),
+                    self.mpu.get_model_parallel_group(),
+                )
+            else:
+                _container.set_tensor_parallel_config(
+                    self.mpu.get_tensor_model_parallel_world_size(),
+                    self.mpu.get_tensor_model_parallel_group(),
+                )
+        else:
+            _container.set_tensor_parallel_config(self._config.hybrid_engine.inference_tp_size, self.mp_group)
+        _container.initialize_tensors(enable_training=True)
+        _container.create_ds_model_config()
+        _container.create_module()
+        _container.module.attention.input_nw = _container.input_nw
+        _container.module.attention.input_nb = _container.input_nb
+        _container.set_params_wo_copy(Z3_enabled=self.Z3_enabled)
+        return _container
+
+    def populate_all_inference_policies(self):
+        self.inference_policies = {}
+        for plcy in replace_policies:
+            _ = plcy(None)
+            if isinstance(plcy._orig_layer_class, list):
+                for orig_layer_class in plcy._orig_layer_class:
+                    self.inference_policies.update({orig_layer_class: (self.new_inference_container, plcy)})
+            elif plcy._orig_layer_class is not None:
+                self.inference_policies.update({plcy._orig_layer_class: (self.new_inference_container, plcy)})
+        self.inference_policies.update(
+            {
+                nn.Linear: (LinearLayer,),
+                nn.Embedding: (EmbeddingLayer,),
+                nn.LayerNorm: (Normalize,),
+                OPTLearnedPositionalEmbedding: (OPTEmbedding,),
+            }
+        )

--- a/atorch/atorch/rl/ds_hybrid_engine/initialize.py
+++ b/atorch/atorch/rl/ds_hybrid_engine/initialize.py
@@ -1,0 +1,203 @@
+from typing import Optional, Union
+
+import torch
+from packaging import version as pkg_version
+from torch.optim import Optimizer
+from torch.optim.lr_scheduler import _LRScheduler
+
+try:
+    import triton  # noqa: F401 # type: ignore
+
+    HAS_TRITON = True
+except ImportError:
+    HAS_TRITON = False
+
+
+from deepspeed.accelerator import get_accelerator
+from deepspeed.git_version_info import git_branch, git_hash, version
+from deepspeed.pipe import PipelineModule
+from deepspeed.runtime import zero
+from deepspeed.runtime.config import DeepSpeedConfig
+from deepspeed.runtime.engine import DeepSpeedEngine, DeepSpeedOptimizerCallable, DeepSpeedSchedulerCallable
+from deepspeed.runtime.pipe.engine import PipelineEngine
+from deepspeed.utils import log_dist, logger
+
+# from deepspeed.runtime.hybrid_engine import DeepSpeedHybridEngine
+from .hybrid_engine import NewDeepSpeedHybridEngine
+
+
+def _parse_version(version_str):
+    """Parse a version string and extract the major, minor, and patch versions."""
+    ver = pkg_version.parse(version_str)
+    return ver.major, ver.minor, ver.micro
+
+
+# Export version information
+__version__ = version
+__version_major__, __version_minor__, __version_patch__ = _parse_version(__version__)
+__git_hash__ = git_hash
+__git_branch__ = git_branch
+
+# Set to torch's distributed package or deepspeed.comm based inside DeepSpeedEngine init
+dist = None
+
+
+def initialize(
+    args=None,
+    model: torch.nn.Module = None,
+    optimizer: Optional[Union[Optimizer, DeepSpeedOptimizerCallable]] = None,
+    model_parameters: Optional[torch.nn.Module] = None,
+    training_data: Optional[torch.utils.data.Dataset] = None,
+    lr_scheduler: Optional[Union[_LRScheduler, DeepSpeedSchedulerCallable]] = None,
+    mpu=None,
+    dist_init_required: Optional[bool] = None,
+    collate_fn=None,
+    config=None,
+    config_params=None,
+):
+    """Initialize the DeepSpeed Engine.
+
+    Arguments:
+        args: an object containing local_rank and deepspeed_config fields.
+            This is optional if `config` is passed.
+
+        model: Required: nn.module class before apply any wrappers
+
+        optimizer: Optional: a user defined Optimizer or Callable that returns an Optimizer object.
+            This overrides any optimizer definition in the DeepSpeed json config.
+
+        model_parameters: Optional: An iterable of torch.Tensors or dicts.
+            Specifies what Tensors should be optimized.
+
+        training_data: Optional: Dataset of type torch.utils.data.Dataset
+
+        lr_scheduler: Optional: Learning Rate Scheduler Object or a Callable that takes an Optimizer
+            and returns a Scheduler object.
+            The scheduler object should define a get_lr(), step(), state_dict(), and load_state_dict() methods
+
+        mpu: Optional: A model parallelism unit object that implements
+            get_{model,data}_parallel_{rank,group,world_size}()
+
+        dist_init_required: Optional: None will auto-initialize torch distributed if needed,
+            otherwise the user can force it to be initialized or not via boolean.
+
+        collate_fn: Optional: Merges a list of samples to form a
+            mini-batch of Tensor(s).  Used when using batched loading from a
+            map-style dataset.
+
+        config: Optional: Instead of requiring args.deepspeed_config you can pass your deepspeed config
+            as an argument instead, as a path or a dictionary.
+
+        config_params: Optional: Same as `config`, kept for backwards compatibility.
+
+    Returns:
+        A tuple of ``engine``, ``optimizer``, ``training_dataloader``, ``lr_scheduler``
+
+        * ``engine``: DeepSpeed runtime engine which wraps the client model for distributed training.
+
+        * ``optimizer``: Wrapped optimizer if a user defined ``optimizer`` is supplied, or if
+          optimizer is specified in json config else ``None``.
+
+        * ``training_dataloader``: DeepSpeed dataloader if ``training_data`` was supplied,
+          otherwise ``None``.
+
+        * ``lr_scheduler``: Wrapped lr scheduler if user ``lr_scheduler`` is passed, or
+          if ``lr_scheduler`` specified in JSON configuration. Otherwise ``None``.
+    """
+    log_dist(
+        "DeepSpeed info: version={}, git-hash={}, git-branch={}".format(__version__, __git_hash__, __git_branch__),
+        ranks=[0],
+    )
+
+    # Disable zero.Init context if it's currently enabled
+    zero.partition_parameters.shutdown_init_context()
+
+    assert model is not None, "deepspeed.initialize requires a model"
+
+    global dist
+    from deepspeed import comm as dist
+
+    dist_backend = get_accelerator().communication_backend_name()
+    dist.init_distributed(dist_backend=dist_backend, dist_init_required=dist_init_required)  # type: ignore
+
+    # Set config using config_params for backwards compat
+    if config is None and config_params is not None:
+        config = config_params
+
+    # Check for deepscale_config for backwards compat
+    if hasattr(args, "deepscale_config") and args.deepscale_config is not None:
+        logger.warning("************ --deepscale_config is deprecated, please use --deepspeed_config ************")
+        if hasattr(args, "deepspeed_config"):
+            assert (
+                args.deepspeed_config is None
+            ), "Not sure how to proceed, we were given both a deepscale_config and deepspeed_config"
+        args.deepspeed_config = args.deepscale_config
+        args.deepscale_config = None
+
+    # Check that we have only one config passed
+    if hasattr(args, "deepspeed_config") and args.deepspeed_config is not None:
+        assert (
+            config is None
+        ), "Not sure how to proceed, we were given deepspeed configs in the deepspeed \
+            arguments and deepspeed.initialize() function call"
+        config = args.deepspeed_config
+    assert config is not None, "DeepSpeed requires --deepspeed_config to specify configuration file"
+
+    if not isinstance(model, PipelineModule):
+        config_class = DeepSpeedConfig(config, mpu)
+        if config_class.hybrid_engine.enabled:
+            engine = NewDeepSpeedHybridEngine(
+                args=args,
+                model=model,
+                optimizer=optimizer,
+                model_parameters=model_parameters,
+                training_data=training_data,
+                lr_scheduler=lr_scheduler,
+                mpu=mpu,
+                dist_init_required=dist_init_required,
+                collate_fn=collate_fn,
+                config=config,
+                config_class=config_class,
+            )
+        else:
+            engine = DeepSpeedEngine(
+                args=args,
+                model=model,
+                optimizer=optimizer,
+                model_parameters=model_parameters,
+                training_data=training_data,
+                lr_scheduler=lr_scheduler,
+                mpu=mpu,
+                dist_init_required=dist_init_required,
+                collate_fn=collate_fn,
+                config=config,
+                config_class=config_class,
+            )
+    else:
+        assert mpu is None, "mpu must be None with pipeline parallelism"
+        mpu = model.mpu()
+        config_class = DeepSpeedConfig(config, mpu)
+        engine = PipelineEngine(
+            args=args,
+            model=model,
+            optimizer=optimizer,
+            model_parameters=model_parameters,
+            training_data=training_data,
+            lr_scheduler=lr_scheduler,
+            mpu=mpu,
+            dist_init_required=dist_init_required,
+            collate_fn=collate_fn,
+            config=config,
+            config_class=config_class,
+        )
+
+    # Restore zero.Init context if necessary
+    zero.partition_parameters.restore_init_context()
+
+    return_items = [
+        engine,
+        engine.optimizer,
+        engine.training_dataloader,
+        engine.lr_scheduler,
+    ]
+    return tuple(return_items)

--- a/atorch/atorch/rl/ds_hybrid_engine/module_inject/containers/__init__.py
+++ b/atorch/atorch/rl/ds_hybrid_engine/module_inject/containers/__init__.py
@@ -1,0 +1,1 @@
+from .llama import DS_LLAMAContainer, LLAMALayerPolicy

--- a/atorch/atorch/rl/ds_hybrid_engine/module_inject/containers/llama.py
+++ b/atorch/atorch/rl/ds_hybrid_engine/module_inject/containers/llama.py
@@ -1,0 +1,175 @@
+# copy from deepspeed https://github.com/microsoft/DeepSpeed/blob/master/deepspeed/module_inject/containers/llama2.py
+import torch
+from deepspeed.model_implementations.transformers.ds_gpt import DeepSpeedGPTInference
+from deepspeed.module_inject.containers.base import BaseTransformerContainer
+from deepspeed.module_inject.containers.features import HybridGatedMLPContainer, HybridSplitQKVContainer
+from deepspeed.module_inject.policy import (
+    TransformerPolicy,
+    maybe_copy,
+    maybe_copy_geglu,
+    maybe_copy_qkv,
+    maybe_get_lora,
+    transformer_param_names,
+)
+from deepspeed.utils.types import ActivationFuncType, NormType
+from torch.nn.parameter import Parameter
+
+# DeepSpeed Team
+from transformers.models.llama.modeling_llama import LlamaDecoderLayer
+
+
+class DS_LLAMAContainer(HybridGatedMLPContainer, HybridSplitQKVContainer, BaseTransformerContainer):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+        # All model specific things should be defined here instead of the base class.
+
+    def create_module(self, config=None):
+
+        _config = config if config is not None else self.ds_model_config
+        _config.rotate_half = True
+        _config.rotate_every_two = False
+        _config.rotary_dim = self.hidden_size // self.num_attention_heads
+        _config.llama = self.policy.client_module.self_attn.config
+        self.module = DeepSpeedGPTInference(_config, mp_group=self.mp_group)
+
+        return self.module
+
+    def set_lora_params(self):
+        """
+        Necessary to implement for `HybridEngineContainer`
+        """
+        self.lora_params = [
+            maybe_get_lora(p)
+            for p in [
+                self.policy.client_module.mlp.up_proj.weight,
+                self.policy.client_module.mlp.gate_proj.weight,
+                self.policy.client_module.mlp.down_proj.weight,
+                self.policy.client_module.self_attn.q_proj.weight,
+                self.policy.client_module.self_attn.k_proj.weight,
+                self.policy.client_module.self_attn.v_proj.weight,
+                self.policy.client_module.self_attn.o_proj.weight,
+            ]
+        ]
+
+    def get_lora_matched_pair(self):
+        up_proj_lora, gate_proj_lora, down_proj_lora, q_lora, k_lora, v_lora, out_lora = self.get_lora_params()
+        ret = [
+            (up_proj_lora, self.inter_up_w),
+            (gate_proj_lora, self.inter_gate_w),
+            (down_proj_lora, self._4hh_w),
+            (out_lora, self.dense_w),
+            (q_lora, self.qw),
+            (k_lora, self.kw),
+            (v_lora, self.vw),
+        ]
+        return ret
+
+    def set_q_k_v(self):
+        """
+        Necessary to implement for `HybridSplitQKVContainer`
+        """
+
+        self.qw = self.policy.client_module.self_attn.q_proj.weight
+        self.qb = None
+        self.kw = self.policy.client_module.self_attn.k_proj.weight
+        self.kb = None
+        self.vw = self.policy.client_module.self_attn.v_proj.weight
+        self.vb = None
+
+    def set_mlp_gate(self):
+        """
+        Necessary to implement for `HybridGatedMLPContainer`
+        """
+        self.inter_up_w = self.policy.client_module.mlp.up_proj.weight
+        self.inter_up_b = None
+        self.inter_gate_w = self.policy.client_module.mlp.gate_proj.weight
+        self.inter_gate_b = None
+
+    def load_params(self, module, sd, weight_quantizer, mp_replace, prefix):
+        param_names = (
+            "self_attn.q_proj.weight",
+            "self_attn.k_proj.weight",
+            "self_attn.v_proj.weight",
+            "self_attn.o_proj.weight",
+            "mlp.up_proj.weight",
+            "mlp.gate_proj.weight",
+            "mlp.down_proj.weight",
+            "input_layernorm.weight",
+            "post_attention_layernorm.weight",
+        )
+
+        maybe_copy_qkv(
+            module.attention,
+            sd,
+            weight_quantizer,
+            mp_replace,
+            "attn_qkvw",
+            [prefix + param_names[0], prefix + param_names[1], prefix + param_names[2]],
+            split_qkv=self.policy.split_qkv,
+        )
+        for i in range(3, 4):
+            maybe_copy(
+                module.attention,
+                sd,
+                weight_quantizer,
+                mp_replace,
+                transformer_param_names[i - 1],
+                prefix + param_names[i],
+            )
+        maybe_copy_geglu(
+            module.mlp, sd, weight_quantizer, mp_replace, "inter_w", [prefix + param_names[4], prefix + param_names[5]]
+        )
+        maybe_copy(module.mlp, sd, weight_quantizer, mp_replace, "output_w", prefix + param_names[6])
+
+        maybe_copy(module.mlp, sd, weight_quantizer, mp_replace, transformer_param_names[8], prefix + param_names[7])
+        maybe_copy(module, sd, weight_quantizer, mp_replace, transformer_param_names[10], prefix + param_names[8])
+
+
+class LLAMALayerPolicy(TransformerPolicy):
+    def __init__(self, client_module, inference=True):
+        super().__init__(
+            inference,
+            mlp_act_func_type=ActivationFuncType.GATED_SILU,
+            norm_type=NormType.RMSNorm,
+        )
+        self.client_module = client_module
+        try:
+
+            LLAMALayerPolicy._orig_layer_class = LlamaDecoderLayer
+        except Exception:
+            LLAMALayerPolicy._orig_layer_class = None
+
+    def get_hidden_heads(self):
+        hidden_heads = (
+            getattr(
+                self.client_module.self_attn.q_proj.weight, "ds_shape", self.client_module.self_attn.q_proj.weight.shape
+            )[1],
+            self.client_module.self_attn.num_heads,
+            self.client_module.input_layernorm.variance_epsilon,
+            getattr(self.client_module.mlp.gate_proj.weight, "ds_shape", self.client_module.mlp.gate_proj.weight.shape)[
+                0
+            ],
+        )
+        return hidden_heads
+
+    def attention(self, enable_training=False):
+        qw = self.client_module.self_attn.q_proj.weight
+        kw = self.client_module.self_attn.k_proj.weight
+        vw = self.client_module.self_attn.v_proj.weight
+
+        qkvw = Parameter(torch.cat((qw, kw, vw), dim=0), requires_grad=enable_training)
+
+        return qkvw, None, self.client_module.self_attn.o_proj.weight, None
+
+    def mlp(self, enable_training=False):
+        mlp1_up = self.client_module.mlp.up_proj.weight
+        mlp1_gate = self.client_module.mlp.gate_proj.weight
+        mlp2 = self.client_module.mlp.down_proj.weight
+
+        mlp1 = Parameter(torch.cat((mlp1_up, mlp1_gate), dim=0), requires_grad=enable_training)
+
+        return mlp1, None, mlp2, None
+
+    def layernorm(self):
+        return self.client_module.post_attention_layernorm.weight, None, self.client_module.input_layernorm.weight, None

--- a/atorch/atorch/rl/ds_hybrid_engine/module_inject/utils.py
+++ b/atorch/atorch/rl/ds_hybrid_engine/module_inject/utils.py
@@ -1,0 +1,23 @@
+from deepspeed.utils import log_dist
+
+
+# helper function to map between DS policies and DS containers
+def policy_to_ds_container(**kwargs):
+
+    from .containers import DS_LLAMAContainer, LLAMALayerPolicy
+
+    policy_to_container = {
+        LLAMALayerPolicy: DS_LLAMAContainer,
+    }
+
+    container = None
+    policy = kwargs["policy"]
+    assert policy is not None, "Policy cannot be None"
+    policy_type = type(policy)
+
+    if policy_type not in policy_to_container:
+        log_dist(f"Policy type {policy_type} not supported", [0])
+    else:
+        container = policy_to_container[policy_type](**kwargs)
+
+    return container

--- a/atorch/atorch/rl/ds_hybrid_engine/replace_policy.py
+++ b/atorch/atorch/rl/ds_hybrid_engine/replace_policy.py
@@ -1,0 +1,9 @@
+# copy from deepspeed https://github.com/microsoft/DeepSpeed/
+from .module_inject.containers import LLAMALayerPolicy
+
+replace_policies = [
+    LLAMALayerPolicy,
+]
+
+# non-transformer-based policies
+generic_policies = []  # type: ignore

--- a/atorch/atorch/rl/inference_backend/vllm_backend.py
+++ b/atorch/atorch/rl/inference_backend/vllm_backend.py
@@ -1,0 +1,49 @@
+import torch
+
+from atorch.common.log_utils import default_logger as logger
+
+try:
+    from vllm import LLM, SamplingParams
+except Exception:
+    logger.warning("vllm not installed")
+
+
+class VLLMComm:
+    def __init__(self, ip, port):
+        from vllm_comm import vllm_comm
+
+        self.client = vllm_comm.vllmClient(ip, port)
+        self.client.create_session()
+
+    def send_data(self, data):
+        self.client.send_data(data.data_ptr(), data.numel() * 2)
+        self.client.delete_session()
+        self.client.create_session()
+
+
+class VLLMBackend:
+    def __init__(self, checkpoint_path=None, gen_kwargs=None, gpu_memory_utilization=0.4, dtype="bfloat16"):
+        self.gen_kwargs = gen_kwargs
+        max_tokens = self.gen_kwargs.get("max_new_tokens", 500)
+        self.sampling_params = SamplingParams(temperature=0, max_tokens=max_tokens)
+        self.llm = LLM(
+            model=checkpoint_path,
+            trust_remote_code=True,
+            gpu_memory_utilization=gpu_memory_utilization,
+            tensor_parallel_size=1,
+            dtype=dtype,
+        )
+        for param in self.llm.llm_engine.workers[0].model.parameters():
+            param.data = torch.empty(0, dtype=param.dtype, device=param.device)
+        torch.cuda.empty_cache()
+        self.tokenizer = None
+
+    def set_train_model_weights(self, train_model):
+        for p1, p2 in zip(self.llm.llm_engine.workers[0].model.parameters(), train_model.parameters()):
+            p1.data = p2.data
+
+    def set_tokenizer(self, tokenizer):
+        self.llm.llm_engine.tokenizer = tokenizer
+
+    def generate(self, prompts):
+        return self.llm.generate(prompts, sampling_params=self.sampling_params)

--- a/atorch/atorch/rl/main.py
+++ b/atorch/atorch/rl/main.py
@@ -1,0 +1,23 @@
+import atorch
+from atorch.rl.config import AtorchRLConfig
+from atorch.rl.data import create_dataset
+from atorch.rl.model_engine import ModelEngine
+from atorch.rl.trainer.ppo_trainer import PPOTrainer
+
+config_file = "my_config.yml"
+
+
+config = AtorchRLConfig.load_yaml(config_file)
+
+atorch.init_distributed()
+
+# create model, optimizer, tokenizer, etc.
+engine = ModelEngine(config)
+
+# create prompt dataset
+dataset = create_dataset(config)
+
+# init trainer
+trainer = PPOTrainer(engine, dataset, config)
+
+trainer.train()

--- a/atorch/atorch/rl/model_engine/__init__.py
+++ b/atorch/atorch/rl/model_engine/__init__.py
@@ -1,0 +1,1 @@
+from .model_engine import ModelEngine, ModelEngineState

--- a/atorch/atorch/rl/model_engine/model_engine.py
+++ b/atorch/atorch/rl/model_engine/model_engine.py
@@ -1,0 +1,496 @@
+import json
+import os
+
+import deepspeed
+import fairscale
+import torch
+from deepspeed.ops.adam import DeepSpeedCPUAdam
+from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+from torch.utils.data import DataLoader
+from torch.utils.data.distributed import DistributedSampler  # noqa: F401
+
+import atorch
+from atorch.auto import auto_accelerate
+from atorch.common.log_utils import default_logger as logger
+from atorch.data.unshuffled_batch_dataloader import DistributedUnshuffledBatchSampler
+from atorch.distributed.distributed import (
+    ParallelGroupContextManager,
+    create_parallel_group,
+    parallel_group,
+    parallel_group_and_ranks,
+)
+from atorch.modules.distributed_modules.transformer import GLMForConditionalGeneration, MegatronGLMModel
+from atorch.rl.model_engine.strategy import get_strategy
+from atorch.rl.model_utils.load_init_model import get_optimizer_class_and_kwargs, get_scheduler_class, init_model
+from atorch.rl.model_utils.model_util import is_trainable_model
+
+
+class ModelEngineState:
+    InitState = 0
+    ExperienceGenerationState = 1
+    RLTrainingState = 2
+    EvaluationState = 3
+
+
+class ModelEngine:
+    def __init__(self, config):
+        """
+        config: AtorchRlConfig
+        atorch_strategy_applied: dict, keep track of whether strategy for training or inferencing has been applied
+        """
+        self.config = config
+        self.state = ModelEngineState.InitState
+        self.model_keys = config.model_keys
+        self.atorch_strategy_applied = {
+            ModelEngineState.ExperienceGenerationState: False,
+            ModelEngineState.RLTrainingState: False,
+        }
+        assert self.model_keys is not None
+        self.init_model_context()
+
+    """ Initialize models, optimizer, tokenizer from config.
+    Also get model optimization strategies for each model in MakeExperienceState and RLTrainingState
+    from config and prepare for them if needed.
+    """
+
+    def init_model_context(self):
+        self.scheduler = {}
+        self.model_configs = {}
+        self.models = {}
+        self.auto_accelerated_models = {}
+        self.auto_accelerated_optimizer = {}
+        self.loss_func = {}
+        self.models_strategies = {}
+        self.optimizer_cls = {}
+        self.optimizer_cls_kwargs = {}
+        self.tokenizer = None
+        self.get_scheduler_class()
+        self.device = torch.device(atorch.local_rank())
+        self.init_child_model()
+
+    def get_scheduler_class(self):
+        self.scheduler_class = get_scheduler_class(self.config.train.scheduler["name"])
+
+    def init_child_model(self):
+        # get strategy torch.native
+        # TODO: use constatns
+        logger.info("training config is {}".format(self.config))
+        for model_type in self.model_keys:
+            self.model_configs[model_type] = getattr(self.config.model, model_type)
+            self.models_strategies[model_type] = get_strategy(
+                self.model_configs[model_type].train_strategy, model_type=model_type
+            )
+            logger.info("model {} train strategy is {}".format(model_type, self.models_strategies[model_type]))
+            # do atorch has some load strategy
+            model = init_model(self.model_configs[model_type])
+            self.models[model_type] = model
+
+            self.optimizer_cls[model_type], self.optimizer_cls_kwargs[model_type] = get_optimizer_class_and_kwargs(
+                model_type, self.model_configs[model_type]
+            )
+            self.apply_strategy_to_child_model(model_type)
+            self.atorch_strategy_applied[ModelEngineState.RLTrainingState] = True
+
+    def apply_strategy_to_child_model(
+        self, model_type, dataset=None, dataloader_args=None, loss_func=None, model_input_format="unpack_sequence"
+    ):
+        if self.models_strategies[model_type] != "torch_native":
+            if model_type in ["actor", "actor_critic_ref", "reward_model", "cost_model"]:
+                with ParallelGroupContextManager(model_type):
+                    if isinstance(self.models_strategies[model_type], str):
+                        ds_config = json.load(open(self.models_strategies[model_type]))
+                        model = self.models[model_type]
+
+                        # initialize torch.optim.AdamW optimizer in trainer
+                        optimizer_class = self.optimizer_cls[model_type]
+                        optimizer_params = self.config.model.model[model_type].optimizer.kwargs
+
+                        optimizer = optimizer_class(
+                            model.parameters(),
+                            **optimizer_params,
+                        )
+
+                        # create scheduler
+                        kwargs = self.config.train.scheduler["kwargs"]
+
+                        # scheduler_class = get_scheduler_class("cosine_warmup")
+                        scheduler = self.scheduler_class(optimizer, **kwargs)
+
+                        # create cpu adam optimizer and replace torch.optim.AadmW.optimizer in accelerator.py
+
+                        if ds_config.get("zero_optimization", None) is not None:
+                            zero_optimization = ds_config["zero_optimization"]
+                            if zero_optimization.get("offload_optimizer", {}).get("device", None) is not None:
+                                defaults = {k: v for k, v in optimizer.defaults.items() if k in ["lr", "weight_decay"]}
+                                optimizer = DeepSpeedCPUAdam(optimizer.param_groups, **defaults)
+                        kwargs = {}
+                        if (
+                            ds_config.get("gradient_accumulation_steps", None)
+                            != self.config.train.gradient_accumulation_steps
+                        ):
+                            ds_config["gradient_accumulation_steps"] = self.config.train.gradient_accumulation_steps
+
+                        if ds_config.get("gradient_clipping", None) and self.config.train.max_grad_norm is not None:
+                            ds_config["gradient_clipping"] = self.config.train.max_grad_norm * 1.0
+
+                        if ds_config.get("bf16", None) is not None:
+                            if ds_config.get("bf16").get("enabled", False):
+                                ds_config.update({"fp16": {"enabled": False, "auto_cast": False}})
+                        kwargs["config_params"] = ds_config
+                        kwargs["model"] = model
+                        kwargs["optimizer"] = optimizer
+                        engine, optimizer, _, _ = deepspeed.initialize(**kwargs)
+                        self.auto_accelerated_models[model_type] = engine
+                        self.auto_accelerated_optimizer[model_type] = optimizer
+                        self.scheduler[model_type] = scheduler
+
+                    else:
+                        status, result, best_strategy = auto_accelerate(
+                            self.models[model_type],
+                            self.optimizer_cls[model_type],
+                            dataset=dataset,
+                            loss_func=loss_func,
+                            prepare_input=None,
+                            model_input_format=model_input_format,
+                            optim_args=self.optimizer_cls_kwargs[model_type],
+                            optim_param_func=None,
+                            dataloader_args=dataloader_args,
+                            ignore_dryrun_on_load_strategy=True,
+                            load_strategy=self.models_strategies[model_type],
+                            find_unused_parameters=True,
+                        )
+                        assert status, "Failed to apply atorch strategy"
+                        logger.info("best strategy for {} is {}".format(model_type, best_strategy))
+                        self.auto_accelerated_models[model_type] = result.model
+                        self.auto_accelerated_optimizer[model_type] = result.optim
+                        self.loss_func[model_type] = result.loss_func
+        else:
+            self.auto_accelerated_models[model_type] = self.models[model_type]
+            optimizer_cls_kwargs = (
+                {} if self.optimizer_cls_kwargs[model_type] is None else self.optimizer_cls_kwargs[model_type]
+            )
+            self.auto_accelerated_optimizer[model_type] = None
+            if self.optimizer_cls[model_type] is not None:
+                self.auto_accelerated_optimizer[model_type] = self.optimizer_cls[model_type](
+                    self.models[model_type].parameters(), **optimizer_cls_kwargs
+                )
+        opt = self.auto_accelerated_optimizer[model_type]
+        if opt is not None and self.scheduler.get(model_type, None) is None:
+            self.scheduler[model_type] = self.scheduler_class(opt, **self.config.train.scheduler["kwargs"])
+
+        # model/optimizer class type is printed to help double check that strategy is applied
+        logger.info(
+            "after atorch applying optimizing strategy for {},  "
+            "the type of model is {} and the type of optimizer is {}".format(
+                model_type, self.auto_accelerated_models[model_type], self.auto_accelerated_optimizer[model_type]
+            )
+        )
+
+    def eval(self):
+        """
+        set all trainable model in model engine in evaluation mode
+        """
+        for _, v in self.auto_accelerated_models.items():
+            v.eval()
+
+    def train(self):
+        """
+        set all trainable model in model engine in train mode
+        """
+        trainable_model = self.get_trainable_model()
+        for model in trainable_model:
+            model.train()
+
+    def get_trainable_model(self):
+        """
+        get trainable model wrapped model engine
+        """
+        trainable_model = []
+        for i in self.model_keys:
+            if is_trainable_model(i):
+                trainable_model.append(self.auto_accelerated_models[i])
+        return trainable_model
+
+    def get_optimizers(self):
+        """
+        get trainable models' optimizers in model engine
+        """
+        optimizers = []
+        for i in self.model_keys:
+            if is_trainable_model(i):
+                optimizers.append(self.auto_accelerated_optimizer[i])
+        return optimizers
+
+    """ Switch to state, and apply corresponding model optimization strategies.
+    """
+
+    def set_state(self, state):
+        if self.state != state:
+            # TODO: apply corresponding strategies to models
+            pass
+        self.state = state
+
+    """Save model/optimizer and scaler state
+    """
+
+    def save(self, path, include_model=True, include_optimizer_state=True):
+        """
+        save model/optimizer state
+        include_optimizer_state: bool, whether to save optimizer state
+        include_model: bool whether to save model state
+        """
+        output_dir = os.path.join(path, "checkpoints")
+        if not os.path.exists(output_dir):
+            os.makedirs(output_dir, exist_ok=True)
+
+        logger.info(f"Saving current state to {output_dir}")
+        for model_key in self.model_keys:
+            # Todo: model is wrapped with different strategy like FSDP, tp, pipeline,
+            # saving strategy varies from strategy to strategy.
+            # atorch is going to be provide accelerated storing and loading method
+            state = {}
+            if is_trainable_model(model_key):
+                model = self.auto_accelerated_models[model_key]
+                opt = self.auto_accelerated_optimizer[model_key]
+                file_name = os.path.join(output_dir, "{}_model.pth".format(model_key))
+                if include_model:
+                    state.update({"model_state_dict": model.state_dict()})
+                if include_optimizer_state:
+                    if isinstance(opt, fairscale.optim.oss.OSS):
+                        opt.consolidate_state_dict()
+                        rank = atorch.rank()
+                        if rank == 0:
+                            state.update({"optimizer_state_dict": opt.state_dict()})
+                            torch.save(state, file_name)
+
+    """Load model/optimizer state.
+    """
+
+    def load(self, path, include_model=True, include_optimizer_state=True):
+        """
+        save model/optimizer state
+        include_optimizer_state: bool, whether to save optimizer state
+        include_model: bool whether to save model state
+        """
+        output_dir = os.path.join(path, "checkpoints")
+
+        for model_key in self.model_keys:
+            # Todo: model is wrapped with different strategy like FSDP, tp, pipeline,
+            # saving strategy varies from strategy to strategy.
+            # atorch is going to be provide accelerated storing and loading method
+            if is_trainable_model(model_key):
+                file_name = os.path.join(output_dir, "{}_model.pth".format(model_key))
+                if not os.path.exists(file_name):
+                    raise Exception("{} not exist".format(file_name))
+                model = self.auto_accelerated_models[model_key]
+                opt = self.auto_accelerated_optimizer[model_key]
+
+                state = torch.load(file_name)
+                if include_model:
+                    model.load_state_dict(state["model_state_dict"])
+                if include_optimizer_state:
+                    opt.load_state_dict(state["optimizer_state_dict"])
+
+        logger.info(f"Saving current state to {output_dir}")
+        for model, opt in zip(self.get_trainable_model(), self.get_optimizers()):
+            # Todo: model is wrapped with different strategy like FSDP, tp, pipeline,
+            # saving strategy varies from strategy to strategy.
+            # atorch is going to be provide accelerated storing and loading method
+
+            state = {
+                "model_state_dict": model.state_dict(),
+            }
+            if include_optimizer_state:
+                state.update({"optimizer_state_dict": opt.state_dict})
+
+            torch.save(state, file_name)
+
+    """Create dataloader from dataset, which will be used in state.
+    if state == ExperienceGenerationState, dataloader for experience generation.
+    if state == RLTrainingState, dataloader for rl training.
+    """
+
+    def create_dataloader(self, dataset, state=None):
+        """
+        create dataloader for make experience and rl training
+        Args:
+            dataset: For making experience, all process reads the same csv file and
+                    get prompts. Each process needs to use seperate prompts to generate
+                    experience. For training, to be decided.
+            state: for debug. Since we can switch model_engine.stat in pre_rl_training_hook
+                    and pre_experience_generation_hook.
+        Returns:
+            dataloader: pytorch dataloader
+        """
+        dataloader = None
+        if state is not None:
+            self.stat = state
+        if self.stat == ModelEngineState.ExperienceGenerationState:
+            ddp_size = atorch.world_size()
+            rank = atorch.rank()
+            # Todo: dataset sampler should take hybrid tensor/model/pipeline parallilism in to consideration
+            dataset_sampler = DistributedSampler(dataset, shuffle=False, num_replicas=ddp_size, rank=rank)
+            dataloader = DataLoader(
+                dataset,
+                shuffle=False,
+                sampler=dataset_sampler,
+                collate_fn=dataset.collate_fn(),
+                batch_size=self.config.generation.batch_size,
+                pin_memory=True,
+                drop_last=True,
+            )
+        elif self.stat == ModelEngineState.EvaluationState:
+            # Todo: dataset sampler should take hybrid tensor/model/pipeline parallilism in to consideration
+            ddp_size = atorch.world_size()
+            rank = atorch.rank()
+            # make sure that every rank has evaluation data
+            # and drop padding dataset
+            dataset_length = len(dataset)
+            i = self.config.generation.batch_size
+            while i * ddp_size < dataset_length:
+                i = i + self.config.generation.batch_size
+            padding_length = i * ddp_size - dataset_length
+            dataset.gen_prompts = dataset.gen_prompts + [dataset.gen_prompts[0]] * padding_length
+
+            dataset_sampler = DistributedUnshuffledBatchSampler(
+                dataset, num_replicas=ddp_size, rank=rank, batch_size=self.config.generation.batch_size
+            )
+            dataloader = DataLoader(
+                dataset,
+                shuffle=False,
+                sampler=dataset_sampler,
+                collate_fn=dataset.collate_fn(),
+                batch_size=self.config.generation.batch_size,
+                pin_memory=True,
+                drop_last=True,
+            )
+        elif self.stat == ModelEngineState.RLTrainingState:
+            dataset.set_tokenizer(self.tokenizer)
+            dataloader = DataLoader(
+                dataset,
+                shuffle=False,
+                collate_fn=dataset.collate_fn(),
+                batch_size=self.config.train.batch_size,
+                pin_memory=True,
+                drop_last=True,
+            )
+        return dataloader
+
+    def world_size(self):
+        return atorch.world_size()
+
+    def post_make_experience_hook(self):
+        pass
+
+    def pre_experience_generation_hook(self):
+        # TODO: change model from training mode to inference mode
+        # for example, the model is warpped as FSDP. But FSDP is not
+        # suitable for inferencing
+        pass
+
+    def pre_make_experience_hook(self):
+        pass
+
+    def apply_strategy(self):
+        if not self.atorch_strategy_applied[ModelEngineState.RLTrainingState]:
+            for model_type in self.config.model_keys:
+                self.apply_strategy_to_child_model(model_type)
+            self.atorch_strategy_applied[ModelEngineState.RLTrainingState] = True
+
+    def pre_rl_training_hook(self):
+        self.apply_strategy()
+        # TODO: recover model from inference to training mode
+
+    def post_rl_training_hook(self):
+        self.eval()
+
+    def unwarp_inference_model(self, model, model_type):
+        """
+        unwarp model for inferencing
+        """
+        if isinstance(model, torch.nn.parallel.DistributedDataParallel) or isinstance(
+            model, fairscale.nn.data_parallel.sharded_ddp.ShardedDataParallel
+        ):
+            # hard code
+            return model
+
+        if isinstance(model, torch.distributed.fsdp.FullyShardedDataParallel) and model_type == "actor":
+            if parallel_group("tensor") is None:
+                create_parallel_group(([("tensor", 2)], None))
+            pg, ranks = parallel_group_and_ranks("tensor")
+            with FSDP.summon_full_params(model):
+                megatron_glm_model = MegatronGLMModel(
+                    model.model.config,
+                    orig_module=model.model.glm,
+                    process_group=pg,
+                    ranks=ranks,
+                    defer_init=False,
+                    orig_module_dst_device="cpu",
+                ).to(atorch.local_rank())
+            print(" megatron_glm_model.parameters")
+            print(megatron_glm_model.word_embeddings.weight)
+            glm_model = GLMForConditionalGeneration(model.model.config)
+            setattr(glm_model, "glm", megatron_glm_model)
+            print(glm_model.glm.word_embeddings.weight)
+
+            return glm_model
+        return model
+
+    def warp_train_model(self, model):
+        """
+        warp model for training
+        """
+
+        # model.float()
+        return model
+
+    def get_model(self, model_type="actor", mode="inference"):
+        model = None
+        if not self.auto_accelerated_models:
+            self.apply_strategy()
+        model = self.auto_accelerated_models[model_type]
+        if mode == "inference":
+            unwrapped_model = self.unwarp_inference_model(model, model_type)
+        else:
+            unwrapped_model = self.warp_train_model(model)
+        return unwrapped_model
+
+    @property
+    def actor(self):
+        return self.auto_accelerated_models.get("actor", None)
+
+    @property
+    def actor_critic_ref(self):
+        return self.auto_accelerated_models.get("actor_critic_ref", None)
+
+    @property
+    def critic(self):
+        return self.auto_accelerated_models.get("critic", None)
+
+    @property
+    def ref_model(self):
+        return self.auto_accelerated_models.get("ref_model", None)
+
+    @property
+    def reward_model(self):
+        return self.auto_accelerated_models.get("reward_model", None)
+
+    @property
+    def cost_model(self):
+        return self.auto_accelerated_models.get("cost_model", None)
+
+    @property
+    def critic_optimizer(self):
+        return self.auto_accelerated_optimizer["critic"]
+
+    @property
+    def actor_optimizer(self):
+        return self.auto_accelerated_optimizer["actor"]
+
+    @property
+    def actor_critic_ref_optimizer(self):
+        return self.auto_accelerated_optimizer["actor_critic_ref"]
+
+    @property
+    def actor_critic_ref_scheduler(self):
+        return self.scheduler["actor_critic_ref"]

--- a/atorch/atorch/rl/model_engine/strategy.py
+++ b/atorch/atorch/rl/model_engine/strategy.py
@@ -1,0 +1,35 @@
+# This file defines some commonly used optimization strategies.
+from atorch.utils.import_util import import_module_from_py_file
+
+
+# use constant to refer actor/critic/reward_model/ref_model
+def get_strategy(file_path, model_type="actor"):
+    """
+    Actor/critic/ref_model/reward_models' strategy
+    could be defined in the same or seperate file.
+    If they are defined in the same file, each strategy
+    should be explicitly announced. For example:
+        actor_strategy = []
+        critic_strategy = []
+        ref_model_strategy = []
+        reward_model_strategy = []
+    """
+    module = import_module_from_py_file(file_path)
+    strategy = None
+    role_strategy = "{}_strategy".format(model_type)
+    if hasattr(module, role_strategy):
+        strategy = getattr(module, role_strategy)
+    elif hasattr(module, "strategy"):
+        strategy = getattr(module, "strategy")
+    else:
+        # if user doesn't define the strategy, atorch would't modify anyting
+        strategy = "torch_native"
+    return strategy
+
+
+def ddp_strategy():
+    return ["parallel_mode"]
+
+
+def zero1_strategy():
+    return ["parallel_mode", "zero1"]

--- a/atorch/atorch/rl/model_utils/llama2_utils.py
+++ b/atorch/atorch/rl/model_utils/llama2_utils.py
@@ -1,0 +1,145 @@
+import re
+
+import torch
+
+
+def get_llama2_params_offsets(config=None, tp_size=1):
+
+    head_coef = config.num_attention_heads // config.num_key_value_heads
+    q_proj_start = 0
+    q_proj_end = q_proj_start + config.hidden_size * config.hidden_size // tp_size
+    k_proj_start = q_proj_end
+    k_proj_end = k_proj_start + config.hidden_size * config.hidden_size // tp_size // head_coef
+    v_proj_start = k_proj_end
+
+    v_proj_end = v_proj_start + config.hidden_size * config.hidden_size // tp_size // head_coef
+    o_proj_start = v_proj_end
+    o_proj_end = o_proj_start + config.hidden_size * config.hidden_size // tp_size
+
+    gate_proj_start = o_proj_end
+    gate_proj_end = gate_proj_start + config.hidden_size * config.intermediate_size // tp_size
+
+    up_proj_start = gate_proj_end
+    up_proj_end = up_proj_start + config.hidden_size * config.intermediate_size // tp_size
+
+    down_proj_start = up_proj_end
+    down_proj_end = down_proj_start + config.hidden_size * config.intermediate_size // tp_size
+
+    down_proj_start = up_proj_end
+    down_proj_end = down_proj_start + config.hidden_size * config.intermediate_size // tp_size
+
+    input_layernorm_start = down_proj_end
+    input_layernorm_end = input_layernorm_start + config.hidden_size
+
+    post_attention_layernorm_start = input_layernorm_end
+    post_attention_layernorm_end = post_attention_layernorm_start + config.hidden_size
+
+    offsets_info = {
+        "q_proj": [q_proj_start, q_proj_end],
+        "k_proj": [k_proj_start, k_proj_end],
+        "v_proj": [v_proj_start, v_proj_end],
+        "o_proj": [o_proj_start, o_proj_end],
+        "gate_proj": [gate_proj_start, gate_proj_end],
+        "up_proj": [up_proj_start, up_proj_end],
+        "down_proj": [down_proj_start, down_proj_end],
+        "input_layernorm": [input_layernorm_start, input_layernorm_end],
+        "post_attention_layernorm": [post_attention_layernorm_start, post_attention_layernorm_end],
+    }
+
+    return offsets_info
+
+
+def move_weight_to_continuous_buffer(state_dict, config, offsets_info, tp_size=1, tp_rank=0):
+    q_proj_shard_size = config.hidden_size // tp_size
+    num_kv_heads_per_gpu = max(1, config.num_key_value_heads // tp_size)
+    kv_proj_shard_size = config.hidden_size // config.num_attention_heads * num_kv_heads_per_gpu
+
+    attention_weight_specs = [
+        # (weight_name, shard_size, offset)
+        ("q_proj", q_proj_shard_size, 0),
+        ("k_proj", kv_proj_shard_size, q_proj_shard_size),
+        ("v_proj", kv_proj_shard_size, q_proj_shard_size + kv_proj_shard_size),
+    ]
+    param_layer_dict = {}
+    param_name_layer_dict = {}
+    for name, loaded_weight in state_dict.items():
+        layer_id = re.findall(r"\d+", name)
+        if len(layer_id) == 0:
+            # non decoder layer parameter
+            continue
+        else:
+            layer_id = int(layer_id[0])
+            if layer_id not in param_layer_dict.keys():
+                param_layer_dict[layer_id] = [loaded_weight]
+                param_name_layer_dict[layer_id] = [name]
+            else:
+                param_layer_dict[layer_id].append(loaded_weight)
+                param_name_layer_dict[layer_id].append(name)
+    fisrt_layer = sorted([layer_id for layer_id in param_layer_dict.keys()])[0]
+
+    offsets_parameters_num = [p[1] - p[0] for p in offsets_info.values()]
+    num_param_per_block = sum(offsets_parameters_num)
+    dtype = [p.dtype for p in param_layer_dict[fisrt_layer]][0]
+    device = [p.device for p in param_layer_dict[fisrt_layer]][0]
+    num_param_decoder_layers = num_param_per_block * len(param_layer_dict.keys())
+    param_all_block_decoder_layers = torch.zeros(num_param_decoder_layers, dtype=dtype, device=device)
+
+    for layer_id in param_layer_dict.keys():
+
+        param_start = (layer_id - fisrt_layer) * num_param_per_block
+        param_end = (layer_id + 1 - fisrt_layer) * num_param_per_block
+        param = param_all_block_decoder_layers.data[param_start:param_end]
+        for loaded_weight, name in zip(param_layer_dict[layer_id], param_name_layer_dict[layer_id]):
+
+            if "rotary_emb.inv_freq" in name:
+                continue
+
+            is_attention_weight = False
+
+            for weight_name, shard_size, _ in attention_weight_specs:
+
+                if weight_name not in name:
+                    continue
+
+                shard_size = loaded_weight.shape[0] // tp_size
+                shard_id = tp_rank
+                loaded_weight = loaded_weight[shard_size * shard_id : shard_size * (shard_id + 1)]
+                param_slice = param.data[offsets_info[weight_name][0] : offsets_info[weight_name][1]]
+                param_slice.copy_(loaded_weight.view_as(param_slice))
+
+                is_attention_weight = True
+                break
+
+            if is_attention_weight:
+                continue
+
+            is_gate_up_weight = False
+            for stride_id, weight_name in enumerate(["gate_proj", "up_proj"]):
+                if weight_name not in name:
+                    continue
+                shard_size = loaded_weight.shape[0] // tp_size
+                loaded_weight = loaded_weight[shard_size * tp_rank : shard_size * (tp_rank + 1)]
+                param_slice = param.data[offsets_info[weight_name][0] : offsets_info[weight_name][1]]
+                param_slice.copy_(loaded_weight.view_as(param_slice))
+                is_gate_up_weight = True
+                break
+            if is_gate_up_weight:
+                continue
+
+            for weight_name in ["down_proj", "o_proj"]:
+                if weight_name not in name:
+                    continue
+                shard_size = loaded_weight.shape[1] // tp_size
+                start_idx = tp_rank * shard_size
+                end_idx = (tp_rank + 1) * shard_size
+
+                loaded_weight = loaded_weight[:, start_idx:end_idx]
+                param_slice = param.data[offsets_info[weight_name][0] : offsets_info[weight_name][1]]
+                param_slice.copy_(torch.clone(loaded_weight).view_as(param_slice))
+
+            for weight_name in ["input_layernorm", "post_attention_layernorm"]:
+                if weight_name not in name:
+                    continue
+                param_slice = param.data[offsets_info[weight_name][0] : offsets_info[weight_name][1]]
+                param_slice.copy_(loaded_weight.view_as(param_slice))
+    return param_all_block_decoder_layers

--- a/atorch/atorch/rl/model_utils/load_init_model.py
+++ b/atorch/atorch/rl/model_utils/load_init_model.py
@@ -1,0 +1,157 @@
+import importlib
+import os
+
+import deepspeed
+import torch
+import transformers  # noqa: F401
+from torch import nn
+from transformers import AutoTokenizer, get_cosine_schedule_with_warmup
+
+from atorch.common.log_utils import default_logger as logger
+from atorch.utils.import_util import import_module_from_py_file
+from atorch.utils.meta_model_utils import init_empty_weights_with_disk_offload
+
+
+def get_optimizer(optimizer_name):
+    if optimizer_name == "torch.optim.adam":
+        return torch.optim.Adam
+    elif optimizer_name == "torch.optim.adamw":
+        return torch.optim.AdamW
+    else:
+        raise Exception("unsupport optimizer")
+
+
+def get_scheduler_class(scheduler_name):
+    cls = None
+    if scheduler_name == "cosine_warmup":
+        cls = get_cosine_schedule_with_warmup
+    else:
+        raise Exception("unsupport scheduler")
+    return cls
+
+
+def get_optimizer_class_and_kwargs(model: str, config):
+    optimizer_cls, kwargs = None, None
+    if model not in ["ref_model", "reward_model", "cost_model"]:
+        name = config.optimizer.name
+        kwargs = config.optimizer.kwargs
+        optimizer_cls = get_optimizer(name)
+    return optimizer_cls, kwargs
+
+
+def load_transformers_pretrained_model(model_cls, model_dir, lazy_load, peft_config=None, **model_params):
+    if model_cls.startswith("transformers"):
+        # load hugging face model by function which
+        # has from_pretrained method such as transformers.AutoModelForSeq2SeqLM
+        model_cls = eval(model_cls)
+        assert hasattr(model_cls, "from_pretrained"), "model doesn't from_pretrained method"
+        from_pretrained = getattr(model_cls, "from_pretrained")
+        if lazy_load:
+            # TODO: test with loading multity model cases
+            with init_empty_weights_with_disk_offload(ignore_tie_weights=False):
+                model = from_pretrained(model_dir, trust_remote_code=True)
+        else:
+            model = from_pretrained(model_dir, trust_remote_code=True)
+    else:
+        # user defined pretrained model, for exapmple
+        # benchmarks.glm_rlhf.reward_model.reward_model.RewardModel
+        # we need to import benchmarks.glm_rlhf.reward_model.reward_model module
+        # and get RewardModel
+        module = model_cls.split(".")[-1]
+        model_class_path = model_cls.replace(module, "").strip(".")
+        model_module = importlib.import_module(model_class_path)
+        model_cls = getattr(model_module, module)
+        hasattr(model_cls, "from_pretrained")
+        from_pretrained = getattr(model_cls, "from_pretrained")
+        if False:
+            # TODO: test with loading multity model cases
+            with init_empty_weights_with_disk_offload(ignore_tie_weights=False):
+                model = from_pretrained(model_dir, **model_params)
+        else:
+            # only work for modeling definition in antnlp/solutions/anllm/examples/rlhf/rl
+            if peft_config is None:
+                model = from_pretrained(model_dir, **model_params)
+            else:
+                model = from_pretrained(model_dir, peft_config=peft_config, **model_params)
+    return model
+
+
+def initialize_model(model_cls, model_path, lazy_load, **model_params):
+    model_module = import_module_from_py_file(model_path)
+    module = getattr(model_module, model_cls)
+    if not lazy_load:
+        model = module(**model_params)
+    else:
+        # to be developed
+        pass
+    return model
+
+
+def init_model(config):
+    # for local debug mode model initialization
+    # device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    model_path = config.model_path
+    model_cls = config.model_cls
+    model_params = config.model_params
+    peft_config = config.peft_config
+    lazy_load = config.lazy_load
+    if os.path.isdir(model_path):
+        # for hugging face model, xxx.from_pretrained is used to load model
+        # and model_path is dir
+        model = load_transformers_pretrained_model(
+            model_cls, model_path, lazy_load, **model_params, peft_config=peft_config
+        )
+    else:
+        # model_path is python file path,
+        # the module is imported and class is initialized
+        model = initialize_model(model_cls, model_path, lazy_load, **model_params)
+    # model.to(device)
+    return model
+
+
+def init_tokenizer(config):
+    tokenizer_path = config.tokenizer_path
+    tokenizer = AutoTokenizer.from_pretrained(tokenizer_path, trust_remote_code=True)
+    return tokenizer
+
+
+def load_ds_model_with_zero3_partition(
+    model_class,
+    model_config_class,
+    model_config_folder=None,
+    checkpoint_path=None,
+    ds_config_dict_or_path=None,
+    prefix="",
+):
+    """
+    Allocate a partitioned module, initialize its weight randomly
+    Load checkpoint only on rank-0 to avoid oom and broadcast to other ranks.
+    For models bigger than the memory of a single GPU, this method is required.
+    """
+    if checkpoint_path is None:
+        logger.info("checkpoint path is None and tring to load pytorch_model.bin in {}".format(model_config_folder))
+        checkpoint_path = os.path.join(model_config_folder, "pytorch_model.bin")
+        assert os.path.exists(checkpoint_path), "{} doesn't exist".format(checkpoint_path)
+
+    with deepspeed.zero.Init(config_dict_or_path=ds_config_dict_or_path):
+        configuration = model_config_class.from_pretrained(model_config_folder, trust_remote_code=True)
+        model = model_class(configuration)
+    if deepspeed.comm.get_rank() == 0:
+        state_dict = torch.load(checkpoint_path, map_location="cpu")
+    else:
+        state_dict = None
+
+    def load(module: nn.Module, prefix=prefix):
+        # because zero3 puts placeholders in model params, this context
+        # manager gathers (unpartitions) the params of the current layer, then loads from
+        # the state dict and then re-partitions them again
+        with deepspeed.zero.GatheredParameters(list(module.parameters(recurse=False)), modifier_rank=0):
+            if deepspeed.comm.get_rank() == 0:
+                module._load_from_state_dict(state_dict, prefix, {}, False, [], [], [])
+        for name, child in module._modules.items():
+            if child is not None:
+                load(child, prefix + name + ".")
+
+    load(model, prefix=prefix)
+    torch.cuda.empty_cache()
+    return model

--- a/atorch/atorch/rl/model_utils/model_util.py
+++ b/atorch/atorch/rl/model_utils/model_util.py
@@ -1,0 +1,340 @@
+import functools
+import os
+import random
+from typing import MutableMapping, Tuple, Union
+
+import numpy as np
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+import transformers
+
+
+def set_seed(seed: int):
+    """
+    Sets seeds across package dependencies for reproducibility.
+    """
+    seed += int(os.environ.get("RANK", 0))
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed(seed)
+
+
+# based on https://github.com/CarperAI/trlx/blob/main/trlx/utils/modeling.py
+def make_head(n_embd: int, out: int, dtype: type = torch.float32) -> nn.Sequential:
+    """Returns a generic sequential MLP head."""
+    return nn.Sequential(
+        nn.Linear(n_embd, n_embd * 2, dtype=dtype),
+        nn.ReLU(),
+        nn.Linear(n_embd * 2, out, dtype=dtype),
+    )
+
+
+# based on https://github.com/CarperAI/trlx/blob/main/trlx/utils/modeling.py
+def freeze_bottom_causal_layers(model: nn.Module, num_layers_unfrozen: int = 0):
+    """Freezes the bottom transformer block layers of the specified model."""
+    hidden_layers = hf_get_decoder_blocks(model)
+    if num_layers_unfrozen == 0:
+        hidden_layers_to_freeze = list(hidden_layers)
+    elif num_layers_unfrozen > 0:
+        hidden_layers_to_freeze = list(hidden_layers)[:-num_layers_unfrozen]
+    else:
+        hidden_layers_to_freeze = []
+
+    glm_embeddings_to_freeze = hf_get_glm_embeddings(model)
+    for layer in hidden_layers_to_freeze + glm_embeddings_to_freeze:
+        layer.requires_grad_(False)
+
+
+# based on https://github.com/CarperAI/trlx/blob/main/trlx/utils/modeling.py
+def rhasattr(obj, attr):
+    """A chain-able attribute version of hasattr. For example, to check if
+    `obj` has the attribute `foo.bar.baz`, you can use:
+        `rhasattr(obj, "foo.bar.baz")`
+    Reference: https://stackoverflow.com/a/67303315
+    """
+    _nested_attrs = attr.split(".")
+    _curr_obj = obj
+    for _a in _nested_attrs[:-1]:
+        if hasattr(_curr_obj, _a):
+            _curr_obj = getattr(_curr_obj, _a)
+        else:
+            return False
+    return hasattr(_curr_obj, _nested_attrs[-1])
+
+
+# copy from https://github.com/CarperAI/trlx/blob/main/trlx/utils/modeling.py
+def rgetattr(obj, attr, *args):
+    """A chain-able attribute version of getattr. For example, to get the
+    attribute `foo.bar.baz` from `obj`, you can use:
+        `rgetattr(obj, "foo.bar.baz")`
+    Reference: https://stackoverflow.com/a/31174427
+    """
+
+    def _getattr(obj, attr):
+        return getattr(obj, attr, *args)
+
+    return functools.reduce(_getattr, [obj] + attr.split("."))
+
+
+# based on https://github.com/CarperAI/trlx/blob/main/trlx/utils/modeling.py
+def findattr(obj, attrs):
+    for attr in attrs:
+        if rhasattr(obj, attr):
+            return rgetattr(obj, attr)
+    raise ValueError(f"Could not find an attribute from `{attrs}` in `{obj}`")
+
+
+# based on https://github.com/CarperAI/trlx/blob/main/trlx/utils/modeling.py
+def hf_get_decoder(model: nn.Module) -> nn.Module:
+    """Returns the causal decoder backbone of the specified HuggingFace transformers
+    model.
+    NOTE: Different model configurations have different causal decoder attribute
+    names.
+        - transformer: (GPT2LMHeadModel, GPTJConfig, GLMModel)
+        - model.decoder: (OPTConfig, BloomConfig)
+        - gpt_neox: (GPTNeoXConfig)
+        - glm.transformer: (GLMForConditionalGeneration)
+    """
+    decoder_attrs = (
+        "transformer",
+        "model.decoder",
+        "gpt_neox",
+        "decoder",
+        "glm.transformer",
+    )
+    return findattr(model, decoder_attrs)
+
+
+# based on https://github.com/CarperAI/trlx/blob/main/trlx/utils/modeling.py
+
+
+def hf_get_decoder_final_norm(model: nn.Module) -> float:
+    """Returns the final (layer) norm of the specified decoder.
+    NOTE: Different model configurations have different final norm attribute names.
+        - transformer.ln_f: (GPT2LMHeadModel, GPTJForCausalLM)
+        - model.decoder.final_layer_norm: (OPTForCausalLM)
+        - gpt_neox.layers.final_layer_norm: (GPTNeoXForCausalLM)
+        - glm.transformer.final_layernorm: (GLMForConditionalGeneration)
+        - transformer.final_layernorm: (GLMModel)
+    """
+    norm_attrs = (
+        "transformer.ln_f",
+        "model.decoder.final_layer_norm",
+        "decoder.final_layer_norm",
+        "gpt_neox.final_layer_norm",
+        "glm.transformer.final_layernorm",
+        "transformer.final_layernorm",
+    )
+    return findattr(model, norm_attrs)
+
+
+# copy from https://github.com/CarperAI/trlx/blob/main/trlx/utils/modeling.py
+def hf_get_decoder_blocks(model):
+    """Returns the decoder hidden layers of the specified model.
+    NOTE: Different model configurations have different hidden layer attribute names.
+        - transformer.h: (BloomForCausalLM, GPT2LMHeadModel, GPTJForCausalLM)
+        - model.decoder.layers: (OPTForCausalLM)
+        - gpt_neox.layers: (GPTNeoXForCausalLM)
+        - decoder.block: (T5ForConditionalGeneration)
+        - glm.transformer.layers: (GLMForConditionalGeneration)
+        - transformer.layers: (GLMModel)
+    """
+    hidden_layers_attrs = (
+        "h",
+        "layers",
+        "decoder.layers",
+        "transformer.h",
+        "model.decoder.layers",
+        "gpt_neox.layers",
+        "decoder.block",
+        "glm.transformer.layers",
+        "glm.word_embeddings",
+        "glm.transformer.position_embeddings",
+        "glm.transformer.block_position_embeddings",
+        "transformer.layers",
+        "word_embeddings",
+        "transformer.position_embeddings",
+        "transformer.block_position_embeddings",
+    )
+    return findattr(model, hidden_layers_attrs)
+
+
+# based on https://github.com/CarperAI/trlx/blob/main/trlx/utils/modeling.py
+def hf_get_glm_embeddings(model):
+    glm_embeddings_attrs = (
+        "glm.word_embeddings",
+        "glm.transformer.position_embeddings",
+        "glm.transformer.block_position_embeddings",
+        "word_embeddings",
+        "transformer.position_embeddings",
+        "transformer.block_position_embeddings",
+    )
+    all_embeddings = []
+    for attr in glm_embeddings_attrs:
+        if rhasattr(model, attr):
+            all_embeddings.append(rgetattr(model, attr))
+    return all_embeddings
+
+
+# copy from https://github.com/CarperAI/trlx/blob/main/trlx/utils/modeling.py
+def hf_get_lm_head(model: nn.Module) -> nn.Module:
+    """Returns the language modeling (lm) head of the specified HuggingFace
+    transformers model.
+    NOTE: Different model configurations have different `lm_head` attribute names.
+        - lm_head: (GPT2LMHeadModel, BloomForCausalLM)
+        - embed_out: (GPTNeoXForCausalLM)
+    """
+    return model.get_output_embeddings()
+
+
+# based on https://github.com/CarperAI/trlx/blob/main/trlx/utils/modeling.py
+def hf_get_hidden_size(config):
+    """Returns the hidden layer dimensionality of the model architecture specified
+    by the HuggingFace transformers config.
+    NOTE: Different model configurations have different hidden size attribute names.
+        - hidden_size: (OPTConfig, BloomConfig, GLMConfig)
+        - n_embd: (GPT2Config, GPTJConfig)
+        - d_model: (PegasusConfig, XLNetConfig)
+    """
+    hidden_size_attrs = ("hidden_size", "n_embd", "d_model")
+    return findattr(config, hidden_size_attrs)
+
+
+# based on https://github.com/CarperAI/trlx/blob/main/trlx/utils/modeling.py
+def hf_get_num_hidden_layers(config: transformers.PretrainedConfig) -> int:
+    """Returns the number of hidden layers in the model architecture specified
+    by the HuggingFace transformers config.
+    NOTE: Different model configurations have different number-of-layers attribute
+    names.
+        - num_hidden_layers: (GPTNeoXConfig, OPTConfig)
+        - n_layer: (GPT2Config, GPTJConfig, BloomConfig)
+        - num_layers: (GLMConfig)
+    """
+    num_hidden_layers_attrs = ("num_hidden_layers", "n_layer", "num_layers")
+    return findattr(config, num_hidden_layers_attrs)
+
+
+# based on https://github.com/CarperAI/trlx/blob/main/trlx/utils/modeling.py
+def get_global_statistics(xs: torch.Tensor) -> Tuple[float, float, int]:
+    """
+    Computes element-wise mean and variance of the tensor across processes
+    """
+    sum_and_count = torch.tensor([xs.sum(), xs.numel()], device=xs.device)
+    dist.all_reduce(sum_and_count, dist.ReduceOp.SUM)
+    global_sum, count = sum_and_count
+    global_mean = global_sum / count
+
+    sum_var = torch.sum((xs - global_mean) ** 2)
+    dist.all_reduce(sum_var, dist.ReduceOp.SUM)
+    global_var = sum_var / count
+    return global_mean, global_var, count
+
+
+# based on https://github.com/CarperAI/trlx/blob/main/trlx/utils/modeling.py
+def whiten(xs: torch.Tensor, shift_mean=True, distributed=True) -> torch.Tensor:
+    """Whitens values"""
+    if distributed and dist.is_initialized():
+        mean, var, _ = get_global_statistics(xs)
+    else:
+        var, mean = torch.var_mean(xs)
+
+    whitened = (xs - mean) * torch.rsqrt(var + 1e-8)
+    if not shift_mean:
+        whitened += mean
+    return whitened
+
+
+# based on https://github.com/CarperAI/trlx/blob/main/trlx/utils/modeling.py
+def logprobs_of_labels(logits, labels):
+    """Log probabilities of the labels
+
+    These are calculated from the logits."""
+    logprobs = F.log_softmax(logits, dim=-1)
+    logprobs_labels = torch.gather(logprobs, dim=-1, index=labels.unsqueeze(-1))
+    return logprobs_labels.squeeze(-1)
+
+
+# based on https://github.com/CarperAI/trlx/blob/main/trlx/utils/modeling.py
+def flatten_dict(
+    d: Union[dict, MutableMapping],
+    parent_key: str = "",
+    sep: str = "/",
+):
+    # From: https://stackoverflow.com/a/6027615
+    items = []
+    for k, v in d.items():
+        new_key = parent_key + sep + k if parent_key else k
+        if isinstance(v, MutableMapping):
+            items.extend(flatten_dict(v, new_key, sep=sep).items())
+        else:
+            items.append((new_key, v))
+    return dict(items)
+
+
+# based on https://github.com/CarperAI/trlx/blob/main/trlx/utils/modeling.py
+def get_tensor_stats(xs: torch.Tensor, mask: torch.Tensor, n: int):
+    mean = (xs * mask).sum() / n
+    torch_inf = torch.tensor(np.inf, dtype=xs.dtype).to(xs.device)
+    return dict(
+        mean=mean.item(),
+        min=torch.where(mask.bool(), xs, torch_inf).min().item(),
+        max=torch.where(mask.bool(), xs, -torch_inf).max().item(),
+        std=torch.sqrt(((xs - mean) * mask).pow(2).sum() / n).item(),
+    )
+
+
+# based on https://github.com/CarperAI/trlx/blob/main/trlx/utils/modeling.py
+class RunningMoments:
+    def __init__(self):
+        """
+        Calculates the running mean and standard deviation of a data stream. Modified version of
+        https://github.com/DLR-RM/stable-baselines3/blob/a6f5049a99a4c21a6f0bcce458ca3306cef310e0/stable_baselines3/common/running_mean_std.py
+        """
+        self.mean = 0
+        self.std = 1
+        self.var = 1
+        self.count = 1e-24
+
+    def update(self, xs):
+        """Updates running moments from batch's moments computed across ranks"""
+        if dist.is_initialized():
+            xs_mean, xs_var, xs_count = get_global_statistics(xs)
+        else:
+            xs_count = xs.numel()
+            xs_var, xs_mean = torch.var_mean(xs, unbiased=False)
+
+        delta = xs_mean - self.mean
+        tot_count = self.count + xs_count
+
+        new_sum = xs_var * xs_count
+        # correct old_sum deviation accounting for the new mean
+        old_sum = self.var * self.count + delta**2 * self.count * xs_count / tot_count
+        tot_sum = old_sum + new_sum
+
+        self.mean += delta * xs_count / tot_count
+        self.var = tot_sum / tot_count
+        self.std = (self.var * tot_count / (tot_count - 1)).sqrt()
+        self.count = tot_count
+
+        return xs_mean, (xs_var * xs_count / (xs_count - 1)).sqrt()
+
+
+class FixedKLController:
+    """Fixed KL controller."""
+
+    def __init__(self, kl_coef):
+        self.value = kl_coef
+
+    def update(self, current: float, n_steps: int):
+        """Returns updated KL coefficient, βₜ₊₁.
+        Arguments:
+            current: The current KL value between the newest policy and the initial policy.
+        """
+        pass
+
+
+def is_trainable_model(model_name):
+    return "actor" in model_name or "critic" in model_name

--- a/atorch/atorch/rl/model_utils/redis_util.py
+++ b/atorch/atorch/rl/model_utils/redis_util.py
@@ -1,0 +1,69 @@
+import json
+import os
+import threading
+from queue import Queue
+
+import redis  # type: ignore
+
+
+class RMQ(object):
+    def __init__(self, topic_name, ip="127.0.0.1", port=6379, queue=None):
+
+        # pool = ConnectionPool.from_url(url=url, decode_responses=True)
+        self.client = redis.Redis(
+            host=ip, port=port, decode_responses=True  # <-- this will ensure that binary data is decoded
+        )
+        self.topic_name = topic_name
+        self.queue = queue
+
+    def publish(self, data, topic_name):
+        self.client.publish(topic_name, data)
+
+    def subscribe(self):
+        pub = self.client.pubsub()
+        pub.subscribe(self.topic_name)
+        return pub
+
+    def run_subscribe(self):
+        pub = self.subscribe()
+        for message in pub.listen():
+            message_type = message["type"]
+            if message_type == "subscribe":
+                continue
+            else:
+                if message["data"] == "STOP":
+                    print("Stopping subscriber...")
+                    pub.unsubscribe()
+                    break
+                else:
+                    self.queue.put(message["data"])
+
+
+class RedisDataLoader:
+    def __init__(self, ip="127.0.0.1", port=6379, batch_size=4):
+        self.rank = os.environ.get("RANK", "0")
+        self.queue = Queue()
+        self.batch_size = batch_size
+        self.redis_client = RMQ(self.rank, ip=ip, port=port, queue=self.queue)
+        self.start_redis_client()
+
+    def start_redis_client(self):
+        t1 = threading.Thread(target=self.redis_client.run_subscribe, args=())
+        t1.start()
+
+    def __iter__(self):
+        return self
+
+    def __len__(self):
+        # TODO get length from csv file
+        return 100
+
+    def __next__(self):
+        batch = {"prompt": [], "prompt_att_mask": [], "output": [], "sample": []}
+        while len(batch["prompt"]) < self.batch_size:
+            ele = self.queue.get()
+            ele = json.loads(ele)
+            batch["prompt"].append(ele["prompt"])
+            batch["output"].append(ele["output"])
+            batch["sample"].append(ele["prompt"] + ele["output"])
+        return batch

--- a/atorch/atorch/rl/ppo_utils/ppo_util.py
+++ b/atorch/atorch/rl/ppo_utils/ppo_util.py
@@ -1,0 +1,180 @@
+import torch
+
+from atorch.rl.model_utils.model_util import get_tensor_stats, logprobs_of_labels, whiten
+
+
+def dist_fn(p):
+    """
+    Creates a categorical distribution parameterized by logits
+
+    Args:
+        p: logits, torch.tensor, batch_size*sequence_length*embedding_size
+    Return:
+        categorical distribution
+    """
+    return torch.distributions.Categorical(logits=p)
+
+
+# based on https://github.com/CarperAI/trlx/blob/main/trlx/models/modeling_ppo.py
+def get_kl_penalty(logits, ref_logits, samples, glm_generation_inputs, attention_mask, kl_controller_value):
+    """
+    Args:
+        logits: logits from actor, torch.tensor, batch_size*sequence_length*embedding_size.
+                Logits is compromised of prompts_logits, padding_logits, response_logits and only response logits
+                is needed.
+        ref_logits: ref logits from ref model, torch.tensor, batch_size*sequence_length*embedding_size
+        samples:
+        attention: torch.tensor
+        kl_controller_value:
+    Return:
+        logprobs: logprobs for response
+        kl_penalty: kl_penalty for response
+        mean_kl: average for response
+    """
+    stats = {}
+    logprobs = logprobs_of_labels(logits[:, :-1, :], samples[:, 1:])
+    ref_logprobs = logprobs_of_labels(ref_logits[:, :-1, :], samples[:, 1:])
+    prompt_tensors = glm_generation_inputs.input_ids
+    start = prompt_tensors.shape[1] - 1
+    ends = start + attention_mask[:, start:].sum(1)
+    n_samples = prompt_tensors.shape[0]
+    log_ratio = (logprobs - ref_logprobs) * attention_mask[:, :-1]
+    mean_kl = (log_ratio.exp() - 1 - log_ratio).mean()
+    kl_penalty = kl_controller_value * -log_ratio
+
+    # to be added to tensorboard
+    stats["policy/mean_log_ratio"] = log_ratio.mean().item()
+    stats["policy/mean_kl_penalty"] = kl_penalty.mean().item()
+
+    kl_penalty = [xs[start : ends[ix]] for ix, xs in enumerate(kl_penalty)]
+    logprobs = [logprobs[ix, start : ends[ix]] for ix in range(n_samples)]
+    return logprobs, kl_penalty, mean_kl, stats
+
+
+# based on https://github.com/CarperAI/trlx/blob/main/trlx/models/modeling_ppo.py
+def get_rewards(kl_penalty, scores, logprobs):
+    """
+    get_rewards
+
+    Args:
+        kl_penalty: a list of tensors, batch_size*sequence_length
+        scores: torch.tensor, scalar calculated by reward model for every str_sample
+        logprobs: torch.tensor, batch_size*sequence_length*embedding_size
+    Return:
+        categorical distribution
+    """
+
+    n_samples = scores.shape[0]
+    all_rewards = []
+    for sample_idx in range(n_samples):
+        if len(kl_penalty[sample_idx]) == 0 or len(logprobs[sample_idx]) == 0:
+            continue
+        rewards = kl_penalty[sample_idx]
+        rewards[-1] += scores[sample_idx]
+        all_rewards.append(rewards)
+    return all_rewards
+
+
+# based on https://github.com/CarperAI/trlx/blob/main/trlx/models/modeling_ppo.py
+def loss(logprobs, values, old_logprobs, old_values, advantages, returns, mask, logits, config=None):
+    """PPO objective function.
+    References:
+    - https://stable-baselines.readthedocs.io/en/master/modules/ppo2.html
+    """
+    clip_ratio = config.clip_ratio
+    cliprange_value = config.cliprange_value
+    cliprange = config.cliprange
+    vf_coef = config.vf_coef
+    ent_coef = config.ent_coef
+    values_clipped = torch.clamp(
+        values,
+        old_values - cliprange_value,
+        old_values + cliprange_value,
+    )
+    n = mask.sum()
+
+    vf_loss1 = (values - returns) ** 2
+    vf_loss2 = (values_clipped - returns) ** 2
+    vf_loss = 0.5 * torch.sum(torch.max(vf_loss1, vf_loss2) * mask) / n
+    vf_clipfrac = torch.sum((vf_loss2 > vf_loss1).float() * mask) / n
+
+    log_ratio = (logprobs - old_logprobs) * mask
+    ratio = torch.exp(log_ratio)
+    # Unbiased KL-div estimates (`k3`). Ref: http://joschu.net/blog/kl-approx.html
+    if clip_ratio:
+        ratio = torch.clamp(ratio, 1.0 - cliprange, 1.0 + cliprange)
+
+    with torch.no_grad():
+        approx_kl = torch.mean((ratio - 1) - log_ratio)  # noqa: F841
+
+    pg_loss1 = -advantages * ratio
+    pg_loss2 = -advantages * torch.clamp(
+        ratio,
+        1.0 - cliprange,
+        1.0 + cliprange,
+    )
+    pg_loss = torch.sum(torch.max(pg_loss1, pg_loss2) * mask) / n
+    pg_clipfrac = torch.sum((pg_loss2 > pg_loss1).float() * mask) / n
+
+    # compared with trlx loss function, entroy loss is added
+    dist = dist_fn(logits)
+    ent_loss = torch.sum(dist.entropy() * mask) / n
+
+    loss = pg_loss + vf_coef * vf_loss - ent_coef * ent_loss
+
+    stats = dict(
+        losses=dict(
+            total_loss=loss.item(),
+            policy_loss=pg_loss.item(),
+            value_loss=vf_loss.item(),
+            entropy_loss=ent_loss.item(),
+        ),
+        values=dict(
+            get_tensor_stats(values, mask, n),
+            values_error=(torch.sum(((values - returns) * mask) ** 2) / n).item(),
+            clipfrac=vf_clipfrac.item(),
+        ),
+        old_values=get_tensor_stats(old_values, mask, n),
+        returns=get_tensor_stats(returns, mask, n),
+        policy=dict(approx_kl=approx_kl.item(), clipfrac=pg_clipfrac.item()),
+        ratio=((ratio * mask).sum().item() / n).item(),
+        padding_percentage=(n / mask.numel()).item(),
+    )
+    return loss, stats
+
+
+# based on https://github.com/CarperAI/trlx/blob/main/trlx/models/modeling_ppo.py
+def get_advantages_and_returns(values, rewards, response_length, use_whitening=True, config=None):
+    """Function that computes advantages and returns from rewards and values.
+    Calculated as in the original PPO paper: https://arxiv.org/abs/1707.06347
+    Note that rewards may include a KL divergence loss term.
+
+    Advantages looks like this:
+    Adv1 =  R1 + γ * λ * R2     + γ^2 * λ^2 * R3       + ...
+            - V1 + γ * (1 - λ) V2 + γ^2 * λ * (1 - λ) V3 + ...
+
+    Returns looks like this:
+    Ret1 =  R1 + γ * λ * R2     + γ^2 * λ^2 * R3       + ...
+                + γ * (1 - λ) V2 + γ^2 * λ * (1 - λ) V3 + ...
+
+    Args:
+        values: Tensor of shape (batch_size, response_size)
+        rewards: Tensor of shape (batch_size, response_size)
+        response_length: Length of the response sequence
+        use_whitening: Whether to use whitening (ie. normalize advantages) or not
+    """
+    gamma = config.gamma
+    lam = config.lam
+    lastgaelam = 0
+
+    advantages_reversed = []
+    for t in reversed(range(response_length)):
+        nextvalues = values[:, t + 1] if t < response_length - 1 else 0.0
+        delta = rewards[:, t] + gamma * nextvalues - values[:, t]
+        lastgaelam = delta + gamma * lam * lastgaelam
+        advantages_reversed.append(lastgaelam)
+    advantages = torch.stack(advantages_reversed[::-1], dim=1)
+    returns = advantages + values
+    if use_whitening:
+        advantages = whiten(advantages)
+    return advantages.detach(), returns

--- a/atorch/atorch/rl/replay_buffer/__init__.py
+++ b/atorch/atorch/rl/replay_buffer/__init__.py
@@ -1,0 +1,1 @@
+from .replay_buffer import ReplayBuffer

--- a/atorch/atorch/rl/replay_buffer/replay_buffer.py
+++ b/atorch/atorch/rl/replay_buffer/replay_buffer.py
@@ -1,0 +1,53 @@
+from atorch.common.log_utils import default_logger as logger
+from atorch.rl.data.data_utils import RLTrainingDataset
+
+
+class ReplayBuffer:
+    def __init__(self, config, element_keys=None):
+        self.config = config
+        self.element_keys = element_keys
+        self.data = {}
+        self.num = 0
+
+    # Reset buffer
+    def reset(self):
+        for k in self.data.keys():
+            self.data[k] = []
+        self.num = 0
+
+    def add_samples(self, samples):
+        assert isinstance(samples, list)
+        for sample in samples:
+            self.add_sample(sample)
+
+    # Add a sample or update a sample with index.
+    def add_sample(self, sample, index=None):
+        sample_keys = [k for k in sample.keys()]
+        if self.element_keys is not None:
+            assert set(sample_keys).issubset(set(self.element_key)), "replay buffer doesn't contains samples key"
+        if index is not None:
+            sample_exist = True
+            for k in sample_keys:
+                if len(self.data.get(k, [])) <= index:
+                    logger.warning("failed to update a sample with index {}".format(index))
+                    sample_exist = False
+                    break
+            if sample_exist:
+                for k in sample_keys:
+                    self.data[k][index] = sample.get(k)
+        else:
+            for k in sample_keys:
+                new_sample = sample.get(k)
+                if k not in self.data.keys():
+                    self.data[k] = [new_sample]
+                else:
+                    self.data[k].append(new_sample)
+            self.num += 1
+
+    # Sync buffer in process_group using allgather.
+    def sync(self, process_group=None):
+        pass
+
+    # Create a dataset
+    def create_dataset(self):
+        return RLTrainingDataset(self)

--- a/atorch/atorch/rl/trainer/__init__.py
+++ b/atorch/atorch/rl/trainer/__init__.py
@@ -1,0 +1,1 @@
+from .rl_trainer import RLTrainer

--- a/atorch/atorch/rl/trainer/ppo_trainer.py
+++ b/atorch/atorch/rl/trainer/ppo_trainer.py
@@ -1,0 +1,12 @@
+from atorch.rl.trainer import RLTrainer
+
+
+class PPOTrainer(RLTrainer):
+    def __init__(self, model_engine, dataset, config):
+        super().__init__(model_engine, dataset, config)
+
+    def make_experience(self, data):
+        pass
+
+    def rl_training(self):
+        pass

--- a/atorch/atorch/rl/trainer/rl_trainer.py
+++ b/atorch/atorch/rl/trainer/rl_trainer.py
@@ -1,0 +1,90 @@
+import atorch
+from atorch.common.log_utils import DashBoardWriter
+from atorch.rl.model_engine import ModelEngineState
+from atorch.rl.replay_buffer import ReplayBuffer
+
+
+class RLTrainer:
+    def __init__(self, model_engine, dataset, config):
+        """
+        dataset: dict, keys are train and eval
+        """
+        self.model_engine = model_engine
+        self.dataset = dataset
+        self.train_dataset_length = len(self.dataset["train"])
+        self.evaluation_dataset_length = len(self.dataset["eval"])
+        self.config = config
+
+        self.train_epoch = config.train.epoch
+        self.num_rollouts = config.train.num_rollouts
+        self.n_updates_per_batch = config.ppo_config.ppo_epoch
+
+        self.replay_buffer = self.create_replay_buffer()
+        self.rl_dataloader = None
+        self.rl_state = False
+        self.dashboard_writer = DashBoardWriter(logdir=config.train.logdir)
+        self.initial_start = True
+
+    def get_train_dataset(self):
+        return self.dataset["train"]
+
+    def get_eval_dataset(self):
+        return self.dataset["eval"]
+
+    def create_replay_buffer(self):
+        return ReplayBuffer(self.config)
+
+    def make_experience(self, data):
+        pass
+
+    def rl_training(self):
+        pass
+
+    def pre_make_expereince_hook(self):
+        if self.rl_state:
+            self.rl_state = False
+            self.model_engine.pre_make_experience_hook()
+
+    def post_experience_generation_hook(self):
+        self.model_engine.post_make_experience_hook()
+
+    def pre_rl_training_hook(self):
+        self.rl_state = True
+        self.model_engine.pre_rl_training_hook()
+        self.replay_buffer.sync()
+        rl_dataset = self.replay_buffer.create_dataset()
+        self.rl_dataloader = self.model_engine.create_dataloader(rl_dataset, state=ModelEngineState.RLTrainingState)
+
+    def post_rl_training_hook(self):
+        self.rl_dataloader = None
+        self.replay_buffer.reset()
+        self.model_engine.post_rl_training_hook()
+
+    def evaluate(self):
+        # Todo: add evaulation prompts and dataloader
+        # Use table to show results in logs or console
+
+        pass
+
+    def train(self):
+        self.model_engine.set_state(ModelEngineState.ExperienceGenerationState)
+        dataloader = self.model_engine.create_dataloader(
+            self.get_train_dataset(), state=ModelEngineState.ExperienceGenerationState
+        )
+
+        from tqdm import tqdm
+
+        for _ in range(self.train_epoch):
+            pbar = tqdm(total=self.num_rollouts, desc="RL_Making_Experience", mininterval=0.01)
+            for data in dataloader:
+                self.pre_make_expereince_hook()
+                rank = atorch.local_rank()
+                data.to(rank)
+                self.make_experience(data)
+                pbar.update(self.config.generation.batch_size)
+                if self.replay_buffer.num >= self.num_rollouts:
+                    pbar = tqdm(total=self.num_rollouts, desc="RL_Making_Experience", mininterval=0.01)
+                    self.post_experience_generation_hook()
+                    self.pre_rl_training_hook()
+                    self.rl_training()
+                    self.post_rl_training_hook()

--- a/atorch/atorch/service/rpc_clients.py
+++ b/atorch/atorch/service/rpc_clients.py
@@ -1,11 +1,11 @@
 import pickle
 
 import grpc
-from google.protobuf import empty_pb2  # type: ignore
+from google.protobuf import empty_pb2
 
 from atorch.common.constants import GrpcEnv
 from atorch.common.util_func import wait_for_server_started
-from atorch.protos import coworker_pb2, coworker_pb2_grpc  # type: ignore
+from atorch.protos import coworker_pb2, coworker_pb2_grpc
 
 
 class GpuPodRpcClient(object):

--- a/atorch/atorch/tests/common_tests/acc_executor_test.py
+++ b/atorch/atorch/tests/common_tests/acc_executor_test.py
@@ -1,0 +1,40 @@
+import os
+import unittest
+
+from atorch.auto.engine.acceleration_engine import AccelerationEngine
+from atorch.auto.engine.task import TaskType
+
+os.environ["BO_SG_MAX_IETR"] = "2"
+
+
+def process_task(tasks, executor):
+    for (task, process_id) in tasks:
+        result = None
+        if task.task_type == TaskType.ANALYSE:
+            result = {"model_params_num": 10000, "model_params_mb": 40000}
+        if task.task_type == TaskType.TUNE:
+            result = task.task_info
+        if task.task_type == TaskType.DRYRUN:
+            result = {"throughput": min(task.task_id + 2.0, 2)}
+        if task.task_type != TaskType.WAIT:
+            executor.report_task_result(task.task_id, process_id, True, result)
+
+
+class TestExecutor(unittest.TestCase):
+    def test_executor(self):
+        device_context = {"node_num": 1, "nproc_per_node": 2}
+
+        executor = AccelerationEngine.create_executor(device_context=device_context)
+
+        process_running = [True for _ in range(2)]
+        while any(process_running):
+            tasks = []
+            for idx, status in enumerate(process_running):
+                if status:
+                    task = executor.get_task(idx)
+                    tasks.append((task, idx))
+                    if task.task_type == TaskType.FINISH or task.task_type == TaskType.FAIL:
+                        self.assertTrue(task.task_type != TaskType.FAIL)
+                        process_running[idx] = False
+            process_task(tasks, executor)
+        self.assertTrue(executor.strategy_infos.num_strategy > 1)

--- a/atorch/atorch/tests/common_tests/acc_planner_test.py
+++ b/atorch/atorch/tests/common_tests/acc_planner_test.py
@@ -1,0 +1,78 @@
+import pickle
+import unittest
+
+from atorch.auto.engine.analyser_result import AnalyserResult
+from atorch.auto.engine.optimization_method import OptimizationMethodLibrary
+from atorch.auto.engine.planner import Planner, PlannerStage
+from atorch.auto.engine.sg_algo.sg_algo_lib import StrategyGenerationAlgorithmLibrary
+from atorch.auto.engine.strategy import StrategyInfoCollection
+
+
+class TestPlanner(unittest.TestCase):
+    def test_planner(self):
+        device_context = {
+            "node_num": 1,
+            "nproc_per_node": 2,
+            "gpu_compute_capability": "5.0",
+        }
+        opt_method_lib = OptimizationMethodLibrary()
+        opt_method_lib.add_methods()
+        algo_lib = StrategyGenerationAlgorithmLibrary()
+        strategy_infos = StrategyInfoCollection(opt_method_lib)
+        analyser_result = AnalyserResult()
+        zero1_strategy = [("zero1", pickle.dumps(None), False)]
+        status, _ = opt_method_lib.validate_strategy(zero1_strategy)
+        self.assertTrue(status)
+        excluded_opts = ["zero"]
+        planner = Planner(
+            opt_method_lib,
+            algo_lib,
+            strategy_infos,
+            analyser_result,
+            device_context,
+            excluded_opts=excluded_opts,
+        )
+        status, _ = opt_method_lib.validate_strategy(zero1_strategy)
+        self.assertFalse(status)
+        amp_native_strategy = [("amp_native", pickle.dumps(None), False)]
+        status, _ = opt_method_lib.validate_strategy(amp_native_strategy)
+        self.assertFalse(status)
+        is_done, tasks, new_strategy_num, _ = planner.plan()
+        self.assertFalse(is_done)
+        self.assertEqual(planner.stage, PlannerStage.ANALYSE)
+        self.assertTrue(len(tasks) > 0)
+        self.assertTrue(new_strategy_num == 0)
+
+        is_done, tasks, new_strategy_num, _ = planner.plan()
+        self.assertFalse(is_done)
+        self.assertEqual(planner.stage, PlannerStage.BASELINE_STRATEGY)
+        self.assertTrue(tasks is None)
+        self.assertTrue(new_strategy_num == 1)
+        strategy = strategy_infos.get_baseline_strategy()
+        self.assertTrue(strategy is not None)
+
+        is_done, tasks, new_strategy_num, algos = planner.plan()
+        self.assertTrue(is_done)
+        self.assertEqual(planner.stage, PlannerStage.SELECT_ALGO)
+        self.assertTrue(tasks is None)
+        self.assertTrue(new_strategy_num == 0)
+        strategy = strategy_infos.get_baseline_strategy()
+        self.assertTrue(algos is not None and len(algos) > 0)
+
+        is_done, _, _, _ = planner.plan()
+        self.assertTrue(is_done)
+
+        strategy_infos = StrategyInfoCollection(opt_method_lib)
+        planner = Planner(
+            opt_method_lib,
+            algo_lib,
+            strategy_infos,
+            analyser_result,
+            device_context,
+            load_strategy=zero1_strategy,
+            excluded_opts=excluded_opts,
+        )
+        is_done, tasks, new_strategy_num, algos = planner.plan()
+        self.assertTrue(is_done)
+        self.assertEqual(algos, [])
+        self.assertTrue(new_strategy_num == 1)

--- a/atorch/atorch/tests/common_tests/acc_strategy_test.py
+++ b/atorch/atorch/tests/common_tests/acc_strategy_test.py
@@ -1,0 +1,66 @@
+import unittest
+
+from atorch.auto.engine.optimization_method import OptimizationMethodLibrary
+from atorch.auto.engine.strategy import StrategyInfoCollection, StrategyStatus
+from atorch.auto.engine.task import TaskType
+
+
+class TestStrategy(unittest.TestCase):
+    def test_strategy(self):
+        opt_method_lib = OptimizationMethodLibrary()
+        strategy_info = StrategyInfoCollection(opt_method_lib)
+        # add strategies
+        strategy = [("parallel_mode", None, False)]
+        strategy_info.add_strategy(strategy)
+        strategy = [
+            ("parallel_mode", None, False),
+            ("amp_native", None, False),
+        ]
+        strategy_info.add_strategy(strategy)
+        strategy = [("zero1", None, False), ("amp_native", None, False)]
+        strategy_info.add_strategy(strategy)
+        self.assertTrue(strategy_info.get_best_strategy() is None)
+        task_id = 0
+        dryrun_count = 0
+        best_throughput = 0
+        best_s_id = -1
+        while True:
+            s_id = strategy_info.get_inactive_strategy()
+            if s_id is None:
+                break
+            strategy_info.assign_strategy_to_task(s_id, task_id)
+            task_status = True
+            result = None
+            s_status = strategy_info[s_id].status
+            if s_status == StrategyStatus.INIT:
+                task_type = TaskType.TUNE
+                result = strategy_info[s_id].strategy
+            elif s_status == StrategyStatus.TUNED:
+                task_type = TaskType.DRYRUN
+                if dryrun_count == 1:
+                    task_status = False
+                result = {"throughput": task_id + 1}
+                if task_status and best_throughput < result["throughput"]:
+                    best_throughput = result["throughput"]
+                    best_s_id = s_id
+                dryrun_count += 1
+            strategy_info.task_done(task_id, task_type, task_status, result)
+            task_id += 1
+        best_s = strategy_info.get_best_strategy()
+        self.assertTrue(best_s is not None)
+        self.assertEqual(best_s, strategy_info[best_s_id].strategy)
+        strategy = [("zero1", None, False), ("amp_native", None, False)]
+        self.assertTrue(strategy_info.is_duplicate(strategy))
+        strategy = [("zero2", None, False)]
+        self.assertFalse(strategy_info.is_duplicate(strategy))
+        num_s = strategy_info.num_strategy
+        strategy = [("zero1", None, False), ("amp_native", None, False)]
+        strategy_info.add_strategy(strategy)
+        self.assertEqual(num_s, strategy_info.num_strategy)
+        opt_method_lib.methods["zero2"].disabled = True
+        strategy = [("zero2", None, False), ("amp_native", None, False)]
+        strategy_info.add_strategy(strategy)
+        self.assertEqual(num_s, strategy_info.num_strategy)
+        opt_method_lib.methods["zero2"].disabled = False
+        strategy_info.add_strategy(strategy)
+        self.assertEqual(num_s + 1, strategy_info.num_strategy)

--- a/atorch/atorch/tests/common_tests/adp_test.py
+++ b/atorch/atorch/tests/common_tests/adp_test.py
@@ -1,0 +1,70 @@
+# coding=utf-8
+from __future__ import absolute_import, unicode_literals
+
+import os
+import unittest
+from copy import copy
+
+import torch
+import torch.nn
+
+from atorch.data_parallel.adp import AllDataParallel
+
+
+@unittest.skipIf(True, "failed on gpu")  # TODO: fix ut on gpu
+# @unittest.skipIf(not torch.cuda.is_available(), "Offload optimizer need apex and gpu")
+class OffloadOptimizerTest(unittest.TestCase):
+    def wrap_env(self):
+
+        # Shallow copy is enought?
+        self.old_env = copy(os.environ)
+        new_envs = {
+            "MASTER_ADDR": "localhost",
+            "WORLD_SIZE": "1",
+            "LOCAL_RANK": "0",
+            "MASTER_PORT": "12345",
+        }
+        os.environ.update(new_envs)
+
+    def unwrap_env(self):
+        os.environ = copy(self.old_env)
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.wrap_env()
+
+    def tearDown(self):
+        self.unwrap_env()
+        return super().tearDown()
+
+    def test_optimizer_state_dict(self):
+        model = torch.nn.ModuleList([torch.nn.Linear(10, 20) for _ in range(5)])
+        # CPU backend only
+        group = torch.distributed.init_process_group("gloo", world_size=1, rank=0)
+        model = AllDataParallel(model, process_group=group)
+        # noop, CUDA is required
+        # model.state_dict()
+        model_str = str(model)
+        self.assertIn(
+            """ModuleList(
+      (0): Linear(in_features=10, out_features=20, bias=True)
+      (1): Linear(in_features=10, out_features=20, bias=True)
+      (2): Linear(in_features=10, out_features=20, bias=True)
+      (3): Linear(in_features=10, out_features=20, bias=True)
+      (4): Linear(in_features=10, out_features=20, bias=True)
+    )
+  )
+)""",
+            model_str,
+        )
+        self.assertIn(
+            (
+                """AllDataParallel(\n  world_size=1, flatten_parameters=True, """
+                """mixed_precision=False, reshard_after_forward=True, """
+                """data_type=[torch.float32], inject_optimizer=False"""
+            ),
+            model_str,
+        )
+        # no... forward need cuda.Stream
+        x = torch.Tensor(data=(8, 10, 10))
+        model.forward(x)

--- a/atorch/atorch/tests/common_tests/amp_test.py
+++ b/atorch/atorch/tests/common_tests/amp_test.py
@@ -1,0 +1,413 @@
+import logging
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+from atorch.auto.accelerate import model_transform
+from atorch.auto.auto_accelerate_context import AutoAccelerateContext
+from atorch.auto.model_context import ModelContext
+from atorch.auto.opt_lib.amp_optimization import AmpNativeOptimization, AmpNativeOptimizer
+from atorch.auto.opt_lib.half_optimization import HalfOptimization
+from atorch.auto.opt_lib.optimization_library import OptimizationLibrary
+from atorch.auto.strategy import Strategy
+from atorch.common.util_func import find_free_port
+from atorch.tests.toy_modules.toy_module import create_model_context, optim_func, run_train
+from atorch.tests.utils.test_utils import DummyProcessGroup
+from atorch.utils.grad_scaler import BF16GradScaler, BF16ShardedGradScaler
+
+
+class AmpOptimizationTest(unittest.TestCase):
+    @unittest.skipIf(
+        not torch.cuda.is_available(),
+        "No gpu available for cuda tests",
+    )
+    def test_amp_native_scaler(self):
+        AutoAccelerateContext.counter += 1
+        model_context1 = create_model_context(data_size=4, batch_size=1)
+        amp_native_opt = AmpNativeOptimization()
+        model_context1 = amp_native_opt.transform(model_context1)
+        model_context1.update_dataloader()
+        model_context1.update_optim()
+        config = {"enabled": True, "dtype": torch.float16}
+        amp_native_opt.apply_wrapper(model_context1, "amp_native", wrapper_config=config)
+        model_context1.model.cuda()
+
+        AutoAccelerateContext.counter += 1
+        model_context2 = create_model_context(data_size=4, batch_size=1)
+        amp_native_opt2 = AmpNativeOptimization()
+        model_context2 = amp_native_opt2.transform(model_context2)
+        model_context2.update_dataloader()
+        model_context2.update_optim()
+        amp_native_opt2.apply_wrapper(model_context2, "amp_native", wrapper_config=config)
+        model_context2.model.cuda()
+
+        device = "cuda:0"
+        run_train(
+            model_context1.model,
+            dataloader=model_context1.dataloader,
+            optim=model_context1.optim,
+            prepare_input=model_context1.prepare_input,
+            loss_func=model_context1.loss_func,
+            device=device,
+        )
+
+        run_train(
+            model_context2.model,
+            dataloader=model_context2.dataloader,
+            optim=model_context2.optim,
+            prepare_input=model_context2.prepare_input,
+            loss_func=model_context2.loss_func,
+            device=device,
+        )
+
+        scaler1 = model_context1.optim.grad_scaler
+        scaler2 = model_context2.optim.grad_scaler
+        self.assertNotEqual(id(scaler1), id(scaler2))
+
+        AutoAccelerateContext.reset()
+
+    @unittest.skipIf(
+        not torch.cuda.is_available(),
+        "No gpu available for cuda tests",
+    )
+    def test_fp16_and_bf16(self):
+        """fp16 needs loss scaling but bf16 does not."""
+        AutoAccelerateContext.counter += 1
+        model_context1 = create_model_context(data_size=4, batch_size=1)
+        fp16_amp_native_opt = AmpNativeOptimization()
+        fp16_config = {"dtype": "fp16"}
+        model_context1 = fp16_amp_native_opt.transform(model_context1, config=fp16_config)
+        model_context1.update_dataloader()
+        model_context1.update_optim()
+        fp16_amp_native_opt.apply_wrapper(model_context1, "amp_native", wrapper_config=fp16_config)
+        self.assertIsInstance(model_context1.optim, AmpNativeOptimizer)
+
+        AutoAccelerateContext.counter += 1
+        model_context2 = create_model_context(data_size=4, batch_size=1)
+        bf16_amp_native_opt = AmpNativeOptimization()
+        bf16_config = {"dtype": "bf16"}
+        model_context2 = bf16_amp_native_opt.transform(model_context2, config=bf16_config)
+        model_context2.update_dataloader()
+        model_context2.update_optim()
+        bf16_amp_native_opt.apply_wrapper(model_context2, "amp_native", wrapper_config=bf16_config)
+        self.assertIsInstance(model_context2.optim, torch.optim.Adam)
+
+    def test_half(self):
+        model_context1 = create_model_context(data_size=4, batch_size=1)
+        opt = HalfOptimization()
+        opt.tune(model_context1, config="fp16")
+
+        def reraise_logging_exception(record):
+            t, v, tb = sys.exc_info()
+            raise t(v).with_traceback(tb)
+
+        # let logger raise exception
+        with patch.object(logging.Handler, "handleError", side_effect=reraise_logging_exception):
+            opt.apply_wrapper(model_context1, wrapper_name="half", wrapper_config="tf32")
+
+    @unittest.skipIf(
+        not torch.cuda.is_available(),
+        "No gpu available for cuda tests",
+    )
+    def test_half_precision_dtype_gpu(self):
+        device = "cuda"
+        for dtype in [torch.bfloat16, torch.float16]:
+            AutoAccelerateContext.counter += 1
+            model_context = create_model_context(data_size=4, batch_size=1)
+            model_context.model.to(device)
+            model_context.update_dataloader()
+            model_context.update_optim()
+            amp_config = {"dtype": dtype}
+            AmpNativeOptimization.apply_wrapper(model_context, "amp_native", amp_config)
+            model = model_context.model
+            dataloader = model_context.dataloader
+            loss_func = model_context.loss_func
+            optimizer = model_context.optim
+            prepare_input = model_context.prepare_input
+
+            for _, batch in enumerate(dataloader):
+                batch = prepare_input(batch, device)
+                outputs = model(batch)
+                self.assertEqual(outputs.dtype, dtype)
+                loss = loss_func(batch, outputs)
+                self.assertEqual(loss.dtype, torch.float32)
+                loss.backward()
+                optimizer.step()
+                optimizer.zero_grad()
+
+
+class OneVarModule(torch.nn.Module):
+    def __init__(self, param_value):
+        super().__init__()
+        self.var = torch.nn.parameter.Parameter(param_value)
+
+    def forward(self):
+        return torch.pow(self.var, 2)
+
+
+class NonFiniteChecking(unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+
+        def identity_loss_func(a, _):
+            return a
+
+        bf16_max = torch.finfo(torch.bfloat16).max
+        self.param_value = torch.tensor(bf16_max, dtype=torch.float32)
+        model = OneVarModule(self.param_value)
+        self.model_context = ModelContext(
+            model=model,
+            optim_func=optim_func,
+            dataset=None,
+            loss_func=identity_loss_func,
+            prepare_input=None,
+            optim_args={"lr": 1},
+        )
+
+    def tearDown(self):
+        del self.model_context
+        return super().tearDown()
+
+    @unittest.skipIf(
+        not torch.cuda.is_available(),
+        "No gpu available for cuda tests",
+    )
+    def test_skipping_update_params_nonfinite_loss(self):
+        bf16_config = {"dtype": "bf16", "skip_if_nonfinite": True}
+        bf16_amp_native_opt = AmpNativeOptimization()
+        model_context = bf16_amp_native_opt.transform(self.model_context, config=bf16_config)
+        model_context.update_optim()
+        bf16_amp_native_opt.apply_wrapper(model_context, "amp_native", wrapper_config=bf16_config)
+        model = model_context.model.cuda()
+        optimizer = model_context.optim
+        loss_func = model_context.loss_func
+        optimizer.zero_grad()
+        y = model()
+        loss = loss_func(y, None)
+        self.assertTrue(torch.all(loss.isinf()))
+        loss.backward()
+        self.assertTrue(torch.all(model.var.grad.isinf()))
+        optimizer.step()
+        self.assertTrue(torch.allclose(model.var, self.param_value))
+        scaler = optimizer.grad_scaler
+        self.assertEqual(scaler._init_scale, 1.0)
+        self.assertEqual(scaler._growth_factor, 1.0)
+        self.assertEqual(scaler._backoff_factor, 1.0)
+        self.assertTrue(optimizer.step_was_skipped)
+
+    @unittest.skipIf(
+        not torch.cuda.is_available(),
+        "No gpu available for cuda tests",
+    )
+    def test_not_skipping_update_params_nonfinite_loss(self):
+        bf16_config = {"dtype": "bf16", "skip_if_nonfinite": False}
+        bf16_amp_native_opt = AmpNativeOptimization()
+        model_context = bf16_amp_native_opt.transform(self.model_context, config=bf16_config)
+        model_context.update_optim()
+        bf16_amp_native_opt.apply_wrapper(model_context, "amp_native", wrapper_config=bf16_config)
+        model = model_context.model.cuda()
+        optimizer = model_context.optim
+        loss_func = model_context.loss_func
+        optimizer.zero_grad()
+        y = model()
+        loss = loss_func(y, None)
+        self.assertTrue(torch.all(loss.isinf()))
+        loss.backward()
+        self.assertTrue(torch.all(model.var.grad.isinf()))
+        optimizer.step()
+        self.assertTrue(torch.all(model.var.isnan()))
+        self.assertFalse(hasattr(optimizer, "grad_scaler"))
+        self.assertFalse(hasattr(optimizer, "step_was_skipped"))
+
+
+class OneLinearModule(torch.nn.Module):
+    def __init__(self, param_value):
+        super().__init__()
+        self.var = torch.nn.Linear(1, 2)
+        for param in self.var.parameters():
+            param.detach().fill_(param_value)
+
+    def forward(self, x):
+        return self.var(x)
+
+
+class FSDPNonFiniteChecking(unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+
+    def tearDown(self):
+        return super().tearDown()
+
+    @unittest.skipIf(
+        not torch.cuda.is_available() or torch.cuda.device_count() < 2,
+        "No gpu available for cuda tests",
+    )
+    def test_skipping_update_params_nonfinite_loss(self):
+        world_size = 2
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = str(find_free_port())
+        mp.spawn(
+            _test_skipping_update_params_nonfinite_loss,
+            args=(world_size,),
+            nprocs=world_size,
+            join=True,
+            daemon=False,
+            start_method="spawn",
+        )
+
+
+def _test_skipping_update_params_nonfinite_loss(rank, world_size):
+    os.environ["LOCAL_RANK"] = str(rank)
+    os.environ["RANK"] = str(rank)
+    os.environ["WORLD_SIZE"] = str(world_size)
+    os.environ["NPROC_PER_NODE"] = str(world_size)
+    dist.init_process_group(backend="nccl", rank=rank, world_size=world_size)
+    device = f"cuda:{rank}"
+    strategy = Strategy(
+        [
+            ("parallel_mode", ([("data", torch.distributed.get_world_size())], None), False),
+            ("fsdp", {"atorch_size_based_min_num_params": 1}, False),
+            ("amp_native", {"dtype": torch.bfloat16, "skip_if_nonfinite": True}, False),
+        ]
+    )
+    opt_lib = OptimizationLibrary()
+
+    def norm_loss_func(a, _):
+        return a.norm()
+
+    bf16_max = torch.finfo(torch.bfloat16).max
+    param_value = torch.tensor(10.0, dtype=torch.float32)
+    model = OneLinearModule(param_value)
+    model_context = ModelContext(
+        model=model,
+        optim_func=optim_func,
+        dataset=None,
+        loss_func=norm_loss_func,
+        prepare_input=None,
+        optim_args={"lr": 1},
+    )
+    model_context = model_transform(model_context, strategy, opt_lib, create_dataloader=False)
+    model = model_context.model
+    optimizer = model_context.optim
+    loss_func = model_context.loss_func
+    for i in range(2):
+        optimizer.zero_grad()
+        # step0, rank0 will cause inf. Other steps and ranks will not.
+        if i == 0:
+            tensor_value = bf16_max if rank == 0 else 1
+        else:
+            tensor_value = 1
+        x = torch.tensor([[tensor_value], [tensor_value]], dtype=torch.bfloat16, device=device)
+        y = model(x)
+        loss = loss_func(y, None)
+        scaler = optimizer.grad_scaler
+        if i == 0:
+            if rank == 0:
+                assert torch.all(loss.isinf())
+            else:
+                assert not loss.isinf().any().item()
+            loss.backward()
+            for param in model.module.parameters():
+                assert torch.all(param.grad.isnan())
+            optimizer.step()
+            for param in model.module.parameters():
+                assert not torch.all(param.isnan())
+            assert scaler.has_overflow()
+            assert optimizer.step_was_skipped
+        else:
+            assert not loss.isinf().any().item()
+            loss.backward()
+            optimizer.step()
+            assert not scaler.has_overflow()
+            assert not optimizer.step_was_skipped
+        assert scaler._init_scale == 1.0
+        assert scaler._growth_factor == 1.0
+        assert scaler._backoff_factor == 1.0
+
+    dist.destroy_process_group()
+
+
+@unittest.skipIf(
+    not torch.cuda.is_available(),
+    "No gpu available for cuda tests",
+)
+class BF16GradScalerTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.x = torch.randn(4, 4).cuda()
+        self.m = torch.nn.Linear(4, 1).cuda()
+        kwargs = {"lr": 0.1}
+        self.o = torch.optim.SGD(self.m.parameters(), **kwargs)
+        return super().setUp()
+
+    def tearDown(self) -> None:
+        del self.x
+        del self.m
+        del self.o
+        return super().tearDown()
+
+    def test_bf16_scaler_has_no_overflow(self):
+        scaler = BF16GradScaler()
+        with torch.cuda.amp.autocast(dtype=torch.bfloat16):
+            y = self.m(self.x)
+            loss = y.mean()
+        scaler.scale(loss).backward()
+        scaler.step(self.o)
+        scaler.update()
+        self.assertFalse(scaler.has_overflow())
+        self.assertEqual(scaler._init_scale, 1.0)
+        self.assertEqual(scaler._backoff_factor, 1.0)
+        self.assertEqual(scaler._growth_factor, 1.0)
+
+    def test_bf16_scaler_has_overflow(self):
+        scaler = BF16GradScaler()
+        with torch.cuda.amp.autocast(dtype=torch.bfloat16):
+            y = self.m(self.x)
+            loss = y.mean()
+        scaler.scale(loss).backward()
+        with torch.no_grad():
+            self.m.weight.grad.fill_(float("NaN"))
+        scaler.step(self.o)
+        scaler.update()
+        self.assertTrue(scaler.has_overflow())
+        self.assertEqual(scaler._init_scale, 1.0)
+        self.assertEqual(scaler._backoff_factor, 1.0)
+        self.assertEqual(scaler._growth_factor, 1.0)
+
+    def test_bf16_scaler_two_steps(self):
+        # The first step has overflow and the 2nd does not.
+        scaler = BF16GradScaler()
+        for i in range(2):
+            with torch.cuda.amp.autocast(dtype=torch.bfloat16):
+                y = self.m(self.x)
+                loss = y.mean()
+            scaler.scale(loss).backward()
+            if i == 0:
+                with torch.no_grad():
+                    self.m.weight.grad.fill_(float("NaN"))
+            scaler.step(self.o)
+            scaler.update()
+            self.o.zero_grad()
+            if i == 0:
+                self.assertTrue(scaler.has_overflow())
+            elif i == 1:
+                self.assertFalse(scaler.has_overflow())
+
+    def test_bf16_sharded_scaler_has_overflow(self):
+        pg = DummyProcessGroup(rank=0, size=1)
+        scaler = BF16ShardedGradScaler(process_group=pg)
+        loss = torch.full((1,), 4.0, dtype=torch.float32, device="cpu")
+        t0 = torch.tensor([float("inf")], dtype=torch.float32, device="cpu")
+        t0.grad = t0.clone()
+        opt = torch.optim.SGD([t0], lr=1.0)
+        scaler.scale(loss)
+        scaler.step(opt)
+        self.assertTrue(scaler.has_overflow())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/atorch/atorch/tests/common_tests/analyser_test.py
+++ b/atorch/atorch/tests/common_tests/analyser_test.py
@@ -1,0 +1,150 @@
+import unittest
+from collections import namedtuple
+
+import numpy
+import torch
+import torch.nn as nn
+import transformers
+from transformers import BertConfig, BertModel
+from transformers.models.bert.modeling_bert import (
+    BertAttention,
+    BertEmbeddings,
+    BertIntermediate,
+    BertLayer,
+    BertOutput,
+    BertPooler,
+    BertSelfAttention,
+    BertSelfOutput,
+)
+
+from atorch.auto.analyser.analyser import get_analyser
+from atorch.auto.model_context import ModelContext
+from atorch.common.constants import AnalyserConstants
+from atorch.tests.toy_modules.toy_module import ToyDataset, ToyModel, prepare_input
+
+_BERT_SUBMODEL_TYPES = (
+    torch.nn.modules.sparse.Embedding,
+    transformers.models.bert.modeling_bert.BertSelfOutput,
+    torch.nn.modules.container.ModuleList,
+    torch.nn.modules.normalization.LayerNorm,
+    transformers.models.bert.modeling_bert.BertPooler,
+    transformers.models.bert.modeling_bert.BertEncoder,
+    transformers.models.bert.modeling_bert.BertIntermediate,
+    torch.nn.modules.linear.Linear,
+    transformers.models.bert.modeling_bert.BertEmbeddings,
+    torch.nn.modules.activation.Tanh,
+    transformers.models.bert.modeling_bert.BertLayer,
+    transformers.models.bert.modeling_bert.BertAttention,
+    transformers.models.bert.modeling_bert.BertOutput,
+    transformers.activations.GELUActivation,
+    transformers.models.bert.modeling_bert.BertSelfAttention,
+    torch.nn.modules.dropout.Dropout,
+)
+
+
+class NeuralNetwork(nn.Module):
+    def __init__(self):
+        super(NeuralNetwork, self).__init__()
+        self.flatten = nn.Flatten()
+        self.linear_relu_stack = nn.Sequential(
+            nn.Linear(28 * 28, 16), nn.ReLU(), nn.Linear(16, 16), nn.ReLU(), nn.Linear(16, 10)
+        )
+
+    def forward(self, data):
+        x = self.flatten(data[0])
+        logits = self.linear_relu_stack(x)
+        return logits
+
+
+class AnalyserTest(unittest.TestCase):
+    def setUp(self):
+        model = BertModel(BertConfig())
+        # construct sequence data
+        input_ids, attention_mask = torch.tensor(
+            [[3, 16, 87, 3, 9], [72, 12, 4, 90, 54]], dtype=torch.long
+        ), torch.tensor([[1, 1, 1, 1, 1], [1, 1, 1, 1, 1]], dtype=torch.long)
+        dataset = torch.utils.data.TensorDataset(input_ids, attention_mask)
+        self.model_context = ModelContext(
+            model=model, optim_func=torch.optim.Adam, optim_args={"lr": 1e-3}, dataset=dataset
+        )
+        self.analyser = get_analyser()
+
+    def test_analyse(self):
+        analyse_methods = [AnalyserConstants.ANALYSE_BASIC, AnalyserConstants.ANALYSE_TRANSFORMER]
+
+        res = self.analyser.analyse(self.model_context, analyse_methods)
+        self.assertCountEqual(
+            res[AnalyserConstants.ANALYSE_BASIC][AnalyserConstants.OPT_CONFIG_SUBMODULE_NAMES], ("BertLayer",)
+        )
+        self.assertEqual(
+            res[AnalyserConstants.ANALYSE_BASIC][AnalyserConstants.MODEL_PARAMS_NUM],
+            109482240,
+        )
+        self.assertAlmostEqual(
+            res[AnalyserConstants.ANALYSE_BASIC][AnalyserConstants.MODEL_PARAMS_MB],
+            417.6416015625,
+        )
+        self.assertTrue(res[AnalyserConstants.ANALYSE_BASIC][AnalyserConstants.HAS_MODULE_FOR_REPLACE])
+        self.assertEqual(
+            res[AnalyserConstants.ANALYSE_BASIC][AnalyserConstants.OPTIMIZER_TYPE],
+            "Adam",
+        )
+        self.assertEqual(
+            res[AnalyserConstants.ANALYSE_TRANSFORMER],
+            {
+                BertEmbeddings.__name__: 1,
+                BertSelfAttention.__name__: 12,
+                BertSelfOutput.__name__: 12,
+                BertAttention.__name__: 12,
+                BertIntermediate.__name__: 12,
+                BertOutput.__name__: 12,
+                BertLayer.__name__: 12,
+                BertPooler.__name__: 1,
+            },
+        )
+        self.assertCountEqual(
+            res[AnalyserConstants.ANALYSE_BASIC][AnalyserConstants.SUBMODULE_TYPES],
+            _BERT_SUBMODEL_TYPES,
+        )
+
+    @unittest.skipIf(torch.cuda.is_available(), "Failed on gpu")
+    def test_dynamic_analyze(self):
+        training_data = ToyDataset(100)
+        model = ToyModel()
+
+        model_context = ModelContext(
+            model=model,
+            optim_func=torch.optim.Adam,
+            optim_args={"lr": 1e-3},
+            dataset=training_data,
+            loss_func=lambda data, pred: nn.CrossEntropyLoss()(pred, data[1]),
+            prepare_input=prepare_input,
+        )
+        analyse_methods = [AnalyserConstants.ANALYSE_DYNAMIC]
+        res = self.analyser.analyse(model_context, analyse_methods)[AnalyserConstants.ANALYSE_DYNAMIC]
+        self.assertEqual(res[AnalyserConstants.DATA_SIZE], 16 + 4)
+        self.assertGreater(res[AnalyserConstants.MODEL_FLOPS_AND_DYNAMIC_MEMORY_MB]["dynamic_memory_mb"], 0)
+        self.assertGreater(res[AnalyserConstants.MODEL_FLOPS_AND_DYNAMIC_MEMORY_MB]["model_flops"], 0)
+        self.assertGreater(res[AnalyserConstants.OPTIMIZER_STATE_NUM_AND_MEMORY_MB]["optimizer_state_num"], 0)
+        self.assertGreater(res[AnalyserConstants.OPTIMIZER_STATE_NUM_AND_MEMORY_MB]["optimizer_state_memory_mb"], 0)
+
+        self.assertEqual(self.analyser._get_data_size_recursively(6), 1)  # int
+        self.assertEqual(self.analyser._get_data_size_recursively(1.2), 1)  # float
+        self.assertEqual(self.analyser._get_data_size_recursively("abcd"), 4)  # str
+        self.assertEqual(self.analyser._get_data_size_recursively(torch.as_tensor([[1, 1], [2, 2]])), 4)  # Tensor
+        self.assertEqual(
+            self.analyser._get_data_size_recursively(
+                namedtuple("Data", ["x", "y"])(torch.as_tensor(1), torch.as_tensor(2))  # namedtuple
+            ),
+            2,
+        )
+        self.assertEqual(self.analyser._get_data_size_recursively([torch.as_tensor(1), torch.as_tensor(2)]), 2)  # list
+        self.assertEqual(self.analyser._get_data_size_recursively((torch.as_tensor(1), torch.as_tensor(2))), 2)  # tuple
+        self.assertEqual(
+            self.analyser._get_data_size_recursively({"1": torch.as_tensor(1), "2": torch.as_tensor(2)}), 2  # dict
+        )
+        self.assertEqual(self.analyser._get_data_size_recursively(numpy.array([[1, 1], [2, 2]])), 4)  # ndarray
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/atorch/atorch/tests/common_tests/analyzer_result_test.py
+++ b/atorch/atorch/tests/common_tests/analyzer_result_test.py
@@ -1,0 +1,36 @@
+import unittest
+
+from atorch.auto.engine.analyser_result import AnalyserResult
+
+
+class AnalyzerResultTest(unittest.TestCase):
+    def test_analyzer_result(self):
+        result = {
+            "analyse_basic": {
+                "model_params_num": {"layer_0": 10, "layer_1": 20},
+                "model_params_mb": {"layer_0": 0.1, "layer_1": 0.2},
+            },
+            "analyse_dynamic": {"fixed_data_size": True, "data_size": 1024},
+        }
+
+        analyzer_result = AnalyserResult()
+        analyzer_result.update(result)
+        self.assertEqual(
+            analyzer_result.get("analyse_basic"),
+            {
+                "model_params_num": {"layer_0": 10, "layer_1": 20},
+                "model_params_mb": {"layer_0": 0.1, "layer_1": 0.2},
+            },
+        )
+
+        self.assertEqual(
+            analyzer_result.get("model_params_num"),
+            {"layer_0": 10, "layer_1": 20},
+        )
+
+        self.assertEqual(analyzer_result.get("data_size"), 1024)
+        self.assertEqual(analyzer_result.get("analyse_transformer"), None)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/atorch/atorch/tests/common_tests/auto_acc_client_test.py
+++ b/atorch/atorch/tests/common_tests/auto_acc_client_test.py
@@ -1,0 +1,112 @@
+import pickle
+import unittest
+from unittest import mock
+
+from atorch.auto.engine.client import build_auto_acc_client
+from atorch.protos import acceleration_pb2
+
+
+class AutoAccelerationClient(unittest.TestCase):
+    def setUp(self):
+        self.client = build_auto_acc_client()
+
+    def test_get_analyse_task(self):
+        method = acceleration_pb2.AnalysisMethod()
+        method.names.extend(["default", "self-defined"])
+        task = acceleration_pb2.AutoAccelerationTask(
+            task_id=0,
+            task_type="ANALYSE",
+            process_mode="ONE_PROCESS",
+            analysis_method=method,
+            time_limit=30,
+        )
+        self.client._stub.get_task = mock.MagicMock(return_value=task)
+        (
+            task_id,
+            task_type,
+            process_mode,
+            time_limit,
+            task_info,
+        ) = self.client.get_task()
+        self.assertEqual(task_id, 0)
+        self.assertEqual(task_type, "ANALYSE")
+        self.assertEqual(process_mode, "ONE_PROCESS")
+        self.assertEqual(time_limit, 30)
+        self.assertEqual(task_info, ["default", "self-defined"])
+
+    def test_get_parallel_task(self):
+        parallel_group_info = {
+            "model_parallel_size": 3,
+            "model_parallel_group": [[0, 1, 2], [3, 4, 5]],
+        }
+        task = acceleration_pb2.AutoAccelerationTask(
+            task_id=1,
+            task_type="SETUP_PARALLEL_GROUP",
+            process_mode="ALL_PROCESS",
+            parallel_group_info=pickle.dumps(parallel_group_info),
+            time_limit=5,
+        )
+        self.client._stub.get_task = mock.MagicMock(return_value=task)
+        (
+            task_id,
+            task_type,
+            process_mode,
+            time_limit,
+            task_info,
+        ) = self.client.get_task()
+        self.assertEqual(task_id, 1)
+        self.assertEqual(task_type, "SETUP_PARALLEL_GROUP")
+        self.assertEqual(process_mode, "ALL_PROCESS")
+        self.assertEqual(time_limit, 5)
+        self.assertEqual(parallel_group_info, pickle.loads(task_info))
+
+    def test_get_strategy_task(self):
+        parallel_group_info = {
+            "model_parallel_size": 3,
+            "model_parallel_group": [[0, 1, 2], [3, 4, 5]],
+        }
+        methods = [
+            ("1D", parallel_group_info, True),
+            ("2D", parallel_group_info, False),
+        ]
+        opt_method0 = acceleration_pb2.OptimizationMethod(
+            name=methods[0][0],
+            config=pickle.dumps(methods[0][1]),
+            tunable=methods[0][2],
+        )
+        opt_method1 = acceleration_pb2.OptimizationMethod(
+            name=methods[1][0],
+            config=pickle.dumps(methods[1][1]),
+            tunable=methods[1][2],
+        )
+        strategy = acceleration_pb2.Strategy()
+        strategy.opt.extend([opt_method0, opt_method1])
+        task = acceleration_pb2.AutoAccelerationTask(
+            task_id=2,
+            task_type="TUNE",
+            process_mode="ONE_MODEL_PARALLEL_GROUP",
+            strategy=strategy,
+            time_limit=600,
+        )
+        self.client._stub.get_task = mock.MagicMock(return_value=task)
+        (
+            task_id,
+            task_type,
+            process_mode,
+            time_limit,
+            task_info,
+        ) = self.client.get_task()
+        self.assertEqual(task_id, 2)
+        self.assertEqual(task_type, "TUNE")
+        self.assertEqual(process_mode, "ONE_MODEL_PARALLEL_GROUP")
+        self.assertEqual(time_limit, 600)
+        for method, info in zip(methods, task_info):
+            self.assertEqual(method[0], info[0])
+            self.assertEqual(method[1], pickle.loads(info[1]))
+            self.assertEqual(method[2], info[2])
+
+    def test_report_more_than_one_result(self):
+        self.client._stub.report_task_result = mock.MagicMock(return_value=None)
+        self.client.report_task_result(0, "TUNE", True, [("method", pickle.dumps({}), False)])
+        self.client.report_task_result(0, "DRYRUN", True, pickle.dumps({}))
+        self.client.report_task_result(0, "ANALYSE", True, pickle.dumps({}))

--- a/atorch/atorch/tests/common_tests/auto_acc_servicer_test.py
+++ b/atorch/atorch/tests/common_tests/auto_acc_servicer_test.py
@@ -1,0 +1,110 @@
+import pickle
+import unittest
+from unittest import mock
+
+from atorch.auto.engine.acceleration_engine import AccelerationEngine
+from atorch.auto.engine.servicer import AutoAccelerationService
+from atorch.auto.engine.task import Task, TaskProcessMode, TaskStatus, TaskType
+from atorch.protos import acceleration_pb2
+
+
+class AccelerationServiceTest(unittest.TestCase):
+    def setUp(self) -> None:
+        executor = AccelerationEngine.create_executor()
+        self.servicer = AutoAccelerationService(executor)
+
+    def test_get_strategy_task(self):
+        config = {
+            "pipeline_parallel_size": 3,
+            "pipeline_parallel_group": [[0, 1, 2], [3, 4, 5]],
+        }
+        optimization_methods = [
+            ("1F1B", pickle.dumps(config), True),
+            ("bidirectional", pickle.dumps(config), False),
+        ]
+        task_id = 1
+        task_type = TaskType.TUNE
+        task_status = TaskStatus.PENDING
+        process_mode = TaskProcessMode.ALL_PROCESS
+        task = Task(
+            task_type,
+            optimization_methods,
+            task_id=task_id,
+            process_mode=process_mode,
+            task_status=task_status,
+            time_limit=5,
+        )
+        self.servicer._executor.get_task = mock.MagicMock(return_value=task)
+        protobuf_task = self.servicer.get_task(acceleration_pb2.GetAutoAccelerationTaskRequest(), None)
+        self.assertEqual(protobuf_task.task_id, task_id)
+        self.assertEqual(protobuf_task.task_type, task_type)
+        self.assertEqual(protobuf_task.process_mode, process_mode)
+        self.assertEqual(protobuf_task.time_limit, 5)
+        for method_tuple, method_proto in zip(optimization_methods, protobuf_task.strategy.opt):
+            self.assertEqual(method_tuple[0], method_proto.name)
+            self.assertEqual(method_tuple[1], method_proto.config)
+            self.assertEqual(method_tuple[2], method_proto.tunable)
+
+    def test_get_analysis_method_task(self):
+        methods = ["default", "static", "dynamic"]
+        task_id = 0
+        task_type = TaskType.ANALYSE
+        task_status = TaskStatus.PENDING
+        process_mode = TaskProcessMode.ONE_PROCESS
+        task = Task(
+            task_type,
+            methods,
+            task_id=task_id,
+            process_mode=process_mode,
+            task_status=task_status,
+            time_limit=30,
+        )
+        self.servicer._executor.get_task = mock.MagicMock(return_value=task)
+        protobuf_task = self.servicer.get_task(acceleration_pb2.GetAutoAccelerationTaskRequest(), None)
+        self.assertEqual(protobuf_task.task_id, task_id)
+        self.assertEqual(protobuf_task.task_type, task_type)
+        self.assertEqual(protobuf_task.process_mode, process_mode)
+        self.assertEqual(protobuf_task.time_limit, 30)
+        self.assertEqual(
+            list(protobuf_task.analysis_method.names),
+            methods,
+        )
+
+    def test_get_parallel_group_info_task(self):
+        parallel_group_info = {
+            "model_parallel_size": 3,
+            "model_parallel_group": [[0, 1, 2], [3, 4, 5]],
+        }
+
+        task_id = 0
+        task_type = TaskType.SETUP_PARALLEL_GROUP
+        process_mode = TaskProcessMode.ALL_PROCESS
+        task_status = TaskStatus.PENDING
+        task = Task(
+            task_type,
+            parallel_group_info,
+            task_id=task_id,
+            process_mode=process_mode,
+            task_status=task_status,
+        )
+        self.servicer._executor.get_task = mock.MagicMock(return_value=task)
+        protobuf_task = self.servicer.get_task(acceleration_pb2.GetAutoAccelerationTaskRequest(), None)
+        self.assertEqual(protobuf_task.task_id, task_id)
+        self.assertEqual(protobuf_task.task_type, task_type)
+        self.assertEqual(protobuf_task.process_mode, process_mode)
+        self.assertEqual(protobuf_task.time_limit, 0)
+        self.assertEqual(
+            protobuf_task.parallel_group_info,
+            pickle.dumps(parallel_group_info),
+        )
+
+    def test_report_strategy_result(self):
+        self.servicer._executor.report_task_result = mock.MagicMock(return_value=None)
+        task_result = acceleration_pb2.AutoAccelerationTaskResult(
+            task_id=0,
+            process_id=0,
+            status=True,
+            task_type="ANALYSE",
+        )
+        task_result.model_meta = pickle.dumps({"num_elements": 10})
+        self.servicer.report_task_result(task_result, None)

--- a/atorch/atorch/tests/common_tests/auto_accelerate_context_test.py
+++ b/atorch/atorch/tests/common_tests/auto_accelerate_context_test.py
@@ -1,0 +1,111 @@
+import unittest
+
+import torch
+
+from atorch.auto.accelerate import record_user_defined_half_precision_dtype
+from atorch.auto.auto_accelerate_context import AutoAccelerateContext
+from atorch.auto.model_context import ModelContext
+from atorch.auto.strategy import Strategy
+from atorch.tests.toy_modules.toy_module import ToyModel
+
+
+class AutoAccContextTest(unittest.TestCase):
+    def test_context(self):
+        model = ToyModel()
+        mc = ModelContext(
+            model=model,
+            optim_func=torch.optim.Adam,
+            optim_args={"lr": 1e-3},
+        )
+        mc.create_optim()
+        loss = torch.tensor(1, dtype=torch.int32)
+
+        # Add some attributes
+        AutoAccelerateContext.add_ac_attr("a", 1)
+        AutoAccelerateContext.add_ac_attr("b", [1, 2])
+        AutoAccelerateContext.add_ac_attr("c", {3: 4})
+        AutoAccelerateContext.add_ac_attr("fn", lambda x: x + 1)
+        AutoAccelerateContext.add_ac_attr("model", mc.model)
+        AutoAccelerateContext.add_ac_attr("optim", mc.optim)
+        AutoAccelerateContext.add_ac_attr("loss", loss)
+
+        # check attributes
+        self.assertEqual(AutoAccelerateContext.a, 1)
+        self.assertEqual(AutoAccelerateContext.b, [1, 2])
+        self.assertEqual(AutoAccelerateContext.c, {3: 4})
+        self.assertEqual(AutoAccelerateContext.fn(0), 1)
+        self.assertEqual(AutoAccelerateContext.model, mc.model)
+        self.assertEqual(AutoAccelerateContext.optim, mc.optim)
+        self.assertTrue(torch.equal(AutoAccelerateContext.loss, loss))
+
+        # reset context to delete all attributes add by `add_ac_attr`
+        AutoAccelerateContext.reset()
+        self.assertFalse(hasattr(AutoAccelerateContext, "a"))
+        self.assertFalse(hasattr(AutoAccelerateContext, "b"))
+        self.assertFalse(hasattr(AutoAccelerateContext, "c"))
+        self.assertFalse(hasattr(AutoAccelerateContext, "fn"))
+        self.assertFalse(hasattr(AutoAccelerateContext, "model"))
+        self.assertFalse(hasattr(AutoAccelerateContext, "optim"))
+        self.assertFalse(hasattr(AutoAccelerateContext, "loss"))
+
+        # class method still exists after calling `reset`
+        self.assertTrue(hasattr(AutoAccelerateContext, "add_ac_attr"))
+        self.assertTrue(hasattr(AutoAccelerateContext, "reset"))
+
+
+class HalfPrecisionRecordingTest(unittest.TestCase):
+    def setUp(self):
+        self.str_dtype_map = {
+            "fp16": torch.float16,
+            "bf16": torch.bfloat16,
+            torch.float16: torch.float16,
+            torch.bfloat16: torch.bfloat16,
+        }
+
+    def test_recording_amp_native(self):
+        for dtype in ["fp16", "bf16", torch.float16, torch.bfloat16]:
+            AutoAccelerateContext.counter += 1
+            strategy = Strategy([("amp_native", {"dtype": dtype})])
+            record_user_defined_half_precision_dtype(strategy)
+            self.assertEqual(
+                AutoAccelerateContext.half_precision_dtype[AutoAccelerateContext.counter], self.str_dtype_map[dtype]
+            )
+        AutoAccelerateContext.reset()
+
+    def test_recording_half(self):
+        for dtype in ["fp16", "bf16"]:
+            AutoAccelerateContext.counter += 1
+            strategy = Strategy([("half", dtype)])
+            record_user_defined_half_precision_dtype(strategy)
+            self.assertEqual(
+                AutoAccelerateContext.half_precision_dtype[AutoAccelerateContext.counter], self.str_dtype_map[dtype]
+            )
+        AutoAccelerateContext.reset()
+
+    def test_half_opt_default_config(self):
+        for opt in ["amp_native", "half"]:
+            AutoAccelerateContext.counter += 1
+            strategy = Strategy([(opt, None)])
+            record_user_defined_half_precision_dtype(strategy)
+            self.assertEqual(AutoAccelerateContext.half_precision_dtype[AutoAccelerateContext.counter], torch.float16)
+        AutoAccelerateContext.reset()
+
+    def test_assert_raise(self):
+        AutoAccelerateContext.counter += 1
+        strategy = Strategy([("amp_native", {"dtype": torch.int32})])
+        with self.assertRaises(ValueError):
+            record_user_defined_half_precision_dtype(strategy)
+        strategy = Strategy([("half", torch.int32)])
+        with self.assertRaises(ValueError):
+            record_user_defined_half_precision_dtype(strategy)
+
+        AutoAccelerateContext.counter += 1
+        strategy1 = Strategy([("half", "fp16")])
+        record_user_defined_half_precision_dtype(strategy1)
+        strategy2 = Strategy([("amp_native", {"dtype": "bf16"})])
+        with self.assertRaises(ValueError):
+            record_user_defined_half_precision_dtype(strategy2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/atorch/atorch/tests/common_tests/auto_accelerate_test.py
+++ b/atorch/atorch/tests/common_tests/auto_accelerate_test.py
@@ -1,0 +1,481 @@
+import os
+import pickle
+import sys
+import tempfile
+import unittest
+
+import torch
+
+import atorch
+from atorch.auto.accelerate import adjust_strategy, auto_accelerate, get_strategy, run_task, save_strategy
+from atorch.auto.analyser.analyser import Analyser
+from atorch.auto.device_context import get_device_context
+from atorch.auto.dry_runner.dry_runner import DryRunner
+from atorch.auto.opt_lib.optimization_library import OptimizationLibrary
+from atorch.auto.strategy import Strategy
+from atorch.auto.task import Task
+from atorch.data import data_to_device
+from atorch.tests.toy_modules.toy_module import (
+    ToyModel,
+    create_model_context,
+    loss_func,
+    optim_func,
+    prepare_input,
+    run_train,
+)
+from atorch.tests.utils.test_utils import run_multi_process_init_distributed, start_coverage, stop_coverage
+
+
+def task_run_code(data_size, batch_size):
+    backend = "nccl" if torch.cuda.is_available() else "gloo"
+    res = atorch.init_distributed(backend, set_cuda_device_using_local_rank=True)
+    if not res:
+        raise Exception("init failed")
+    model_context = create_model_context(data_size=data_size, batch_size=batch_size)
+    opt_lib = OptimizationLibrary()
+    dry_runner = DryRunner()
+    analyser = Analyser()
+    tasks = []
+    task = Task(id=0, task_type="ANALYSE", process_mode="ONE_PROCESS", task_info=["analyse_basic"])
+    tasks.append(task)
+    pg_info = ([("data", 2)], None)
+    task = Task(id=1, task_type="SETUP_PARALLEL_GROUP", process_mode="ALL_PROCESS", task_info=pg_info)
+    tasks.append(task)
+    task = Task(id=2, task_type="WAIT")
+    tasks.append(task)
+    strategy = Strategy([("parallel_mode", pg_info, False)])
+    task = Task(id=3, task_type="DRYRUN", process_mode="ALL_PROCESS", task_info=strategy)
+    tasks.append(task)
+    task = Task(id=4, task_type="FINISH", process_mode="ALL_PROCESS", task_info=strategy)
+    tasks.append(task)
+    for task in tasks:
+        status, result = run_task(model_context, task, opt_lib=opt_lib, dry_runner=dry_runner, analyser=analyser)
+        assert status is True
+        if task.type == "FINISH":
+            m_model, m_optim, m_dataloader, m_loss_func, m_prepare_input = (
+                result.model,
+                result.optim,
+                result.dataloader,
+                result.loss_func,
+                result.prepare_input,
+            )
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    num = run_train(m_model, m_dataloader, m_optim, m_prepare_input, m_loss_func, device)
+    assert num == data_size // batch_size, f"num={num}"
+
+    atorch.reset_distributed()
+
+
+class FakeEasyDLClient(object):
+    def __init__(self, addr, port):
+        tasks = []
+        task = Task(id=0, task_type="ANALYSE", process_mode="ONE_PROCESS", task_info=["analyse_basic"])
+        tasks.append(task)
+        pg_info = ([("data", 2)], None)
+        task = Task(id=1, task_type="SETUP_PARALLEL_GROUP", process_mode="ALL_PROCESS", task_info=pg_info)
+        tasks.append(task)
+        task = Task(id=2, task_type="WAIT")
+        tasks.append(task)
+        strategy = Strategy([("parallel_mode", pg_info, False)])
+        task = Task(id=3, task_type="DRYRUN", process_mode="ALL_PROCESS", task_info=strategy)
+        tasks.append(task)
+        task = Task(id=4, task_type="FINISH", process_mode="ALL_PROCESS", task_info=strategy)
+        tasks.append(task)
+        self.tasks = tasks
+        self.index = 0
+
+    def get_task(self):
+        if self.index < len(self.tasks):
+            self.index += 1
+            return self.tasks[self.index - 1]
+        return None
+
+    def report_task_result(self, task, status, result):
+        pass
+
+
+class FakeEasyDLClientWithFailTask(FakeEasyDLClient):
+    def __init__(self, addr, port):
+        tasks = []
+        task = Task(id=0, task_type="ANALYSE", process_mode="ONE_PROCESS", task_info=["analyse_basic"])
+        tasks.append(task)
+        task = Task(id=4, task_type="FAIL", process_mode="ALL_PROCESS", task_info=None)
+        tasks.append(task)
+        self.tasks = tasks
+        self.index = 0
+
+
+class FakeEngine(object):
+    def __init__(
+        self,
+        device_context,
+        included_opts=None,
+        excluded_opts=None,
+        load_strategy=None,
+        time_limit=None,
+        verbose=False,
+    ):
+        pass
+
+    def start_service(self, port):
+        pass
+
+    def tear_down(self):
+        pass
+
+
+def func_run_code(data_size, batch_size):
+    backend = "nccl" if torch.cuda.is_available() else "gloo"
+    res = atorch.init_distributed(backend, set_cuda_device_using_local_rank=True)
+    if not res:
+        raise Exception("init failed")
+    model_context = create_model_context(data_size=data_size, batch_size=batch_size)
+
+    atorch.auto.accelerate.EngineClient = FakeEasyDLClient
+    atorch.auto.accelerate.AccelerationEngine = FakeEngine
+
+    status, res, best_strategy = auto_accelerate(
+        model_context.model,
+        model_context.optim_func,
+        model_context.dataset,
+        loss_func=model_context.loss_func,
+        prepare_input=model_context.prepare_input,
+        optim_args=model_context.optim_args,
+        dataloader_args=model_context.dataloader_args,
+    )
+    assert len(best_strategy) == 1
+    assert status
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    num = run_train(res.model, res.dataloader, res.optim, res.prepare_input, res.loss_func, device)
+    assert num == data_size // batch_size, f"num={num}"
+
+    model_context = create_model_context(data_size=data_size, batch_size=batch_size)
+    atorch.auto.accelerate.EngineClient = FakeEasyDLClientWithFailTask
+    status, _, _ = auto_accelerate(
+        model_context.model,
+        model_context.optim_func,
+        model_context.dataset,
+        loss_func=model_context.loss_func,
+        prepare_input=model_context.prepare_input,
+        optim_args=model_context.optim_args,
+        dataloader_args=model_context.dataloader_args,
+    )
+    assert status is False
+    atorch.reset_distributed()
+
+
+def save_load_code(data_size, batch_size):
+    backend = "nccl" if torch.cuda.is_available() else "gloo"
+    res = atorch.init_distributed(backend, set_cuda_device_using_local_rank=True)
+    if not res:
+        raise Exception("init failed")
+    model_context = create_model_context(data_size=data_size, batch_size=batch_size)
+
+    b_data = [None, None]
+    if atorch.rank() == 0:
+        pg_info = ([("data", 1)], None)
+        strategy = Strategy([("parallel_mode", pg_info, False)])
+        _, filename = tempfile.mkstemp(suffix="st")
+        save_strategy(strategy, filename)
+        _, save_filename = tempfile.mkstemp(suffix="st")
+        b_data = [filename, save_filename]
+
+    torch.distributed.broadcast_object_list(b_data, src=0)
+
+    status, res, best_strategy = auto_accelerate(
+        model_context.model,
+        model_context.optim_func,
+        model_context.dataset,
+        loss_func=model_context.loss_func,
+        prepare_input=model_context.prepare_input,
+        optim_args=model_context.optim_args,
+        dataloader_args=model_context.dataloader_args,
+        load_strategy=b_data[0],
+        save_strategy_to_file=b_data[1],
+    )
+    assert status
+    assert len(best_strategy) == 1
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    num = run_train(res.model, res.dataloader, res.optim, res.prepare_input, res.loss_func, device)
+    assert num == data_size // batch_size, f"num={num}"
+
+    status, strategy = get_strategy(b_data[1])
+    assert status
+    assert strategy == best_strategy
+
+    pg_info = ([("data", 8)], None)
+    strategy = Strategy([("parallel_mode", pg_info, False)])
+    s_data = pickle.dumps(strategy)
+    status, res, strategy = auto_accelerate(
+        model_context.model,
+        model_context.optim_func,
+        model_context.dataset,
+        loss_func=model_context.loss_func,
+        prepare_input=model_context.prepare_input,
+        optim_args=model_context.optim_args,
+        dataloader_args=model_context.dataloader_args,
+        load_strategy=s_data,
+    )
+    assert status
+    assert len(strategy) == 1
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    num = run_train(res.model, res.dataloader, res.optim, res.prepare_input, res.loss_func, device)
+    assert num == data_size // batch_size, f"num={num}"
+    assert strategy == best_strategy
+
+    atorch.reset_distributed()
+
+
+def set_seed_code(data_size, batch_size):
+    backend = "nccl" if torch.cuda.is_available() else "gloo"
+    res = atorch.init_distributed(backend, set_cuda_device_using_local_rank=True)
+    if not res:
+        raise Exception("init failed")
+    seed = 13
+    model_context = create_model_context(data_size=data_size, batch_size=batch_size, sampler_seed=seed)
+    assert model_context.sampler_seed == 13
+
+    atorch.auto.accelerate.EngineClient = FakeEasyDLClient
+    atorch.auto.accelerate.AccelerationEngine = FakeEngine
+
+    status, res, _ = auto_accelerate(
+        model_context.model,
+        model_context.optim_func,
+        model_context.dataset,
+        loss_func=model_context.loss_func,
+        prepare_input=model_context.prepare_input,
+        optim_args=model_context.optim_args,
+        dataloader_args=model_context.dataloader_args,
+    )
+    assert status
+    dataloader = res.dataloader
+    sampler = dataloader.sampler
+    assert isinstance(sampler, torch.data.utils.distributed.DistributedSampler)
+    assert sampler.seed == seed
+
+
+class FakeEasyDLClientOnlyPass(FakeEasyDLClient):
+    def __init__(self, addr, port):
+        tasks = []
+        task = Task(id=0, task_type="ANALYSE", process_mode="ONE_PROCESS", task_info=["analyse_basic"])
+        tasks.append(task)
+        pg_info = ([("data", 2)], None)
+        task = Task(id=1, task_type="SETUP_PARALLEL_GROUP", process_mode="ALL_PROCESS", task_info=pg_info)
+        tasks.append(task)
+        task = Task(id=2, task_type="WAIT")
+        tasks.append(task)
+        strategy = Strategy([("parallel_mode", pg_info, False)])
+        task = Task(id=3, task_type="DRYRUN", process_mode="ALL_PROCESS", task_info=strategy)
+        tasks.append(task)
+        task = Task(id=4, task_type="FINISH", process_mode="ALL_PROCESS", task_info=strategy)
+        tasks.append(task)
+        self.tasks = tasks
+        self.index = 0
+
+
+def only_pass_model_code(dp_size):
+    backend = "nccl" if torch.cuda.is_available() else "gloo"
+    res = atorch.init_distributed(backend, set_cuda_device_using_local_rank=True)
+    if not res:
+        raise Exception("init_distributed failed")
+    model = ToyModel()
+    atorch.auto.accelerate.EngineClient = FakeEasyDLClientOnlyPass
+    atorch.auto.accelerate.AccelerationEngine = FakeEngine
+
+    pg_info = ([("data", dp_size)], None)
+    strategy = Strategy([("parallel_mode", pg_info, False)])
+
+    status, res, best_strategy = auto_accelerate(model, load_strategy=strategy)
+    assert len(best_strategy) == 1
+    assert status
+    assert res.model is not None
+    assert res.dataloader is None
+    assert res.optim is None
+    assert res.prepare_input is data_to_device
+    assert res.loss_func is None
+    assert best_strategy == strategy
+
+
+class FakeEasyDLClientPassSampleBatch(FakeEasyDLClient):
+    def __init__(self, addr, port):
+        tasks = []
+        task = Task(id=0, task_type="ANALYSE", process_mode="ONE_PROCESS", task_info=["analyse_basic"])
+        tasks.append(task)
+        pg_info = ([("data", 2)], None)
+        task = Task(id=1, task_type="SETUP_PARALLEL_GROUP", process_mode="ALL_PROCESS", task_info=pg_info)
+        tasks.append(task)
+        task = Task(id=2, task_type="WAIT")
+        tasks.append(task)
+        strategy = Strategy([("parallel_mode", pg_info, False)])
+        task = Task(id=3, task_type="DRYRUN", process_mode="ALL_PROCESS", task_info=strategy)
+        tasks.append(task)
+        task = Task(id=4, task_type="FINISH", process_mode="ALL_PROCESS", task_info=strategy)
+        tasks.append(task)
+        self.tasks = tasks
+        self.index = 0
+
+
+def pass_sample_batch_code(dp_size):
+    backend = "nccl" if torch.cuda.is_available() else "gloo"
+    res = atorch.init_distributed(backend, set_cuda_device_using_local_rank=True)
+    if not res:
+        raise Exception("init_distributed failed")
+    model = ToyModel()
+    batch_size = 2
+    sample_batch = [torch.ones([batch_size, 16], dtype=torch.float32), torch.ones([batch_size, 4], dtype=torch.float32)]
+    atorch.auto.accelerate.EngineClient = FakeEasyDLClientPassSampleBatch
+    atorch.auto.accelerate.AccelerationEngine = FakeEngine
+
+    pg_info = ([("data", dp_size)], None)
+    strategy = Strategy([("parallel_mode", pg_info, False)])
+
+    status, res, best_strategy = auto_accelerate(
+        model,
+        prepare_input=prepare_input,
+        optim_func=optim_func,
+        load_strategy=strategy,
+        loss_func=loss_func,
+        sample_batch=sample_batch,
+        batch_size=batch_size,
+    )
+    assert len(best_strategy) == 1
+    assert status
+    assert res.model is not None
+    assert res.dataloader is None
+    assert res.optim is not None
+    assert res.prepare_input is not None
+    assert res.loss_func is not None
+    assert best_strategy == strategy
+
+
+class AutoAccelerateTest(unittest.TestCase):
+    def test_tasks(self):
+        run_dist_code("test_tasks")
+
+    def test_func(self):
+        run_dist_code("test_func")
+
+    @unittest.skipIf(
+        not torch.cuda.is_available() or torch.cuda.device_count() < 2, "Skip when gpu not exists or only 1 gpu"
+    )
+    def test_only_pass_model_to_auto_accelerate(self):
+        run_dist_code("only_pass_model")
+
+    @unittest.skipIf(
+        not torch.cuda.is_available() or torch.cuda.device_count() < 2, "Skip when gpu not exists or only 1 gpu"
+    )
+    def test_pass_sample_batch(self):
+        run_dist_code("pass_sample_batch")
+
+    @unittest.skipIf(
+        not torch.cuda.is_available() or torch.cuda.device_count() < 2, "Skip when gpu not exists or only 1 gpu"
+    )
+    def test_seed(self):
+        run_dist_code("set_seed_code")
+
+
+class LoadSaveStrategyTest(unittest.TestCase):
+    @unittest.skipIf(torch.cuda.is_available(), "Skip on gpu as cpu test covers it.")
+    def test_load_save_strategy(self):
+        pg_info = ([("data", 2)], None)
+        strategy = Strategy([("parallel_mode", pg_info, False), ("amp_native", None, False)])
+        _, filename = tempfile.mkstemp(suffix="st")
+        save_strategy(strategy, filename)
+        status, loaded_strategy = get_strategy(filename)
+        self.assertTrue(status)
+        self.assertEqual(loaded_strategy, strategy)
+        data = pickle.dumps(strategy)
+        status, loaded_strategy = get_strategy(data)
+        self.assertTrue(status)
+        self.assertEqual(loaded_strategy, strategy)
+        status, _ = get_strategy("_bad_filename.st")
+        self.assertFalse(status)
+        easydl_strategy = strategy.convert_strategy_to_easydl_format()
+        self.assertEqual(len(easydl_strategy), 2)
+
+    @unittest.skipIf(torch.cuda.is_available(), "Skip on gpu as cpu test covers it.")
+    def test_adjust_strategy(self):
+        pg_info = ([("model", 2), ("data", 2)], None)
+        strategy = Strategy([("parallel_mode", pg_info, False), ("amp_native", None, False)])
+        device_context = get_device_context()
+        device_context._node_num = 2
+        device_context._nproc_per_node = 8
+        opt_lib = OptimizationLibrary()
+        finetune_strategy = False
+        status, strategy = adjust_strategy(strategy, device_context, finetune_strategy, opt_lib)
+        self.assertTrue(status)
+        data_parallel_size = 1
+        found, p_mode = strategy.get_parallel_mode()
+        self.assertTrue(found)
+        for name, size in p_mode[0]:
+            if name == "data":
+                data_parallel_size = size
+        self.assertEqual(data_parallel_size, 8)
+        device_context._node_num = 1
+        device_context._nproc_per_node = 1
+        status, _ = adjust_strategy(strategy, device_context, finetune_strategy, opt_lib)
+        self.assertFalse(status)
+
+        device_context._node_num = 10
+        device_context._nproc_per_node = 2
+        finetune_strategy = True
+        strategy = ["parallel_mode", "amp_native"]
+        status, strategy = get_strategy(strategy)
+        self.assertTrue(status)
+        status, strategy = adjust_strategy(strategy, device_context, finetune_strategy, opt_lib)
+        self.assertTrue(status)
+        data_parallel_size = 1
+        _, p_mode = strategy.get_parallel_mode()
+        for name, size in p_mode[0]:
+            if name == "data":
+                data_parallel_size = size
+        self.assertEqual(data_parallel_size, 20)
+
+        strategy = Strategy(
+            [
+                ("amp_native", None, False),
+                ("module_replace", None, False),
+                ("tensor_parallel", None, True),
+                ("fsdp", None, False),
+            ]
+        )
+        removed_items = strategy.remove_distributed_method(opt_lib)
+        self.assertEqual(len(strategy), 2)
+        self.assertEqual(len(removed_items), 2)
+        strategy = Strategy(
+            [
+                ("amp_native", None, False),
+                ("module_replace", None, False),
+                ("tensor_parallel", None, True),
+                ("fsdp", {"cpu_offload": True}, False),
+            ]
+        )
+        removed_items = strategy.remove_distributed_method(opt_lib)
+        self.assertEqual(len(strategy), 3)
+        self.assertEqual(len(removed_items), 1)
+
+    def test_load_save_with_api(self):
+        run_dist_code("save_load")
+
+
+def run_dist_code(name, nproc=2):
+    code_path = os.path.abspath(__file__)
+    run_multi_process_init_distributed(nproc=nproc, training_script=code_path, training_script_args=(name,))
+
+
+if __name__ == "__main__":
+    cov_status = start_coverage()
+    if sys.argv[1] == "test_tasks":
+        task_run_code(data_size=100, batch_size=2)
+    elif sys.argv[1] == "test_func":
+        func_run_code(data_size=100, batch_size=2)
+    elif sys.argv[1] == "save_load":
+        save_load_code(data_size=100, batch_size=2)
+    elif sys.argv[1] == "only_pass_model":
+        only_pass_model_code(dp_size=2)
+    elif sys.argv[1] == "pass_sample_batch":
+        pass_sample_batch_code(dp_size=2)
+    elif sys.argv[1] == "test_seed":
+        set_seed_code(data_size=100, batch_size=2)
+    if cov_status:
+        stop_coverage()

--- a/atorch/atorch/tests/common_tests/bf16_optimizer_test.py
+++ b/atorch/atorch/tests/common_tests/bf16_optimizer_test.py
@@ -1,0 +1,119 @@
+import copy
+import unittest
+
+import torch
+from fairscale.optim.oss import OSS
+
+import atorch
+from atorch.distributed.distributed import reset_distributed
+from atorch.optimizers import BF16Optimizer
+
+
+class BF16OptimizerTest(unittest.TestCase):
+    @unittest.skipIf(not torch.cuda.is_available(), "run on gpu")
+    def test_bf16_optimizer(self):
+
+        model = torch.nn.Linear(2, 2).bfloat16().to(0)
+        model1 = copy.deepcopy(model)
+        inputs = torch.ones(2, 2).bfloat16().to(0)
+        mse_loss = torch.nn.MSELoss()
+        label = torch.ones(2, 2).bfloat16().to(0)
+        y = model(inputs)
+        loss = mse_loss(y, label)
+        loss.backward()
+        optimizer = torch.optim.SGD(model.parameters(), lr=0.01)
+        optimizer.step()
+        bf_16_grad = copy.deepcopy([p.grad for p in model.parameters()])
+        bf_16_params_after_optimizer_step = copy.deepcopy([p for p in model.parameters()])
+        optimizer.zero_grad()
+
+        inputs = torch.ones(2, 2).bfloat16().to(0)
+        mse_loss = torch.nn.MSELoss()
+        label = torch.ones(2, 2).bfloat16().to(0)
+        y = model1(inputs)
+        loss = mse_loss(y, label)
+        loss.backward()
+        optimizer = torch.optim.SGD(model1.parameters(), lr=0.01)
+        bf_16_finetune_optimizer = BF16Optimizer(optimizer)
+        self.assertEqual(len(bf_16_finetune_optimizer.fp32_from_fp16_groups), 1)
+        self.assertEqual(len(bf_16_finetune_optimizer.fp32_from_fp32_groups), 1)
+        self.assertEqual(len(bf_16_finetune_optimizer.fp16_groups), 1)
+        for i, param_group in enumerate(bf_16_finetune_optimizer.optimizer.param_groups):
+            for p in param_group["params"]:
+                self.assertTrue(p.dtype == torch.float)
+
+        model_grad = copy.deepcopy([p.grad for p in model1.parameters()])
+        res = [(p1 - p2).sum().abs() for p1, p2 in zip(model_grad, bf_16_grad)]
+        self.assertTrue(sum(res) < 1e-8)
+        # self.assertEqual()
+
+        bf_16_finetune_optimizer._model_grads_to_master_grads()
+        self.assertEqual(bf_16_finetune_optimizer.fp32_from_fp16_groups[0][0].grad.dtype, torch.float32)
+
+        bf_16_finetune_optimizer.step()
+        bf_16_params_bf_16_finetune_optimizer_step = copy.deepcopy([p for p in model.parameters()])
+        res = [
+            (p1 - p2).sum().abs()
+            for p1, p2 in zip(bf_16_params_bf_16_finetune_optimizer_step, bf_16_params_after_optimizer_step)
+        ]
+        self.assertTrue(sum(res) < 1e-8)
+        bf_16_finetune_optimizer.zero_grad()
+        self.assertEqual(bf_16_finetune_optimizer.fp32_from_fp16_groups[0][0].grad.sum(), 0)
+        self.assertEqual(sum([p.grad.sum() for p in model1.parameters()]), 0)
+
+    @unittest.skipIf(not torch.cuda.is_available(), "run on gpu")
+    def test_bf16_finetune_oss_optimizer(self):
+        atorch.init_distributed("nccl")
+
+        model = torch.nn.Linear(2, 2).bfloat16().to(0)
+        model1 = copy.deepcopy(model)
+        inputs = torch.ones(2, 2).bfloat16().to(0)
+        mse_loss = torch.nn.MSELoss()
+        label = torch.ones(2, 2).bfloat16().to(0)
+        y = model(inputs)
+        loss = mse_loss(y, label)
+        loss.backward()
+
+        oss_optimizer = OSS([p for p in model.parameters()], lr=0.1)
+
+        bf_16_finetune_optimizer = BF16Optimizer(oss_optimizer)
+        lr = torch.optim.lr_scheduler.ExponentialLR(bf_16_finetune_optimizer, gamma=0.98)
+        self.assertEqual(len(bf_16_finetune_optimizer.fp32_from_fp16_groups), 1)
+        self.assertEqual(len(bf_16_finetune_optimizer.fp32_from_fp32_groups), 1)
+        self.assertEqual(len(bf_16_finetune_optimizer.fp16_groups), 1)
+
+        for i, param_group in enumerate(bf_16_finetune_optimizer.optimizer.optim.param_groups):
+            for p in param_group["params"]:
+                self.assertTrue(p.dtype == torch.float)
+
+        for i, param_group in enumerate(bf_16_finetune_optimizer.param_groups):
+            for p in param_group["params"]:
+                self.assertTrue(p.dtype == torch.float)
+
+        bf_16_finetune_optimizer.step()
+        lr.step()
+
+        model_fp32_param_grad = []
+        for i, param_group in enumerate(bf_16_finetune_optimizer.optimizer.optim.param_groups):
+            for p in param_group["params"]:
+                self.assertTrue(p.requires_grad)
+                model_fp32_param_grad.append(p.grad)
+                self.assertTrue(p.grad.dtype == torch.float)
+                self.assertTrue(p.dtype == torch.float)
+        y = model1(inputs)
+        loss = mse_loss(y, label)
+        loss.backward()
+        model1_grad = [p.grad for p in model1.parameters()]
+
+        res = [(p1.float() - p2).sum() for p1, p2 in zip(model1_grad, model_fp32_param_grad)]
+        self.assertEqual(sum(res), 0)
+        res = [p.grad.sum() for p in model.parameters()]
+        self.assertTrue(sum(res) != 0)
+        bf_16_finetune_optimizer.zero_grad()
+        res = [p.grad.sum() for p in model.parameters()]
+        self.assertEqual(sum(res), 0)
+        reset_distributed()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/atorch/atorch/tests/common_tests/bo_sg_test.py
+++ b/atorch/atorch/tests/common_tests/bo_sg_test.py
@@ -1,0 +1,196 @@
+import collections
+import json
+import pickle
+import unittest
+
+import pandas as pd
+import torch
+
+from atorch.auto.engine.optimization_method import OptimizationMethodLibrary
+from atorch.auto.engine.sg_algo.hebo.design_space.design_space import DesignSpace
+from atorch.auto.engine.sg_algo.utils import (
+    analyse_strategies,
+    gen_space_config,
+    get_finished_strategies,
+    rec_to_easydl_strategy,
+    transform_finished_strategies_to_hebo,
+    unfeasible_filter,
+)
+from atorch.auto.engine.strategy import StrategyStatus
+
+StrategyInfo = collections.namedtuple(
+    "StrategyInfo",
+    "strategy status dryrun_result process_mode",
+)
+
+
+opt_method_lib = OptimizationMethodLibrary()
+
+
+finished_strategies = {}
+fsdp_config = {}
+fsdp_config["sync_module_states"] = True
+para_config = pickle.dumps(([("data", 2), ("tensor", 4)], None))
+finished_strategies[0] = StrategyInfo(
+    [
+        ("parallel_mode", pickle.dumps(([("data", 8)], None)), False),
+        (
+            "fsdp",
+            pickle.dumps(fsdp_config),
+            False,
+        ),
+    ],
+    StrategyStatus.SUCCEED,
+    {"throughput": 30.0},
+    "ONE_PROCESS",
+)
+finished_strategies[1] = StrategyInfo(
+    [
+        ("zero1", pickle.dumps(None), False),
+        ("parallel_mode", para_config, False),
+    ],
+    StrategyStatus.SUCCEED,
+    {"throughput": 135.0},
+    "ONE_PROCESS",
+)
+
+finished_strategies[2] = StrategyInfo(
+    [
+        ("zero1", pickle.dumps(None), False),
+        ("parallel_mode", para_config, False),
+    ],
+    StrategyStatus.SUCCEED,
+    {"throughput": 65.0},
+    "ONE_PROCESS",
+)
+
+finished_strategies[3] = StrategyInfo(
+    [
+        ("parallel_mode", para_config, False),
+        (
+            "fsdp",
+            pickle.dumps(fsdp_config),
+            False,
+        ),
+    ],
+    StrategyStatus.SUCCEED,
+    {"throughput": 33.0},
+    "ONE_PROCESS",
+)
+finished_strategies[4] = StrategyInfo(
+    [
+        ("amp_native", pickle.dumps(None), False),
+        ("parallel_mode", para_config, False),
+    ],
+    StrategyStatus.SUCCEED,
+    {"throughput": 200.0},
+    "ONE_PROCESS",
+)
+finished_strategies[5] = StrategyInfo(
+    [
+        ("parallel_mode", para_config, False),
+    ],
+    StrategyStatus.SUCCEED,
+    {"throughput": 11.0},
+    "ONE_PROCESS",
+)
+finished_strategies[6] = StrategyInfo(
+    [
+        ("parallel_mode", para_config, False),
+    ],
+    StrategyStatus.FAILED,
+    None,
+    "ONE_PROCESS",
+)
+finished_strategies[7] = StrategyInfo(
+    [("parallel_mode", pickle.dumps(([("data", 8)], None)), False)],
+    StrategyStatus.FAILED,
+    None,
+    "ONE_PROCESS",
+)
+
+
+class bosgTest(unittest.TestCase):
+    @unittest.skipIf(torch.cuda.is_available(), "run on cpu only")
+    def test_analyse_strategies(self):
+        iterations, patience = analyse_strategies(finished_strategies)
+        self.assertEqual(iterations, 8)
+        self.assertEqual(patience, 3)
+
+    @unittest.skipIf(torch.cuda.is_available(), "run on cpu only")
+    def test_get_finished_strategies(self):
+        got_finished_strategies = get_finished_strategies(finished_strategies)
+        self.assertEqual(got_finished_strategies, finished_strategies)
+
+    @unittest.skipIf(torch.cuda.is_available(), "run on cpu only")
+    def test_transform_rec_to_easydl_strategy(self):
+        parallel_mode = json.dumps({"data": 4, "tensor": 2})
+        rec_df = pd.DataFrame(
+            data=[
+                ["amp_native", "fsdp", parallel_mode, "NotChosen"],
+                ["amp_native", "NotChosen", parallel_mode, "module_replace"],
+            ],
+            columns=["amp", "zero", "parallel_mode", "module_replace"],
+        )
+        strategy_list = rec_to_easydl_strategy(rec_df, wrap_cls=("GPT2Block",))
+
+        self.assertEqual(len(strategy_list), 2)
+        for strategy in strategy_list:
+            self.assertEqual(isinstance(strategy, list), True)
+            for opt in strategy:
+                self.assertEqual(isinstance(opt, tuple), True)
+                self.assertEqual(len(opt), 3)
+
+    @unittest.skipIf(torch.cuda.is_available(), "run on cpu only")
+    def test_gen_space_config(self):
+
+        space_config = gen_space_config(opt_method_lib.groups, opt_method_lib.methods, 1)
+        names = [item["name"] for item in space_config]
+        self.assertEqual("zero" not in names, True)
+        self.assertEqual("parallel_mode" not in names, True)
+
+        space_config = gen_space_config(opt_method_lib.groups, opt_method_lib.methods, 4)
+        names = [item["name"] for item in space_config]
+        self.assertEqual("zero" in names, True)
+        self.assertEqual("parallel_mode" in names, True)
+
+        space_config = gen_space_config(
+            opt_method_lib.groups,
+            opt_method_lib.methods,
+            4,
+            ["checkpoint"],
+        )
+        for item in space_config:
+            if item["name"] == "checkpoint":
+                self.assertEqual("NotChosen" not in item["categories"], True)
+
+    @unittest.skipIf(torch.cuda.is_available(), "run on cpu only")
+    def test_transform_finished_strategies_to_hebo(self):
+        space_config = gen_space_config(opt_method_lib.groups, opt_method_lib.methods, 4)
+
+        space = DesignSpace().parse(space_config)
+
+        X, y = transform_finished_strategies_to_hebo(space, opt_method_lib.groups, finished_strategies)
+
+        self.assertEqual(len(X.columns.tolist()), 5)
+        self.assertEqual(len(X), 8)
+        self.assertEqual(len(y), 8)
+
+    @unittest.skipIf(torch.cuda.is_available(), "run on cpu only")
+    def test_unfeasible_filter(self):
+        NOT_COMPATIBLE_OPTS = []
+
+        space_config = gen_space_config(opt_method_lib.groups, opt_method_lib.methods, 8)
+        space = DesignSpace().parse(space_config)
+        rec_df = space.sample(num_samples=20)
+        rec, status = unfeasible_filter(rec_df, ["amp", "zero"], NOT_COMPATIBLE_OPTS)
+        self.assertEqual(len(rec), 1)
+        for _, row in rec[["amp", "zero"]].iterrows():
+            vals = []
+            for col, val in row.items():
+                vals.append(val)
+        self.assertEqual("+".join(vals) not in NOT_COMPATIBLE_OPTS, True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/atorch/atorch/tests/common_tests/clip_grad_norm_test.py
+++ b/atorch/atorch/tests/common_tests/clip_grad_norm_test.py
@@ -1,0 +1,299 @@
+import functools
+import itertools
+import math
+import os
+import unittest
+from copy import deepcopy
+
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+from torch.distributed.fsdp import ShardingStrategy
+from torch.distributed.fsdp.fully_sharded_data_parallel import FullyShardedDataParallel as FSDP
+from torch.distributed.fsdp.wrap import transformer_auto_wrap_policy
+
+from atorch.auto.accelerate import auto_accelerate
+from atorch.auto.clip_grad_norm import clip_grad_norm as auto_acc_clip_grad_norm
+from atorch.auto.clip_grad_norm import fsdp_grad_norm_per_param, fsdp_param_norm_and_grad_num_zero
+from atorch.common.util_func import find_free_port
+from atorch.distributed.distributed import init_distributed, parallel_group, reset_distributed
+from atorch.tests.toy_modules.toy_module import ToyCustomModule, ToyModel, loss_func
+from atorch.utils.version import torch_version
+
+
+def _fsdp_strategy_clip_grad_norm(rank, world_size, free_port):
+    os.environ["LOCAL_RANK"] = str(rank)
+    os.environ["RANK"] = str(rank)
+    os.environ["WORLD_SIZE"] = str(world_size)
+    os.environ["NPROC_PER_NODE"] = str(world_size)
+    os.environ["MASTER_ADDR"] = "localhost"
+    os.environ["MASTER_PORT"] = str(free_port)
+    dist.init_process_group(backend="nccl", rank=rank, world_size=world_size)
+    device = torch.device(f"cuda:{rank}")
+    local_model = ToyModel(use_custom_module=True)
+    atorch_wrap_cls = {
+        ToyCustomModule,
+    }
+    wrap_policy = functools.partial(transformer_auto_wrap_policy, transformer_layer_cls=atorch_wrap_cls)
+    fsdp_model = FSDP(
+        deepcopy(local_model).to(device), sharding_strategy=ShardingStrategy.FULL_SHARD, auto_wrap_policy=wrap_policy
+    )
+    fsdp_strategy = [
+        ("parallel_mode", ([("data", torch.distributed.get_world_size())], None)),
+        ("fsdp", {"atorch_wrap_cls": atorch_wrap_cls}),
+    ]
+    status, result, _ = auto_accelerate(
+        model=local_model,
+        load_strategy=fsdp_strategy,
+        ignore_dryrun_on_load_strategy=True,
+    )
+    assert status is True
+    auto_acc_model = result.model
+
+    for model in (fsdp_model, auto_acc_model):
+        input_data = [
+            torch.ones([1, 16], dtype=torch.float32).to(device),
+            torch.ones([1, 4], dtype=torch.float32).to(device),
+        ]
+        out = model(input_data)
+        loss = loss_func(input_data, out)
+        loss.backward()
+
+    LARGE_FACTOR = 100
+    for param in itertools.chain(fsdp_model.parameters(), auto_acc_model.parameters()):
+        if param.grad is not None:  # gradients may be `None` for `use_orig_params=True`
+            param.grad *= LARGE_FACTOR
+
+    max_norm = 2.5
+    norm_type = 2
+    auto_acc_grad_norm = auto_acc_clip_grad_norm(auto_acc_model, max_norm=max_norm, norm_type=norm_type)
+    if torch_version() >= (1, 12, 1) and torch_version() <= (1, 13, 1):
+        from torch.testing._internal.common_fsdp import _collect_total_grad_norm_fsdp
+
+        # in torch 1.x, fsdp_model.clip_grad_norm_ returns None.
+        fsdp_total_norm = _collect_total_grad_norm_fsdp(fsdp_model, norm_type, rank)
+    elif torch_version() >= (2, 0, 0):
+        fsdp_total_norm = fsdp_model.clip_grad_norm_(max_norm=max_norm, norm_type=norm_type)
+    assert torch.equal(auto_acc_grad_norm, fsdp_total_norm)
+
+    dist.destroy_process_group()
+
+
+def _fsdp_norm_utils(rank, world_size, free_port):
+    os.environ["LOCAL_RANK"] = str(rank)
+    os.environ["RANK"] = str(rank)
+    os.environ["WORLD_SIZE"] = str(world_size)
+    os.environ["NPROC_PER_NODE"] = str(world_size)
+    os.environ["MASTER_ADDR"] = "localhost"
+    os.environ["MASTER_PORT"] = str(free_port)
+    dist.init_process_group(backend="nccl", rank=rank, world_size=world_size)
+    device = torch.device(f"cuda:{rank}")
+    local_model = ToyModel(use_custom_module=True)
+    atorch_wrap_cls = {
+        ToyCustomModule,
+    }
+    ref_local_model = deepcopy(local_model).to(device)
+    fsdp_strategy = [
+        ("parallel_mode", ([("data", torch.distributed.get_world_size())], None)),
+        ("fsdp", {"atorch_wrap_cls": atorch_wrap_cls, "use_orig_params": True, "sync_module_states": True}),
+    ]
+    status, result, _ = auto_accelerate(
+        model=local_model,
+        load_strategy=fsdp_strategy,
+        ignore_dryrun_on_load_strategy=True,
+    )
+    assert status is True
+    auto_acc_model = result.model
+
+    for model in (ref_local_model, auto_acc_model):
+        batch_dim = 1 if model is auto_acc_model else world_size
+        input_data = [
+            torch.ones([batch_dim, 16], dtype=torch.float32).to(device),
+            torch.ones([batch_dim, 4], dtype=torch.float32).to(device),
+        ]
+        out = model(input_data)
+        loss = loss_func(input_data, out)
+        loss.backward()
+
+    LARGE_FACTOR = 100
+    for param in itertools.chain(ref_local_model.parameters(), auto_acc_model.parameters()):
+        if param.grad is not None:  # gradients may be `None` for `use_orig_params=True`
+            param.grad *= LARGE_FACTOR
+
+    norm_type = 2
+
+    total_param_norm, total_grad_num_zeros = fsdp_param_norm_and_grad_num_zero(auto_acc_model, norm_type=norm_type)
+    ref_total_param_norm = torch.linalg.vector_norm(
+        torch.stack(
+            [
+                torch.linalg.vector_norm(param.detach(), norm_type, dtype=torch.float32)
+                for param in ref_local_model.parameters()
+                if param.numel() > 0
+            ],
+        ),
+        norm_type,
+        dtype=torch.float32,
+    )
+
+    def _count_grad_zero(params):
+        grad_num_zeros = 0
+        for param in params:
+            if param.grad is not None:
+                grad = param.grad.detach()
+                grad_num_zeros += grad.numel() - torch.count_nonzero(grad)
+        return grad_num_zeros
+
+    ref_total_grad_num_zeros = _count_grad_zero(ref_local_model.parameters())
+    if torch.distributed.get_rank() == 0:
+        assert (
+            torch.isclose(total_param_norm, ref_total_param_norm)
+            and total_grad_num_zeros.item() == ref_total_grad_num_zeros.item()
+        )
+    # print(f"total_param_norm: {total_param_norm}, total_grad_num_zeros: {total_grad_num_zeros}, "
+    #       f"ref_total_param_norm: {ref_total_param_norm}, ref_total_grad_num_zeros: {ref_total_grad_num_zeros}")
+
+    grad_norms = fsdp_grad_norm_per_param(auto_acc_model, 1, norm_type=norm_type)
+    ref_grad_norms = {
+        name: torch.linalg.vector_norm(param.grad.detach(), norm_type, dtype=torch.float32)
+        if param.grad is not None
+        else torch.tensor(0).to(torch.cuda.current_device())
+        for name, param in ref_local_model.named_parameters()
+    }
+    if torch.distributed.get_rank() == 0:
+        assert set(grad_norms.keys()) == set(ref_grad_norms.keys())
+        for k in grad_norms:
+            assert torch.isclose(grad_norms[k], ref_grad_norms[k])
+    # print(f"grad_norms: {grad_norms}")
+    # print(f"ref_grad_norms: {ref_grad_norms}")
+
+    dist.destroy_process_group()
+
+
+def is_tensor_parallel_parameter(param):
+    return hasattr(param, "is_tensor_parallel") and param.is_tensor_parallel
+
+
+def clip_grad_norm_for_ut(parameters, max_norm, norm_type=2, tp_group=None):
+    """Adapted from deepspeed"""
+    if isinstance(parameters, torch.Tensor):
+        parameters = [parameters]
+    parameters = list(filter(lambda p: p.grad is not None, parameters))
+    max_norm = float(max_norm)
+    norm_type = float(norm_type)
+    if norm_type == math.inf:
+        total_norm = max(p.grad.data.abs().max() for p in parameters)
+        total_norm_cuda = torch.cuda.FloatTensor([float(total_norm)])
+        # Take max across all GPUs.
+        if tp_group is not None:
+            dist.all_reduce(total_norm_cuda, op=dist.ReduceOp.MAX, group=tp_group)
+        total_norm = total_norm_cuda[0].item()
+    else:
+        total_norm = 0
+        for p in parameters:
+            if tp_group is not None:
+                if (torch.distributed.get_rank(tp_group) == 0) or is_tensor_parallel_parameter(p):
+                    param_norm = p.grad.data.norm(norm_type)
+                    total_norm += param_norm.item() ** norm_type
+            else:
+                param_norm = p.grad.data.float().norm(norm_type)
+                total_norm += param_norm.item() ** norm_type
+
+        # Sum across all model parallel GPUs.
+        total_norm_cuda = torch.cuda.FloatTensor([float(total_norm)])
+        if tp_group is not None:
+            dist.all_reduce(total_norm_cuda, op=dist.ReduceOp.SUM, group=tp_group)
+        total_norm = total_norm_cuda[0].item() ** (1.0 / norm_type)
+
+    clip_coef = max_norm / (total_norm + 1e-6)
+    if clip_coef < 1:
+        for p in parameters:
+            p.grad.data.mul_(clip_coef)
+    return total_norm
+
+
+def _tp_strategy_clip_grad_norm(rank, world_size, free_port):
+    os.environ["LOCAL_RANK"] = str(rank)
+    os.environ["RANK"] = str(rank)
+    os.environ["WORLD_SIZE"] = str(world_size)
+    os.environ["NPROC_PER_NODE"] = str(world_size)
+    os.environ["MASTER_ADDR"] = "localhost"
+    os.environ["MASTER_PORT"] = str(free_port)
+    init_distributed(backend="nccl")
+    device = torch.device(f"cuda:{rank}")
+    torch.cuda.set_device(torch.device(f"cuda:{rank}"))
+    local_model = ToyModel(use_custom_module=True)
+    tp_strategy = [("parallel_mode", ([("tensor", torch.distributed.get_world_size())], None)), "tensor_parallel"]
+    status, result, _ = auto_accelerate(
+        model=local_model,
+        load_strategy=tp_strategy,
+        ignore_dryrun_on_load_strategy=True,
+        sample_batch=[
+            torch.ones([1, 16], dtype=torch.float32).to(device),
+            torch.ones([1, 4], dtype=torch.float32).to(device),
+        ],
+        batch_size=1,
+    )
+    assert status is True
+    auto_acc_model = result.model
+    max_norm = 2.5
+    norm_type = 2
+    auto_acc_grad_norm = auto_acc_clip_grad_norm(auto_acc_model, max_norm=max_norm, norm_type=norm_type)
+    tp_group = parallel_group("tensor")
+    ds_result = clip_grad_norm_for_ut(
+        auto_acc_model.parameters(), max_norm=max_norm, norm_type=norm_type, tp_group=tp_group
+    )
+    assert auto_acc_grad_norm.cpu().item() == ds_result
+    reset_distributed()
+
+
+class TestClipGradNorm(unittest.TestCase):
+    @unittest.skipIf(
+        not torch.cuda.is_available() or torch.cuda.device_count() < 2,
+        "No gpu available for cuda tests",
+    )
+    def test_fsdp_strategy_clip_grad_norm(self):
+        world_size = 2
+        mp.spawn(
+            _fsdp_strategy_clip_grad_norm,
+            args=(world_size, find_free_port()),
+            nprocs=world_size,
+            join=True,
+            daemon=False,
+            start_method="spawn",
+        )
+
+    @unittest.skipIf(
+        not torch.cuda.is_available() or torch.cuda.device_count() < 2,
+        "No gpu available for cuda tests",
+    )
+    def test_tp_strategy_clip_grad_norm(self):
+        world_size = 2
+        mp.spawn(
+            _tp_strategy_clip_grad_norm,
+            args=(world_size, find_free_port()),
+            nprocs=world_size,
+            join=True,
+            daemon=False,
+            start_method="spawn",
+        )
+
+
+class TestFSDPNormUtils(unittest.TestCase):
+    @unittest.skipIf(
+        not torch.cuda.is_available() or torch.cuda.device_count() < 2 or torch_version() < (2, 0, 0),
+        "No gpu available for cuda tests, torch 2.0 needed for use_orig_param",
+    )
+    def test_fsdp_norm_utils(self):
+        world_size = 2
+        mp.spawn(
+            _fsdp_norm_utils,
+            args=(world_size, find_free_port()),
+            nprocs=world_size,
+            join=True,
+            daemon=False,
+            start_method="spawn",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/atorch/atorch/tests/common_tests/data_utils_test.py
+++ b/atorch/atorch/tests/common_tests/data_utils_test.py
@@ -1,0 +1,65 @@
+import unittest
+from collections import OrderedDict, abc
+
+import torch
+
+from atorch.data import expand_batch_dim
+
+
+@unittest.skipIf(torch.cuda.is_available(), "Skip on gpu as cpu test covers it.")
+class DataUtilTest(unittest.TestCase):
+    def test_expand_torch_tensor(self):
+        bs, c, h, w = 16, 3, 4, 4
+        input_tensor = torch.ones([c, h, w], dtype=torch.float32)
+        output_tensor = expand_batch_dim(input_tensor, batch_size=bs)
+        self.assertTrue(torch.equal(output_tensor, torch.ones([bs, c, h, w], dtype=torch.float32)))
+
+    def test_expand_list_of_tensors(self):
+        bs = 4
+        input_tensors = [torch.ones([i], dtype=torch.float32) for i in range(1, 4)]
+        output_tensors = expand_batch_dim(input_tensors, batch_size=bs)
+        for i in range(0, 3):
+            self.assertTrue(torch.equal(output_tensors[i], torch.ones([bs, i + 1], dtype=torch.float32)))
+
+    def test_expand_nested_list_of_tensors(self):
+        dtype = torch.float32
+        bs = 4
+        input_tensors = tuple([torch.ones([4], dtype=dtype), [torch.ones([i], dtype=dtype) for i in range(1, 4)]])
+        output_tensors = expand_batch_dim(input_tensors, batch_size=bs)
+        expected_output = tuple(
+            [torch.ones([bs, 4], dtype=dtype), [torch.ones([bs, i], dtype=dtype) for i in range(1, 4)]]
+        )
+        self.assertIsInstance(output_tensors, tuple)
+        for output, expect in zip(output_tensors, expected_output):
+            if isinstance(output, torch.Tensor):
+                self.assertTrue(torch.equal(output, expect))
+            elif isinstance(output, abc.Sequence):
+                for o, e in zip(output, expect):
+                    self.assertTrue(torch.equal(o, e))
+
+    def test_expand_map_of_tensors(self):
+        bs, c, h, w = 16, 3, 4, 4
+        dtype = torch.float32
+        input_dict = {
+            "data": torch.ones([c, h, w], dtype=dtype),
+            "label": torch.tensor(0, dtype=dtype),
+        }
+        output_dict = expand_batch_dim(input_dict, batch_size=bs)
+        self.assertIsInstance(output_dict, dict)
+        self.assertTrue(torch.equal(output_dict["data"], torch.ones([bs, c, h, w], dtype=dtype)))
+        self.assertTrue(torch.equal(output_dict["label"], torch.zeros(bs, dtype=dtype)))
+
+        input_ordered_dict = OrderedDict(
+            {
+                "data": torch.ones([c, h, w], dtype=dtype),
+                "label": torch.tensor(0, dtype=dtype),
+            }
+        )
+        output_ordered_dict = expand_batch_dim(input_ordered_dict, batch_size=bs)
+        self.assertIsInstance(output_ordered_dict, OrderedDict)
+        self.assertTrue(torch.equal(output_ordered_dict["data"], torch.ones([bs, c, h, w], dtype=dtype)))
+        self.assertTrue(torch.equal(output_ordered_dict["label"], torch.zeros(bs, dtype=dtype)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/atorch/atorch/tests/common_tests/device_context_test.py
+++ b/atorch/atorch/tests/common_tests/device_context_test.py
@@ -1,0 +1,20 @@
+import unittest
+
+import torch
+
+from atorch.auto.device_context import DeviceContext
+
+
+class DeviceContextTest(unittest.TestCase):
+    def test_device_cpu(self):
+        dc = DeviceContext()
+        context = dc.detect()
+        self.assertGreater(context["cpu_num_per_node"], 0)
+        self.assertGreater(context["cpu_memory_per_node"], 0)
+
+    @unittest.skipIf(not torch.cuda.is_available(), "Skip for non gpu device.")
+    def test_device_gpu(self):
+        dc = DeviceContext()
+        context = dc.detect()
+        self.assertGreater(context["total_gpu"], 0)
+        self.assertGreater(context["gpu_memory"], 0)

--- a/atorch/atorch/tests/common_tests/dim_planner_test.py
+++ b/atorch/atorch/tests/common_tests/dim_planner_test.py
@@ -1,0 +1,105 @@
+import unittest
+
+import torch
+from torch.nn import MSELoss
+from torch.utils.data import Dataset
+
+from atorch.auto.model_context import ModelContext
+from atorch.auto.opt_lib.shard_planners.dim_planner import DimPlanner
+from atorch.utils.version import torch_version
+
+
+class FakeDeviceContext(object):
+    """
+    Device context contains compute resources information below.
+        number of nodes
+        number of logical cpu cores per node
+        gpu model
+        gpu memory(B)
+        number of gpus per node
+        total gpus of the training job
+    """
+
+    def __init__(self):
+        self.intra_node_bandwidth = 2**4
+        self.inter_node_bandwidth = 2**3
+        self.fp32_flops = 2**4
+        self.gpu_memory = 2**13
+
+
+class MyModule(torch.nn.Module):
+    def __init__(self, in_features, out_features, bias=True):
+        super().__init__()
+        self.layer = torch.nn.Linear(in_features, out_features, bias=bias)
+        self.layers = torch.nn.ModuleList([torch.nn.Linear(out_features, out_features, bias=bias) for _ in range(3)])
+
+    def forward(self, input_):
+        data = torch.nn.functional.gelu(self.layer(input_[0]))
+        for op in self.layers:
+            data = op(data)
+        return data
+
+
+class ToyDataset(Dataset):
+    def __init__(self, size):
+        self.size = size
+
+    def __len__(self):
+        return self.size
+
+    def __getitem__(self, idx):
+        return torch.ones((4, 8)), torch.zeros((4, 8))
+
+
+def prepare_input(data, device):
+    return data[0].to(device), data[1].to(device)
+
+
+def my_loss_func(data, outputs):
+    loss_fct = MSELoss()
+    loss = loss_fct(outputs.view(-1), data[-1].view(-1))
+    return loss
+
+
+def create_model_context(data_size=512, batch_size=16, loss_func=None):
+    model = MyModule(8, 8, True)
+    dataset = ToyDataset(data_size)
+    model_context = ModelContext(
+        model=model,
+        optim_func=torch.optim.SGD,
+        dataset=dataset,
+        prepare_input=prepare_input,
+        dataloader_args={"batch_size": batch_size, "drop_last": True},
+        optim_args={"lr": 0.001},
+        loss_func=loss_func,
+    )
+    return model_context
+
+
+def run_dim_planner(num_nodes, num_devices_per_node, loss_func):
+    model_context = create_model_context(loss_func=loss_func)
+    device_context = FakeDeviceContext()
+    dim_planner = DimPlanner(
+        num_nodes=num_nodes,
+        num_devices_per_node=num_devices_per_node,
+        use_fake_mode=False,
+        device_context=device_context,
+    )
+    (
+        optimal_tensor_size,
+        optimal_pipe_size,
+        optimal_data_size,
+        insert_before_nodes,
+    ) = dim_planner.generate_sharding_plan(model_context)
+    assert len(insert_before_nodes) == optimal_pipe_size - 1
+    assert optimal_tensor_size * optimal_pipe_size * optimal_data_size == num_nodes * num_devices_per_node
+
+
+class TestDimPlanner(unittest.TestCase):
+    @unittest.skipIf(not torch.cuda.is_available() or torch_version() < (2, 0, 0), "Test on GPU image")
+    def test_dim_planner(self):
+        run_dim_planner(2, 4, my_loss_func)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/atorch/atorch/tests/common_tests/distributed_mappings_test.py
+++ b/atorch/atorch/tests/common_tests/distributed_mappings_test.py
@@ -1,0 +1,118 @@
+import os
+import unittest
+
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+import atorch
+from atorch.common.log_utils import default_logger as logger
+from atorch.distributed.distributed import create_parallel_group, parallel_group, parallel_group_and_ranks
+from atorch.modules.distributed_modules.mappings_registry import get_communicator
+from atorch.utils.sharding_spec import MeshShardingSpec
+
+logger.setLevel("INFO")
+os.environ["NCCL_DEBUG"] = "ERROR"
+
+
+def init_dist(rank, world_size):
+    os.environ["LOCAL_RANK"] = rank
+    os.environ["RANK"] = rank
+    os.environ["WORLD_SIZE"] = world_size
+    os.environ["NPROC_PER_NODE"] = world_size
+    atorch.init_distributed("nccl")
+    torch.cuda.device(atorch.local_rank())
+    parallel_config = ([("model", world_size)], None)
+    create_parallel_group(parallel_config)
+
+
+def _run_sequence_partition_to_feature_partition(rank, world_size):
+    init_dist(rank, world_size)
+
+    device = torch.device("cuda:{}".format(atorch.local_rank()))
+    torch.cuda.set_device(device)
+
+    pg = parallel_group("model")
+    _, ranks = parallel_group_and_ranks("model")
+
+    prev_shard = MeshShardingSpec(
+        dims=(1,),
+        group=pg,
+        ranks=ranks,
+    )
+    cur_shard = MeshShardingSpec(
+        dims=(-1,),
+        group=pg,
+        ranks=ranks,
+    )
+    my_rank = dist.get_rank(pg)
+    local_tensor = [list(range(my_rank, my_rank + world_size**2, world_size))]
+    local_tensor = [local_tensor]
+    local_tensor = torch.Tensor(local_tensor).contiguous()
+    local_tensor.to(device)
+    resharding_operator = get_communicator(prev_shard, cur_shard)
+    resharded_tensor = resharding_operator(local_tensor)
+    target_resharded_tensor = [[[my_rank + i] for i in range(world_size)]]
+    target_resharded_tensor = torch.Tensor(target_resharded_tensor)
+    assert torch.all(torch.isclose(resharded_tensor, target_resharded_tensor))
+
+    atorch.reset_distributed()
+
+
+def _run_data_partition_to_feature_partition(rank, world_size):
+    init_dist(rank, world_size)
+
+    device = torch.device("cuda:{}".format(atorch.local_rank()))
+    torch.cuda.set_device(device)
+
+    pg = parallel_group("model")
+    _, ranks = parallel_group_and_ranks("model")
+
+    prev_shard = MeshShardingSpec(
+        dims=(0,),
+        group=pg,
+        ranks=ranks,
+    )
+    cur_shard = MeshShardingSpec(
+        dims=(-1,),
+        group=pg,
+        ranks=ranks,
+    )
+    my_rank = dist.get_rank(pg)
+    local_tensor = [list(range(my_rank, my_rank + world_size**2, world_size))]
+    local_tensor = [local_tensor]
+    local_tensor = torch.Tensor(local_tensor).contiguous()
+    local_tensor.to(device)
+    resharding_operator = get_communicator(prev_shard, cur_shard)
+    resharded_tensor = resharding_operator(local_tensor)
+    target_resharded_tensor = [[[my_rank + i]] for i in range(world_size)]
+    target_resharded_tensor = torch.Tensor(target_resharded_tensor)
+    assert torch.all(torch.isclose(resharded_tensor, target_resharded_tensor))
+
+    atorch.reset_distributed()
+
+
+class TestReshardingOperator(unittest.TestCase):
+    @unittest.skipIf(True, "Failed on gpu")
+    def test_sequence_partition_to_feature_partition(self):
+        world_size = 2
+        mp.spawn(
+            _run_sequence_partition_to_feature_partition,
+            args=(world_size),
+            nprocs=world_size,
+            join=True,
+        )
+
+    @unittest.skipIf(True, "Failed on gpu")
+    def test_data_partition_to_feature_partition(self):
+        world_size = 2
+        mp.spawn(
+            _run_data_partition_to_feature_partition,
+            args=(world_size),
+            nprocs=world_size,
+            join=True,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/atorch/atorch/tests/common_tests/distributed_test.py
+++ b/atorch/atorch/tests/common_tests/distributed_test.py
@@ -1,0 +1,325 @@
+import copy
+import os
+import subprocess
+import sys
+import unittest
+from datetime import timedelta
+
+import numpy as np
+import torch
+import torch.distributed as dist
+
+import atorch
+from atorch.common.util_func import find_free_port, get_ip_address
+from atorch.distributed.distributed import ParallelGroupContextManager
+from atorch.distributed.distributed import _DistributedContext
+from atorch.distributed.distributed import _DistributedContext as dc
+from atorch.distributed.distributed import (
+    create_parallel_group,
+    destroy_parallel_group,
+    get_pg_ranks,
+    get_ranks_in_same_group,
+    init_distributed,
+    local_rank,
+    parallel_group,
+    parallel_group_and_ranks,
+    parallel_group_size,
+    parallel_rank,
+    rank,
+    reset_distributed,
+    world_size,
+)
+from atorch.distributed.launch import check_process_loop, parse_args
+from atorch.tests.utils.test_utils import (
+    elastic_run_multi_process,
+    run_multi_process_init_distributed,
+    start_coverage,
+    stop_coverage,
+)
+
+
+def _test_allreduce(data, names):
+    for name in names:
+        assert parallel_group_and_ranks(name) is not None
+        assert parallel_rank(name) is not None
+        assert parallel_group_size(name) is not None
+        group = parallel_group(name)
+        assert group is not None
+        torch.distributed.all_reduce(data, group=group)
+
+
+def dist_code_for_test(backend, use_atorch_init=True, coworker_num_per_node=0, pg_configs=None):
+    if use_atorch_init:
+        res = atorch.init_distributed(
+            backend, coworker_num_per_node=coworker_num_per_node, set_cuda_device_using_local_rank=True
+        )
+        if not res:
+            raise Exception("init failed")
+    else:
+        torch.distributed.init_process_group(
+            backend,
+            init_method="env://",
+            world_size=int(os.getenv("WORLD_SIZE")),
+            rank=int(os.getenv("RANK")),
+        )
+        if not torch.distributed.is_initialized():
+            raise Exception("init failed")
+
+    if coworker_num_per_node > 0:
+        assert atorch.distributed.world_size() == 1
+        assert atorch.distributed.rank() == 0
+        assert atorch.distributed.is_coworker() or atorch.distributed.local_rank() == 1
+        assert atorch.distributed.coworker_local_rank() == 0 or atorch.distributed.local_rank() == 1
+        assert atorch.distributed.worker_local_rank() == 0 or atorch.distributed.local_rank() == 0
+        assert atorch.distributed.coworker_num_per_node() == 1
+        assert atorch.distributed.worker_num_per_node() == 1
+
+    device = f"cuda:{local_rank()}" if torch.cuda.is_available() else "cpu"
+    if pg_configs is not None:
+        data = torch.ones(1).to(device)
+        for idx, config in enumerate(pg_configs):
+            parallel_config = (config, None)
+            p_names = [p[0] for p in parallel_config[0]]
+            if idx > 0:
+                prefix_name = f"pg_p_{idx}_"
+                with ParallelGroupContextManager(prefix_name):
+                    create_parallel_group(parallel_config)
+                    assert dc.PG_NAME_PREFIX == prefix_name
+                    for name in dc.PARALLEL_RANK:
+                        assert name.startswith(prefix_name)
+                    for name in dc.PARALLEL_GROUP:
+                        assert name.startswith(prefix_name)
+                    _test_allreduce(data, p_names)
+            else:
+                create_parallel_group(parallel_config)
+                _test_allreduce(data, p_names)
+            destroy_parallel_group()
+    elif coworker_num_per_node == 0:
+        torch.distributed.barrier()
+
+    if use_atorch_init:
+        atorch.reset_distributed()
+        assert atorch.distributed.is_coworker() is False
+    else:
+        torch.distributed.destroy_process_group()
+
+
+class ParseArgsTest(unittest.TestCase):
+    def test_parse_args(self):
+        args = [
+            "--nnodes=1",
+            "--node_rank=0",
+            "--nproc_per_node=8",
+            "mycode.py",
+            "params for my code",
+        ]
+        res = parse_args(args)
+        self.assertEqual(res.node_rank, 0)
+        self.assertEqual(res.nproc_per_node, 8)
+        self.assertEqual(res.nnodes, 1)
+        self.assertEqual(res.training_script, args[-2])
+        self.assertEqual(res.training_script_args, [args[-1]])
+
+
+class DistributedTest(unittest.TestCase):
+    def test_init_distributed(self):
+        backend = "nccl" if torch.cuda.is_available() else "gloo"
+        res = init_distributed(backend)
+        self.assertTrue(res)
+        self.assertEqual(world_size(), 1)
+        self.assertEqual(rank(), 0)
+        self.assertEqual(local_rank(), 0)
+        reset_distributed()
+
+    def test_two_process_init_distributed(self):
+        run_dist_code("test_basic_dist", nproc=2, use_launch=False)
+
+    def test_two_process_init_distributed_with_coworker(self):
+        run_dist_code("test_basic_dist_with_coworker", nproc=2)
+
+
+@unittest.skipIf(True, "Failed on gpu, accl is not installed")
+class DistributedCudaAcclTest(unittest.TestCase):
+    def test_init_distributed_accl(self):
+        res = init_distributed("accl")
+        self.assertTrue(res)
+        self.assertEqual(world_size(), 1)
+        self.assertEqual(rank(), 0)
+        self.assertEqual(local_rank(), 0)
+        reset_distributed()
+
+    def test_two_process_init_distributed(self):
+        run_dist_code("test_basic_dist_with_accl", nproc=2)
+
+
+class ParallelGroupTest(unittest.TestCase):
+    def test_ranks_generation(self):
+        dmp_sizes = [
+            [("model", 2), ("pipeline", 2), ("data", 2)],
+            [("tensor", 4), ("data", 2)],
+            [("model", 2), ("sequence", 2), ("pipeline", 2), ("data", 2)],
+        ]
+        correct_ranks = [
+            {
+                "model": [[0, 1], [2, 3], [4, 5], [6, 7]],
+                "pipeline": [[0, 2], [1, 3], [4, 6], [5, 7]],
+                "data": [[0, 4], [1, 5], [2, 6], [3, 7]],
+            },
+            {
+                "tensor": [[0, 1, 2, 3], [4, 5, 6, 7]],
+                "data": [[0, 4], [1, 5], [2, 6], [3, 7]],
+            },
+            {
+                "model": [[0, 1], [2, 3], [4, 5], [6, 7], [8, 9], [10, 11], [12, 13], [14, 15]],
+                "sequence": [[0, 2], [1, 3], [4, 6], [5, 7], [8, 10], [9, 11], [12, 14], [13, 15]],
+                "pipeline": [[0, 4], [1, 5], [2, 6], [3, 7], [8, 12], [9, 13], [10, 14], [11, 15]],
+                "data": [[0, 8], [1, 9], [2, 10], [3, 11], [4, 12], [5, 13], [6, 14], [7, 15]],
+            },
+        ]
+        correct_same_group_ranks_10 = [
+            {
+                "model": [10, 11],
+                "pipeline": [8, 10],
+                "data": [10, 14],
+            },
+            {
+                "tensor": [8, 9, 10, 11],
+                "data": [10, 14],
+            },
+            {
+                "model": [10, 11],
+                "sequence": [8, 10],
+                "pipeline": [10, 14],
+                "data": [2, 10],
+            },
+        ]
+        correct_same_group_ranks_0 = [
+            {
+                "model": [0, 1],
+                "pipeline": [0, 2],
+                "data": [0, 4],
+            },
+            {
+                "tensor": [0, 1, 2, 3],
+                "data": [0, 4],
+            },
+            {
+                "model": [0, 1],
+                "sequence": [0, 2],
+                "pipeline": [0, 4],
+                "data": [0, 8],
+            },
+        ]
+
+        for index, slicing_dim in enumerate(dmp_sizes):
+            size = np.prod([p[1] for p in slicing_dim])
+            _DistributedContext.WORLD_SIZE = size
+            rank_order = list(range(size))
+            pg_ranks = get_pg_ranks(slicing_dim, rank_order)
+            for name in pg_ranks[0]:
+                self.assertEqual(pg_ranks[0][name], correct_ranks[index][name])
+            ranks_in_same_group = get_ranks_in_same_group((slicing_dim, rank_order), 0)
+            self.assertEqual(ranks_in_same_group, correct_same_group_ranks_0[index])
+            _DistributedContext.WORLD_SIZE = size * 2
+            rank_order = list(range(size * 2))
+            pg_ranks = get_pg_ranks(slicing_dim, rank_order)
+            for name in pg_ranks[0]:
+                self.assertEqual(pg_ranks[0][name], correct_ranks[index][name])
+                second_instance_correct_ranks = copy.deepcopy(correct_ranks[index][name])
+                for d in second_instance_correct_ranks:
+                    for i in range(len(d)):
+                        d[i] += size
+                self.assertEqual(pg_ranks[1][name], second_instance_correct_ranks)
+            ranks_in_same_group = get_ranks_in_same_group((slicing_dim, rank_order), 10)
+            self.assertEqual(ranks_in_same_group, correct_same_group_ranks_10[index])
+        reset_distributed()
+
+    def test_2_process_create_groups(self):
+        run_dist_code("test_pg_dist_with_2node", nproc=2)
+
+    @unittest.skipIf(torch.cuda.is_available() and torch.cuda.device_count() < 4, "Requires 4 gpus")
+    def test_4_process_create_groups(self):
+        run_dist_code("test_pg_dist_with_4node", nproc=4)
+
+    @unittest.skipIf(torch.cuda.is_available() and torch.cuda.device_count() < 4, "Requires 4 gpus")
+    def test_4_process_create_groups_without_atorch_init(self):
+        run_dist_code("test_pg_dist_with_4node_without_atorch_init", nproc=4)
+
+
+def rpc_code(backend):
+    res = atorch.init_distributed(backend)
+    if not res:
+        raise Exception("init failed")
+    from atorch.distributed.distributed import coworker_addrs
+
+    port = int(os.getenv("MASTER_PORT2", -1))
+    co_addr_ip = coworker_addrs()
+    store_port = int(co_addr_ip[1].split(":")[1])
+    assert port == store_port
+    destroy_parallel_group()
+
+
+class CoworkerTest(unittest.TestCase):
+    def test_one_worker_and_one_coworker(self):
+        port = find_free_port()
+        ip = get_ip_address()
+        cmd = [sys.executable, "-u"]
+        path = os.path.abspath(__file__)
+        cmd.append(path)
+        cmd.append("test_rpc")
+        current_env = os.environ.copy()
+        common_env = {
+            "RANK": "0",
+            "LOCAL_RANK": "0",
+            "WORLD_SIZE": "2",
+            "COWORKER_SIZE": "1",
+            "MASTER_ADDR": ip,
+            "MASTER_PORT2": str(port),
+        }
+        store = dist.TCPStore(
+            ip,
+            port,
+            is_master=True,
+            timeout=timedelta(seconds=90),
+        )
+        ip_and_port = ip + ":" + str(port)
+        store.set(str(1), ip_and_port)
+        processes = []
+        port = find_free_port()
+        common_env["MASTER_PORT"] = str(port)
+        current_env.update(common_env)
+        process = subprocess.Popen(cmd, env=current_env)
+        processes.append((process, None, None))
+        check_process_loop(processes)
+
+
+def run_dist_code(name, nproc=2, use_launch=True):
+    code_path = os.path.abspath(__file__)
+    if use_launch:
+        run_multi_process_init_distributed(nproc=nproc, training_script=code_path, training_script_args=(name,))
+    else:
+        elastic_run_multi_process(nproc=nproc, training_script=code_path, training_script_args=(name,))
+
+
+if __name__ == "__main__":
+    cov_status = start_coverage()
+    backend = "nccl" if torch.cuda.is_available() else "gloo"
+    if sys.argv[1] == "test_basic_dist":
+        dist_code_for_test(backend)
+    elif sys.argv[1] == "test_basic_dist_with_coworker":
+        dist_code_for_test(backend, coworker_num_per_node=1)
+    elif sys.argv[1] == "test_basic_dist_with_accl":
+        dist_code_for_test("accl")
+    elif sys.argv[1] == "test_pg_dist_with_2node":
+        configs = [("model", 2)], [("data", 2)]
+        dist_code_for_test(backend, pg_configs=configs)
+    elif sys.argv[1] == "test_pg_dist_with_4node":
+        configs = [("model", 4)], [("model", 2), ("data", 2)]
+        dist_code_for_test(backend, pg_configs=configs)
+    elif sys.argv[1] == "test_pg_dist_with_4node_without_atorch_init":
+        configs = [("model", 4)], [("pipe", 2), ("data", 2)]
+        dist_code_for_test(backend, use_atorch_init=False, pg_configs=configs)
+    elif sys.argv[1] == "test_rpc":
+        rpc_code(backend)
+    if cov_status:
+        stop_coverage()

--- a/atorch/atorch/tests/common_tests/distributed_transformer_test.py
+++ b/atorch/atorch/tests/common_tests/distributed_transformer_test.py
@@ -1,0 +1,136 @@
+import os
+import tempfile
+import unittest
+
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+from atorch.common.log_utils import default_logger as logger
+from atorch.modules.distributed_transformer import DistributedSoftmax
+from atorch.modules.distributed_transformer.commu_utils import AllGatherQMicro, ReduceScatterContext
+
+logger.setLevel("INFO")
+os.environ["NCCL_DEBUG"] = "ERROR"
+
+
+def _run_distributed_softmax(rank, world_size, tmp_file):
+    if torch.cuda.is_available():
+        torch.cuda.set_device(rank)
+        device = torch.device(f"cuda:{rank}")
+        backend = "nccl"
+    else:
+        device = torch.device("cpu")
+        backend = "gloo"
+    dist.init_process_group(
+        init_method="file://" + tmp_file,
+        rank=rank,
+        backend=backend,
+        world_size=world_size,
+    )
+
+    # batch size, num heads, q dim, local sequence, hidden size
+    bs, nh, qd, ls = 10, 12, 32, 512
+    dtype = torch.float32
+    torch.manual_seed(0)
+    s = torch.rand((bs, nh, qd, ls * world_size), requires_grad=True, dtype=dtype).to(device).split(ls, dim=-1)[rank]
+    s.retain_grad()
+    p = DistributedSoftmax.apply(s)
+    dummy_label = torch.rand((bs, nh, qd, ls * world_size), dtype=dtype).to(device)
+    dummy_label_local = dummy_label.split(ls, dim=-1)[rank]
+    (p - dummy_label_local).sum().backward()
+
+    torch.manual_seed(0)
+    ss = torch.rand((bs, nh, qd, ls * world_size), requires_grad=True, dtype=dtype).to(device)
+    ss.retain_grad()
+    assert torch.all(torch.isclose(ss.split(ls, dim=-1)[rank], s))
+    pp = ss.softmax(-1)
+    pp_local = pp.split(ls, dim=-1)[rank]
+
+    logger.info(
+        f"Rank [{rank}] p: max diff {(pp_local - p).abs().max():.3e}"
+        f" ,not close ratio "
+        f"{(~torch.isclose(pp_local, p)).sum() / p.numel():.3%}"
+    )
+    (pp - dummy_label).sum().backward()
+    ss_grad = ss.grad.split(ls, dim=-1)[rank]
+    logger.info(
+        f"Rank [{rank}] s' grad: max diff {(ss_grad - s.grad).abs().max():.3e}"
+        f" ,not close ratio "
+        f"{(~torch.isclose(ss_grad, s.grad)).sum() / s.numel():.3%}"
+    )
+    dist.destroy_process_group()
+
+
+def _run_allgather_reducescatter(rank, world_size, tmp_file):
+    if torch.cuda.is_available():
+        torch.cuda.set_device(rank)
+        device = torch.device(f"cuda:{rank}")
+        backend = "nccl"
+    else:
+        device = torch.device("cpu")
+        backend = "gloo"
+    dist.init_process_group(
+        init_method="file://" + tmp_file,
+        rank=rank,
+        backend=backend,
+        world_size=world_size,
+    )
+
+    # batch size, num heads, q dim, local sequence, hidden size
+    bs, nh, qd, ls = 10, 12, 32, 512
+    dtype = torch.float32
+    torch.manual_seed(0)
+
+    inp = torch.rand((bs, nh, qd, ls), requires_grad=True, dtype=dtype, device=device)
+    lin = torch.nn.Linear(ls, ls).to(device)
+    allgathered = AllGatherQMicro.apply(inp)
+    inter = lin(allgathered)
+    reduced = ReduceScatterContext.apply(inter)
+    logger.info(
+        f"Rank [{rank}] inp: {inp.requires_grad},\n"
+        f"allgathered: {allgathered.requires_grad},\n"
+        f"inter: {inter.requires_grad},\nreduced: {reduced.requires_grad}"
+    )
+    dist.destroy_process_group()
+
+
+class TestDistributedTransformer(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.mkstemp()[1]
+
+    def tearDown(self):
+        try:
+            os.remove(self.temp)
+        except FileNotFoundError:
+            pass
+
+    @unittest.skipIf(
+        not torch.cuda.is_available() or torch.cuda.device_count() < 2,
+        "No gpu available for cuda tests",
+    )
+    def test_distributed_softmax(self):
+        world_size = 2
+        mp.spawn(
+            _run_distributed_softmax,
+            args=(world_size, self.temp),
+            nprocs=world_size,
+            join=True,
+        )
+
+    @unittest.skipIf(
+        not torch.cuda.is_available() or torch.cuda.device_count() < 2,
+        "No gpu available for cuda tests",
+    )
+    def test_allgather_reducescatter(self):
+        world_size = 2
+        mp.spawn(
+            _run_allgather_reducescatter,
+            args=(world_size, self.temp),
+            nprocs=world_size,
+            join=True,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/atorch/atorch/tests/common_tests/dryrunner_test.py
+++ b/atorch/atorch/tests/common_tests/dryrunner_test.py
@@ -1,0 +1,67 @@
+import os
+import unittest
+
+import torch
+
+import atorch
+from atorch.auto.dry_runner.dry_runner import get_dryrunner
+from atorch.tests.toy_modules.toy_module import create_model_context
+from atorch.tests.utils.test_utils import run_multi_process_init_distributed, start_coverage, stop_coverage
+
+
+def two_process_profile_func():
+    if torch.cuda.is_available():
+        backend = "nccl"
+    else:
+        backend = "gloo"
+    data_size = 16
+    batch_size = 2
+    warmup_step_num = 0
+    profile_step_num = 4
+
+    res = atorch.init_distributed(backend, set_cuda_device_using_local_rank=True)
+    if not res:
+        raise Exception("init failed")
+    model_context = create_model_context(data_size=data_size, batch_size=batch_size)
+    if torch.cuda.is_available():
+        model_context.model.to("cuda")
+    dry_runner = get_dryrunner()
+    model_context.update_dataloader()
+    model_context.update_optim()
+    status, result = dry_runner.profile(
+        model_context, warmup_step_num=warmup_step_num, profile_step_num=profile_step_num
+    )
+    assert status
+    assert result is not None
+    atorch.reset_distributed()
+
+
+class DryRunnerTest(unittest.TestCase):
+    def test_one_process_profile(self):
+        data_size = 8
+        batch_size = 2
+        model_context = create_model_context(data_size=data_size, batch_size=batch_size)
+        if torch.cuda.is_available():
+            model_context.model.to("cuda")
+        model_context.update_dataloader()
+        model_context.update_optim()
+        dry_runner = get_dryrunner()
+        status, result = dry_runner.profile(model_context, warmup_step_num=1, profile_step_num=2)
+        self.assertTrue(status)
+        self.assertTrue(result is not None)
+        status, result = dry_runner.profile(model_context, warmup_step_num=0, profile_step_num=2)
+        self.assertTrue(status)
+        self.assertTrue(result is not None)
+        status, result = dry_runner.profile(model_context, warmup_step_num=0, profile_step_num=200)
+        self.assertTrue(not status)
+
+    def test_two_process_profile(self):
+        code_path = os.path.abspath(__file__)
+        run_multi_process_init_distributed(nproc=2, training_script=code_path)
+
+
+if __name__ == "__main__":
+    cov_status = start_coverage()
+    two_process_profile_func()
+    if cov_status:
+        stop_coverage()

--- a/atorch/atorch/tests/common_tests/ds_3d_parallel_optimization_test.py
+++ b/atorch/atorch/tests/common_tests/ds_3d_parallel_optimization_test.py
@@ -1,0 +1,192 @@
+import os
+import unittest
+
+import torch
+import torch.multiprocessing as mp
+import torch.nn.functional as F
+from transformers.models.gpt2.configuration_gpt2 import GPT2Config
+from transformers.models.gpt2.modeling_gpt2 import GPT2Model
+
+import atorch
+from atorch.auto import auto_accelerate
+from atorch.auto.opt_lib.ds_3d_parallel_optimization import DeepSpeed3DParallelConfig
+from atorch.common.util_func import find_free_port
+from atorch.modules.distributed_modules.cross_entropy import vocab_parallel_cross_entropy
+from atorch.tests.common_tests.ds_pipe_test import _weight_align as _ds_pipe_weight_align
+from atorch.tests.common_tests.ds_pipe_test import gpt2_custom_patcher
+from atorch.tests.common_tests.manual_tp_test import _weight_align as _tp_weigth_align
+from atorch.tests.common_tests.manual_tp_test import get_gpt2_tpinfo
+from atorch.utils.manual_tp_utils import tp_manual_shard_custom_fn
+from atorch.utils.meta_model_utils import build_recorded_module, record_module_init
+from atorch.utils.version import torch_version
+
+
+def get_gpt2_3d_parallel_cfg(gpt2_model_config):
+    def batch_fn(data):
+        tokens = data["input_ids"]
+        position_ids = data["position_ids"]
+        attention_mask = data["attention_mask"]
+        labels = data["labels"]
+        loss_mask = data["loss_mask"]
+        return (tokens, position_ids, attention_mask), (
+            labels,
+            loss_mask,
+        )
+
+    ds_config = {
+        "train_micro_batch_size_per_gpu": 4,  # relevant to data_iter
+        "gradient_accumulation_steps": 8,
+        "pipeline": {"activation_checkpoint_interval": 1},
+        "fp16": {"enabled": True},
+    }
+
+    ds_3d_parallel_cfg = DeepSpeed3DParallelConfig(
+        tpinfo=get_gpt2_tpinfo(),
+        custom_patcher=gpt2_custom_patcher(gpt2_model_config),
+        ds_config=ds_config,
+        batch_fn=batch_fn,
+    )
+    return ds_3d_parallel_cfg
+
+
+def _weight_align(model, ref_model, tp_model):
+    _tp_weigth_align(tp_model, ref_model)
+    _ds_pipe_weight_align(model, tp_model)
+
+
+def run_ds_3d_parallel(rank, world_size):
+    os.environ["LOCAL_RANK"] = str(rank)
+    os.environ["RANK"] = str(rank)
+    os.environ["WORLD_SIZE"] = str(world_size)
+    os.environ["NPROC_PER_NODE"] = str(world_size)
+    atorch.init_distributed("nccl", set_cuda_device_using_local_rank=True)
+
+    # record meta init model
+    device = torch.cuda.current_device()
+    gpt2_model_config = GPT2Config(
+        resid_pdrop=0.0,
+        embd_pdrop=0.0,
+        attn_pdrop=0.0,
+        n_embd=256,
+        n_head=4,
+        n_layer=3,
+        n_positions=512,
+        vocab_size=50000,
+    )
+    # meta model for ds 3d parallel
+    with record_module_init():
+        meta_model = GPT2Model(gpt2_model_config)
+
+    strategy = [
+        ("parallel_mode", ([("tensor", 2), ("data", 1), ("pipeline", 2)], None)),
+        ("deepspeed_3d_parallel", get_gpt2_3d_parallel_cfg(gpt2_model_config)),
+    ]
+
+    def my_loss_func(logits, labels):
+        labels, loss_mask = labels[0], labels[1]
+        logits = logits.float()
+        losses = vocab_parallel_cross_entropy(logits, labels).view(-1)
+        loss = torch.sum(losses * loss_mask.view(-1))
+        if loss_mask.sum().item() > 0:
+            loss = loss / loss_mask.sum()
+        return loss
+
+    def optim_param_func(model):
+        no_decay = ["bias", "LayerNorm.weight"]
+        optimizer_grouped_parameters = [
+            {
+                "params": [p for n, p in model.named_parameters() if not any(nd in n for nd in no_decay)],
+                "weight_decay": 1e-1,
+            },
+            {
+                "params": [p for n, p in model.named_parameters() if any(nd in n for nd in no_decay)],
+                "weight_decay": 0.0,
+            },
+        ]
+        return optimizer_grouped_parameters
+
+    status, result, best_strategy = auto_accelerate(
+        meta_model,
+        torch.optim.AdamW,
+        optim_args={"lr": 1e-5},
+        optim_param_func=optim_param_func,
+        loss_func=my_loss_func,
+        load_strategy=strategy,
+        ignore_dryrun_on_load_strategy=True,
+    )
+    assert status, f"auto_accelerate failed. status: {status}, result: {result}, best_strategy: {best_strategy}"
+    model = result.model
+
+    # ref model, tp model for weight align
+    torch.manual_seed(1234)
+    torch.cuda.manual_seed(1234)
+    ref_model = GPT2Model(gpt2_model_config).to(device)
+    with record_module_init():
+        tp_meta_model = GPT2Model(gpt2_model_config)
+    tp_manual_shard_custom_fn(tp_meta_model, get_gpt2_tpinfo())
+    tp_model = build_recorded_module(tp_meta_model).to(device)
+    _weight_align(model.module, ref_model, tp_model)
+
+    def gpt2_dummy_data_iter():
+        cnt = 0
+        while True:
+            torch.manual_seed(cnt)
+            torch.cuda.manual_seed(cnt)
+            input_ids = torch.randint(0, 10000, (4, 512), device=device)
+            position_ids = torch.arange(0, 512, dtype=torch.long, device=device)
+            attention_mask = torch.randint(0, 2, (4, 512), device=device)
+            labels = torch.randint(0, 10000, (4, 512), device=device)
+            loss_mask = torch.randint(0, 2, (4, 512), device=device)
+            yield locals()
+            cnt += 1
+
+    # train_batch compute
+    data_iter = gpt2_dummy_data_iter()
+    ds_loss = model.train_batch(data_iter)
+
+    # ref compute
+    ref_data_iter = gpt2_dummy_data_iter()
+    total_loss = None
+    for _ in range(8):  # relevant to gradient_accumulation_steps
+        data = next(ref_data_iter)
+        with torch.cuda.amp.autocast(dtype=torch.float16):
+            last_hidden_state = ref_model(
+                input_ids=data["input_ids"], position_ids=data["position_ids"], attention_mask=data["attention_mask"]
+            ).last_hidden_state
+            logits = F.linear(last_hidden_state, ref_model.wte.weight)
+            losses = torch.nn.CrossEntropyLoss(reduction="none")(
+                logits.view(-1, logits.size(-1)), data["labels"].view(-1)
+            )
+        loss = torch.sum(losses * data["loss_mask"].view(-1))
+        if data["loss_mask"].sum().item() > 0:
+            loss = loss / data["loss_mask"].sum()
+        if total_loss is None:
+            total_loss = torch.zeros_like(loss)
+        total_loss += loss.detach()
+    ref_loss = total_loss / 8
+
+    assert torch.all(torch.isclose(ds_loss, ref_loss)), f"ds_loss: {ds_loss}, ref_loss: {ref_loss}"
+    atorch.reset_distributed()
+
+
+class TestDeepSpeed3DParallel(unittest.TestCase):
+    @unittest.skipIf(
+        not torch.cuda.is_available() or torch.cuda.device_count() < 4 or torch_version() < (2, 0, 0),
+        "Must have at least 4 GPUs for tensor + pipeline parallel test",
+    )
+    def test_ds_3d_parallel(self):
+        world_size = 4
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = str(find_free_port())
+        mp.spawn(
+            run_ds_3d_parallel,
+            args=(world_size,),
+            nprocs=world_size,
+            join=True,
+        )
+        os.environ["MASTER_ADDR"] = ""
+        os.environ["MASTER_PORT"] = ""
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/atorch/atorch/tests/common_tests/ds_pipe_test.py
+++ b/atorch/atorch/tests/common_tests/ds_pipe_test.py
@@ -1,0 +1,99 @@
+import functools
+import unittest
+from collections import OrderedDict
+
+import torch
+import torch.nn.functional as F
+from transformers.models.gpt2.configuration_gpt2 import GPT2Config
+from transformers.models.gpt2.modeling_gpt2 import GPT2Model
+
+import atorch
+from atorch.utils.ds_pipe_utils import PipeModuleFromRecordedMeta
+from atorch.utils.meta_model_utils import record_module_init
+from atorch.utils.version import torch_version
+
+
+def gpt2_custom_patcher(cfg):
+    def wpe_patcher(fw, self):
+        @functools.wraps(fw)
+        def fw_wrapper(input):
+            assert (
+                isinstance(input, tuple) and len(input) == 3
+            ), "input should be (hidden_states, position_ids, attention_mask)"
+            hidden_states, position_ids, attention_mask = input
+            position_embeddings = fw(position_ids)
+            hidden_states = hidden_states + position_embeddings
+            return hidden_states, attention_mask
+
+        return fw_wrapper
+
+    def h_patcher(fw, self):
+        @functools.wraps(fw)
+        def fw_wrapper(input):
+            assert isinstance(input, tuple) and len(input) == 2, "input should be (hidden_states, attention_mask)"
+            hidden_states, attention_mask = input
+            ori_attn_mask = attention_mask
+            attention_mask = attention_mask[:, None, None, :]
+            attention_mask = attention_mask.to(hidden_states.dtype)  # fp16 compatibility
+            attention_mask = (1.0 - attention_mask) * torch.finfo(hidden_states.dtype).min
+            outputs = fw(hidden_states, attention_mask=attention_mask)
+            hidden_states = outputs[0]
+            return hidden_states, ori_attn_mask
+
+        return fw_wrapper
+
+    gpt2_custom_forward_patchers = {"wpe": wpe_patcher}
+    gpt2_custom_forward_patchers.update({f"h.{i}": h_patcher for i in range(cfg.n_layer)})
+    return gpt2_custom_forward_patchers
+
+
+def _weight_align(pipe_model, ref_model):
+    sd = ref_model.state_dict()
+    prefix_odict = OrderedDict()
+    prefix_odict[pipe_model._ori_module_name[0]] = "tied_modules." + pipe_model._ori_module_name[0]
+    for i, n in enumerate(pipe_model._ori_module_name[1:]):
+        prefix_odict[n + "."] = str(i + 1) + "."
+    new_sd = type(sd)()
+    for k in sd:
+        for prefix in prefix_odict:
+            if k.startswith(prefix):
+                new_k = k.replace(prefix, prefix_odict[prefix])
+                break
+        new_sd[new_k] = sd[k]
+    pipe_model.load_state_dict(new_sd, strict=False)
+
+
+class TestDeepspeedPipelne(unittest.TestCase):
+    @unittest.skipIf(
+        not torch.cuda.is_available() or torch_version() < (2, 0, 0),
+        "skip if no gpu, torch 2.0 needed for torch.device context manager.",
+    )
+    def test_meta_to_pipelinemodule(self):
+        atorch.init_distributed(set_cuda_device_using_local_rank=True)
+        gpt2_config = GPT2Config(
+            resid_pdrop=0.0, embd_pdrop=0.0, attn_pdrop=0.0, n_embd=256, n_head=4, n_layer=3, n_positions=512
+        )
+        with record_module_init():
+            meta_model = GPT2Model(gpt2_config)
+        device = torch.cuda.current_device()
+        pipe_model = PipeModuleFromRecordedMeta(meta_model, gpt2_custom_patcher(gpt2_config), num_stages=1)
+        ref_model = GPT2Model(gpt2_config).to(device)
+        _weight_align(pipe_model, ref_model)
+        input_ids = torch.randint(0, 10000, (2, 512), device=device)
+        position_ids = torch.arange(0, 512, dtype=torch.long, device=device)
+        attention_mask = torch.randint(0, 2, (2, 512), device=device)
+        pipe_out = pipe_model(
+            (
+                input_ids,
+                position_ids,
+                attention_mask,
+            )
+        )
+        ref_out = ref_model(input_ids=input_ids, position_ids=position_ids, attention_mask=attention_mask)
+        ref_out = F.linear(ref_out.last_hidden_state, ref_model.wte.weight)
+        assert torch.all(torch.isclose(pipe_out, ref_out))
+        atorch.reset_distributed()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/atorch/atorch/tests/common_tests/elastic_dataset_test.py
+++ b/atorch/atorch/tests/common_tests/elastic_dataset_test.py
@@ -1,0 +1,59 @@
+# Copyright 2022 The DLRover Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import shlex
+import subprocess
+import time
+import unittest
+
+from dlrover.python.elastic_agent.master_client import MasterClient, build_master_client
+
+from atorch.common.util_func import find_free_port
+from atorch.data.elastic_dataset import SimpleElasticDataset
+
+
+def data_process(i):
+    return i
+
+
+class SimpleElasticDatasetTest(unittest.TestCase):
+    def setUp(self) -> None:
+        port = find_free_port()
+        command_line = f"python -m dlrover.python.master.main --port {port} --job_name test --platform local"
+        args = shlex.split(command_line)
+        self._master_proc = subprocess.Popen(args)
+        addr = f"localhost:{port}"
+        time.sleep(3)  # Wait the master starts.
+        MasterClient._instance = build_master_client(addr)
+        self.dataset = SimpleElasticDataset(
+            name="test",
+            data_process_fn=data_process,
+            dataset_size=10000,
+            batch_size=10,
+            epochs=1,
+            shuffle=False,
+            num_minibatches_per_shard=10,
+        )
+
+    def addCleanup(self):
+        self._master_proc.kill()
+
+    def test_index_sharding_client(self):
+        self.assertEqual(len(self.dataset), 10000)
+        i = self.dataset.__getitem__(0)
+        self.assertTrue(i == 0)
+        self.assertFalse(self.dataset._shard_client._sample_queue.empty())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/atorch/atorch/tests/common_tests/engine_client_test.py
+++ b/atorch/atorch/tests/common_tests/engine_client_test.py
@@ -1,0 +1,81 @@
+import pickle
+import unittest
+from unittest import mock
+
+from atorch.auto.engine_client import EngineClient
+
+
+class FakeEasyDLClient(object):
+    def get_task(self):
+        pass
+
+    def report_task_result(self):
+        pass
+
+
+class EngineClientt(unittest.TestCase):
+    def setUp(self):
+        self.test_client = EngineClient()
+        if self.test_client.client is None:
+            fake_client = FakeEasyDLClient()
+            setattr(self.test_client, "client", fake_client)
+
+    def test_get_analyse_task(self):
+        task_info = ["default", "self-defined"]
+        task_id = 0
+        task_type = "ANALYSE"
+        process_mode = "ONE_PROCESS"
+        self.test_client.client.get_task = mock.MagicMock(return_value=(task_id, task_type, process_mode, 0, task_info))
+        task = self.test_client.get_task()
+        self.assertEqual(task.id, task_id)
+        self.assertEqual(task.type, task_type)
+        self.assertEqual(task.process_mode, process_mode)
+        self.assertEqual(task.analysis_method, task_info)
+
+    def test_get_parallel_group_task(self):
+        task_info = {
+            "model_parallel_size": 3,
+            "model_parallel_group": [[0, 1, 2], [3, 4, 5]],
+        }
+        task_id = 0
+        task_type = "SETUP_PARALLEL_GROUP"
+        process_mode = "ALL_PROCESS"
+        self.test_client.client.get_task = mock.MagicMock(
+            return_value=(task_id, task_type, process_mode, 0, pickle.dumps(task_info))
+        )
+        task = self.test_client.get_task()
+        self.assertEqual(task.id, task_id)
+        self.assertEqual(task.type, task_type)
+        self.assertEqual(task.process_mode, process_mode)
+        self.assertEqual(task.parallel_group_info, task_info)
+        with self.assertRaises(AttributeError):
+            task.analysis_method
+
+        with self.assertRaises(AttributeError):
+            task.strategy
+
+    def test_get_strategy_task(self):
+        task_info = {
+            "pipeline_parallel_size": 3,
+            "pipeline_parallel_group": [[0, 1, 2], [3, 4, 5]],
+        }
+        serialized_task_info = pickle.dumps(task_info)
+        serialized_methods = [
+            ("1F1B", serialized_task_info, True),
+            ("bidirectional", serialized_task_info, False),
+        ]
+        original_methods = [
+            ("1F1B", task_info, True),
+            ("bidirectional", task_info, False),
+        ]
+        task_id = 0
+        task_type = "TUNE"
+        process_mode = "ALL_PROCESS"
+        self.test_client.client.get_task = mock.MagicMock(
+            return_value=(task_id, task_type, process_mode, 0, serialized_methods)
+        )
+        task = self.test_client.get_task()
+        self.assertEqual(task.id, task_id)
+        self.assertEqual(task.type, task_type)
+        self.assertEqual(task.process_mode, process_mode)
+        self.assertEqual(task.strategy.opt_list, original_methods)

--- a/atorch/atorch/tests/common_tests/file_io_test.py
+++ b/atorch/atorch/tests/common_tests/file_io_test.py
@@ -1,0 +1,47 @@
+import os
+import shutil
+import tempfile
+import unittest
+from os.path import join as path_join
+
+import atorch
+
+
+class DataSetTest(unittest.TestCase):
+    def setUp(self):
+        atorch.file_io
+        self._local_tmp_dir = tempfile.mktemp()
+        super(DataSetTest, self).setUp()
+
+    def tearDown(self):
+        shutil.rmtree(self._tmp_dir)
+        super(DataSetTest, self).tearDown()
+
+    def _file_io_test(self, uri):
+        os.mkdir(path_join(uri, "path1"))
+        os.makedirs(path_join(uri, "path2/path1"))
+        self.assertEqual(os.listdir(uri), ["path1", "path2"])
+        self.assertEqual(path_join(uri, "path2"), ["path1"])
+
+        value = "atorch write test."
+        with open(path_join(uri, "out.txt"), "w") as fd:
+            fd.write(value)
+        with open(path_join(uri, "out.txt"), "r") as fd:
+            content = fd.read()
+        self.assertEqual(content, value)
+
+        os.rename(path_join(uri, "out.txt"), path_join(uri, "in.txt"))
+        self.assertEqual(os.listdir(uri), ["path1", "path2", "in.txt"])
+        with open(path_join(uri, "in.txt"), "r") as fd:
+            content = fd.read()
+        self.assertEqual(content, value)
+
+        os.remove(path_join(uri, "in.txt"))
+        self.assertEqual(os.listdir(uri), ["path1", "path2"])
+
+    def local_file_io_test(self):
+        self._file_io_test(self.local_file_io_test)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/atorch/atorch/tests/common_tests/fsdp_save_auto_acc_test.py
+++ b/atorch/atorch/tests/common_tests/fsdp_save_auto_acc_test.py
@@ -1,0 +1,362 @@
+import contextlib
+import itertools
+import os
+import tarfile
+import unittest
+from collections.abc import Mapping
+
+import pytest
+import requests
+
+torch = pytest.importorskip("torch", "2.0.9")
+import torch.multiprocessing as mp  # noqa: E402
+from torch.distributed.fsdp import FullStateDictConfig  # noqa: E402
+from torch.distributed.fsdp import FullyShardedDataParallel as FSDP  # noqa: E402
+from torch.distributed.fsdp import OptimStateKeyType, StateDictType  # noqa: E402
+
+import atorch  # noqa: E402
+from atorch.auto.accelerate import auto_accelerate  # noqa: E402
+from atorch.common.util_func import find_free_port  # noqa: E402
+from atorch.tests.toy_modules.toy_module import create_model_context, get_gpt2_module_type, run_train  # noqa: E402
+from atorch.utils.fsdp_save_util import (  # noqa: E402
+    ShardOptim,
+    ShardTensorUtil,
+    save_fsdp_flat_param,
+    save_fsdp_optim_param,
+)
+from atorch.utils.meta_model_utils import init_empty_weights_with_disk_offload  # noqa: E402
+from atorch.utils.version import torch_version  # noqa: E402
+
+
+def compare_optim(path, model, rank):
+    origin = torch.load(f"{path}/origin_state.pt")
+    sm = ShardOptim(path)
+    reshard_optim_state = sm.reshard_optim_state_dict(model)
+    optim_state_dict = origin["optimizer_state_dict"]
+    origin_reshard_origin_state = FSDP.shard_full_optim_state_dict(
+        optim_state_dict, model
+    )  # may be removed after PyTorch 2.2
+    rekeyed_reshard_origin_state = FSDP.rekey_optim_state_dict(
+        origin_reshard_origin_state, OptimStateKeyType.PARAM_NAME, model
+    )
+    rekeyed_reshard_optim_state = FSDP.rekey_optim_state_dict(reshard_optim_state, OptimStateKeyType.PARAM_NAME, model)
+
+    def compare(a, b, name, result):
+        if isinstance(a, torch.Tensor) and isinstance(b, torch.Tensor):
+            r = (a == b).all()
+            if isinstance(r, torch.Tensor):
+                r = r.item()
+            result[name] = r
+        elif isinstance(a, Mapping) and isinstance(b, Mapping):
+            if len(a) != len(b):
+                raise ValueError
+            for k in a:
+                compare(a[k], b[k], f"{name}-{k}", result)
+        else:
+            result[name] = a == b
+
+    result = {}
+    compare(rekeyed_reshard_optim_state, rekeyed_reshard_origin_state, str(rank), result)
+    return all(result.values()), reshard_optim_state
+
+
+def run_gpt2_with_strategy(
+    rank, use_bf16, fsdp_config, ckpt_path, is_save, is_load, world_size, compare_range=None, is_train=False
+):
+    hidden_size = 256
+    head_num = 4
+    layer_num = 3
+    seq_length = 512
+    data_size = 16
+    batch_size = 2
+    os.environ["LOCAL_RANK"] = str(rank)
+    os.environ["RANK"] = str(rank)
+    backend = "nccl" if torch.cuda.is_available() else "gloo"
+    res = atorch.init_distributed(backend, set_cuda_device_using_local_rank=True)
+    if not res:
+        raise Exception("init failed")
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    use_fa = torch.cuda.get_device_capability()[0] >= 8
+
+    def func(name):
+        return name
+
+    shard_kwargs = {"name_mapping_func_or_dict": func}
+    ctx = (
+        contextlib.nullcontext()
+        if not is_load
+        else init_empty_weights_with_disk_offload(
+            ckpt_path=ckpt_path, shard_kwargs=shard_kwargs, meta_init_offload_name="1"
+        )
+    )
+    with ctx:
+        model_context = create_model_context(
+            data_size=data_size,
+            batch_size=batch_size,
+            use_optim_param_func=True,
+            use_gpt2=True,
+            hidden_size=hidden_size,
+            head_num=head_num,
+            layer_num=layer_num,
+            seq_length=seq_length,
+        )
+    ctx = (
+        contextlib.nullcontext()
+        if not is_load
+        else init_empty_weights_with_disk_offload(
+            ckpt_path=ckpt_path, shard_kwargs=shard_kwargs, meta_init_offload_name="2"
+        )
+    )
+    with ctx:
+        model_context_1 = create_model_context(
+            data_size=data_size,
+            batch_size=batch_size,
+            use_optim_param_func=True,
+            use_gpt2=True,
+            hidden_size=hidden_size,
+            head_num=head_num,
+            layer_num=layer_num,
+            seq_length=seq_length,
+        )
+
+    amp_config = {"dtype": torch.bfloat16 if use_bf16 else torch.float16}
+    default_fsdp_config = {
+        "limit_all_gathers": True,
+    }
+    default_fsdp_config.update(fsdp_config if fsdp_config is not None else {})
+
+    if torch_version() >= (2, 0, 0):
+        default_fsdp_config["use_orig_params"] = True
+    checkpoint_config = default_fsdp_config["atorch_wrap_cls"]
+
+    if use_fa:
+        strategy = [
+            "parallel_mode",
+            "module_replace",
+            ("amp_native", amp_config),
+            ("fsdp", default_fsdp_config),
+            ("checkpoint", checkpoint_config),
+        ]
+    else:
+        strategy = [
+            "parallel_mode",
+            ("amp_native", amp_config),
+            ("fsdp", default_fsdp_config),
+            ("checkpoint", checkpoint_config),
+        ]
+
+    status, result, best_strategy = auto_accelerate(
+        model_context.model,
+        model_context.optim_func,
+        model_context.dataset,
+        model_context.loss_func,
+        model_context.prepare_input,
+        model_context.model_input_format,
+        model_context.optim_args,
+        model_context.optim_param_func,
+        model_context.dataloader_args,
+        load_strategy=strategy,
+        ignore_dryrun_on_load_strategy=True,
+        meta_init_offload_name="1",
+    )
+    status, result_1, best_strategy = auto_accelerate(
+        model_context_1.model,
+        model_context_1.optim_func,
+        model_context_1.dataset,
+        model_context_1.loss_func,
+        model_context_1.prepare_input,
+        model_context_1.model_input_format,
+        model_context_1.optim_args,
+        model_context_1.optim_param_func,
+        model_context_1.dataloader_args,
+        load_strategy=strategy,
+        ignore_dryrun_on_load_strategy=True,
+        meta_init_offload_name="2",
+    )
+    assert status
+    assert len(best_strategy) == len(strategy)
+    if is_load:
+        for (_, p), (_, p1) in zip(result.model.named_parameters(), result_1.model.named_parameters()):
+            r = p == p1
+            if isinstance(r, torch.Tensor):
+                r = r.all().item()
+            if not r:
+                raise ValueError("all auto acc parameters must be same")
+    m_model = result.model
+    m_dataloader = result.dataloader
+    m_optim = result.optim
+    m_prepare_input = result.prepare_input
+    m_loss_func = result.loss_func
+    input_dtype = torch.float32
+    if is_load:
+        reshard_optim_state = None
+        for i in compare_range:
+            result, reshard_optim_state = compare_optim(i, m_model, rank)
+            if not result:
+                raise ValueError("optim error")
+        m_optim.load_state_dict(reshard_optim_state)
+
+    if is_train:
+        run_train(
+            m_model,
+            m_dataloader,
+            m_optim,
+            m_prepare_input,
+            m_loss_func,
+            device,
+            input_dtype=input_dtype,
+            gpt2_model=True,
+        )
+    if is_save:
+        save_fsdp_flat_param(m_model, ckpt_path)
+        save_fsdp_optim_param(m_model, m_optim, ckpt_path)
+        save_policy = FullStateDictConfig(offload_to_cpu=True, rank0_only=True)
+        with FSDP.state_dict_type(m_model, StateDictType.FULL_STATE_DICT, save_policy):
+            model_state_dict = m_model.state_dict()
+            optim_state_dict = FSDP.full_optim_state_dict(m_model, m_optim)
+
+        if rank == 0:
+            torch.save(
+                {
+                    "model_state_dict": model_state_dict,
+                    "optimizer_state_dict": optim_state_dict,
+                },
+                f"{ckpt_path}/origin_state.pt",
+            )
+    atorch.reset_distributed()
+
+
+class FSDPShardSaveLoadTest(unittest.TestCase):
+    def setUp(self):
+
+        atorch.reset_distributed()
+        url = "http://alps-common.oss-cn-hangzhou-zmf.aliyuncs.com/users/lizhi/test_fsdp_save.tar"
+        target_path = "/tmp/test_fsdp_save.tar"
+        if os.path.exists(target_path):
+            self.has_test_weights = True
+            return
+        response = requests.get(url, stream=True)
+        self.has_test_weights = False
+        if response.status_code == 200:
+            self.has_test_weights = True
+            with open(target_path, "wb") as f:
+                f.write(response.raw.read())
+            extract_direcotry = os.path.dirname(target_path)
+
+            if tarfile.is_tarfile(target_path):
+                with tarfile.open(target_path) as f:
+                    f.extractall(path=extract_direcotry)
+            self.has_test_weights = os.path.exists("/tmp/test_fsdp_save")
+            if not self.has_test_weights:
+                print("There is no weight for testing, generate one")
+
+    def tearDown(self):
+        atorch.reset_distributed()
+
+    def _cmp_param(self, path):
+        shard = ShardTensorUtil(path, 1, 256, device="cpu")
+        origin = torch.load(f"{path}/origin_state.pt")
+        model_state = origin["model_state_dict"]
+        a = []
+        for k, v in model_state.items():
+            s = shard.load_tensor_by_name(k)
+            v = v.to("cpu")
+            if s is not None:
+                a.append((s == v).all().item())
+        return all(a)
+
+    @unittest.skipIf(
+        not torch.cuda.is_available() or torch.cuda.device_count() < 4,
+        "Must have at least 4 GPUs for gpu test",
+    )
+    def test_gpt2_with_exist_weight(self):
+        if not self.has_test_weights:
+            return
+
+        self.assertTrue(self._cmp_param("/tmp/test_fsdp_save/2/block/"))
+        fsdp_config = {
+            "sync_module_states": True,
+            "atorch_wrap_cls": tuple(get_gpt2_module_type(module=i) for i in ("mlp", "attn")),
+        }
+        world_size = 4
+        args = (
+            True,
+            fsdp_config,
+            "/tmp/test_fsdp_save/2/block/",
+            True,
+            True,
+            world_size,
+            ["/tmp/test_fsdp_save/2/block/"],
+            True,
+        )
+        os.environ["WORLD_SIZE"] = str(world_size)
+        os.environ["NPROC_PER_NODE"] = str(world_size)
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = str(find_free_port())
+        mp.spawn(
+            run_gpt2_with_strategy,
+            args=args,
+            nprocs=world_size,
+            join=True,
+            daemon=False,
+            start_method="spawn",
+        )
+
+    @unittest.skipIf(
+        not torch.cuda.is_available() or torch.cuda.device_count() < 4,
+        "Must have at least 4 GPUs for gpu test",
+    )
+    def test_gpt2_save_and_prepare(self):
+        """This test will test different wrap class: block or (mlp, attt), world size (2,3,4).
+        Save shard checkpoint and origin checkpoint, compare them.
+        Save optim and use FSDP.shard_full_optim_state_dict to reshard optim state, compare the
+        reshard optim state.
+        """
+        if self.has_test_weights:
+            return
+        gpt2block_cls = [["block"], ["mlp", "attn"]]
+        world_sizes = [2, 4]
+        compare_optim_paths = []
+        # get all combinations
+        world_sizes_and_gpt2block_cls = list(itertools.product(world_sizes, gpt2block_cls))
+
+        def boot_inner_test(self, world_size, cls, bf16, test_optim=False):
+            os.environ["WORLD_SIZE"] = str(world_size)
+            os.environ["NPROC_PER_NODE"] = str(world_size)
+            os.environ["MASTER_ADDR"] = "localhost"
+            os.environ["MASTER_PORT"] = str(find_free_port())
+
+            wrap_cls = tuple(get_gpt2_module_type(module=i) for i in cls)
+
+            fsdp_config = {
+                "sync_module_states": True,
+                "atorch_wrap_cls": wrap_cls,
+            }
+            save_path = f"/tmp/test_fsdp_save/{world_size}/{'-'.join(cls)}"
+            compare_optim_paths.append(save_path)
+            if test_optim:
+                args = (bf16, fsdp_config, compare_optim_paths[0], False, True, world_size, compare_optim_paths)
+            else:
+                args = (bf16, fsdp_config, save_path, True, False, world_size, None)
+            mp.spawn(
+                run_gpt2_with_strategy,
+                args=args,
+                nprocs=world_size,
+                join=True,
+                daemon=False,
+                start_method="spawn",
+            )
+            if not test_optim:
+                self.assertTrue(self._cmp_param(save_path))
+
+        for world_size, cls in world_sizes_and_gpt2block_cls:
+            boot_inner_test(self, world_size, cls, bf16=True, test_optim=False)
+            boot_inner_test(self, world_size, cls, bf16=False, test_optim=False)
+        for world_size, cls in world_sizes_and_gpt2block_cls:
+            boot_inner_test(self, world_size, cls, bf16=True, test_optim=True)
+            boot_inner_test(self, world_size, cls, bf16=False, test_optim=True)
+        atorch.reset_distributed()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/atorch/atorch/tests/common_tests/fsdp_to_tp_test.py
+++ b/atorch/atorch/tests/common_tests/fsdp_to_tp_test.py
@@ -1,0 +1,132 @@
+import os
+import unittest
+
+import torch
+import torch.multiprocessing as mp
+from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+
+import atorch
+from atorch.common.log_utils import default_logger as logger
+from atorch.common.util_func import find_free_port
+from atorch.distributed.distributed import create_parallel_group
+from atorch.modules.distributed_modules.layers import RowParallelLinear
+from atorch.modules.distributed_modules.transformer import MegatronGLMModel
+from atorch.tests.glm.modeling_glm import GLMConfig, GLMModel
+
+logger.setLevel("INFO")
+os.environ["NCCL_DEBUG"] = "ERROR"
+
+
+def init_dist(rank, world_size):
+    os.environ["LOCAL_RANK"] = str(rank)
+    os.environ["RANK"] = str(rank)
+    os.environ["WORLD_SIZE"] = str(world_size)
+    os.environ["NPROC_PER_NODE"] = str(world_size)
+    if torch.cuda.is_available():
+        atorch.init_distributed("nccl")
+    else:
+        atorch.init_distributed("gloo")
+
+
+def _run_linear_fsdp_to_tp(rank, world_size):
+    init_dist(rank, world_size)
+    config = [("tensor", world_size)]
+    create_parallel_group((config, None))
+    pg, ranks = atorch.distributed.distributed.parallel_group_and_ranks("tensor")
+
+    device = torch.device(rank)
+    linear = torch.nn.Linear(4, 2).to(device)
+    torch.cuda.set_device(device)
+    sharded_module = FSDP(linear).to(device)
+    input_x = torch.tensor([[1.0, 2.0, 2.0, 2.0], [1.0, 2.0, 2.0, 2.0], [1.0, 2.0, 2.0, 2.0], [1.0, 2.0, 2.0, 2.0]]).to(
+        device
+    )
+
+    print(input_x)
+    with FSDP.summon_full_params(sharded_module):
+        weight = sharded_module.weight
+        print("shard", weight.device)
+        row_parallel_linear = RowParallelLinear(
+            orig_module=sharded_module, process_group=pg, ranks=ranks, defer_init=False
+        )
+        row_parallel_linear.to(device)
+        print("row", row_parallel_linear.weight.device)
+        if rank == 0:
+            assert torch.norm(weight[:, 0:2].to(device) - row_parallel_linear.weight, p=-1) == 0
+
+    atorch.reset_distributed()
+
+
+def _run_megatron_glm_fsdp_to_tp(rank, world_size):
+    init_dist(rank, world_size)
+    config = [("tensor", world_size)]
+    create_parallel_group((config, None))
+    pg, ranks = atorch.distributed.distributed.parallel_group_and_ranks("tensor")
+
+    device = torch.device(rank)
+
+    config = GLMConfig()
+    torch.manual_seed(0)
+    glm_model = GLMModel(config).to(device)
+
+    class FakeInput:
+        input_ids = torch.ones((4, 10), dtype=torch.long).to(device)
+        attention_mask = torch.ones((4, 10)).to(device)
+
+    glm_model.eval()
+    res1 = glm_model(input_ids=FakeInput.input_ids, attention_mask=FakeInput.attention_mask)
+
+    with FSDP.summon_full_params(glm_model):
+
+        megatron_glm_model = MegatronGLMModel(
+            glm_model.config,
+            orig_module=glm_model,
+            process_group=pg,
+            ranks=ranks,
+            defer_init=False,
+            orig_module_dst_device="cpu",
+        ).to(device)
+        megatron_glm_model.eval()
+        res2 = megatron_glm_model(input_ids=FakeInput.input_ids, attention_mask=FakeInput.attention_mask)
+
+    res = torch.norm(res1.last_hidden_states - res2.last_hidden_states, p=-1)
+    assert res == 0
+    atorch.reset_distributed()
+
+
+class TestMegatronLinearFSDPToTP(unittest.TestCase):
+    @unittest.skipIf(torch.cuda.device_count() < 2, "gpu_num >=2")
+    def test_run_linear_fsdp_to_tp(self):
+
+        world_size = 2
+        os.environ["MASTER_ADDR"] = "localhost"  #
+        os.environ["MASTER_PORT"] = str(find_free_port())
+        mp.spawn(
+            _run_linear_fsdp_to_tp,
+            args=(world_size,),
+            nprocs=world_size,
+            join=True,
+        )
+        os.environ["MASTER_ADDR"] = ""
+        os.environ["MASTER_PORT"] = ""
+
+
+class TestMegatronGLMFSDPToTP(unittest.TestCase):
+    @unittest.skipIf(torch.cuda.device_count() < 2, "gpu_num >=2")
+    def test_run_megatron_glm_fsdp_to_tp(self):
+
+        world_size = 2
+        os.environ["MASTER_ADDR"] = "localhost"  #
+        os.environ["MASTER_PORT"] = str(find_free_port())
+        mp.spawn(
+            _run_megatron_glm_fsdp_to_tp,
+            args=(world_size,),
+            nprocs=world_size,
+            join=True,
+        )
+        os.environ["MASTER_ADDR"] = ""
+        os.environ["MASTER_PORT"] = ""
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/atorch/atorch/tests/common_tests/hebo_test.py
+++ b/atorch/atorch/tests/common_tests/hebo_test.py
@@ -1,0 +1,147 @@
+import unittest
+import warnings
+
+import numpy as np
+import pandas as pd
+import torch
+
+from atorch.auto.engine.sg_algo.hebo.acquisitions.acq import MACE, Acquisition, Mean, Sigma
+from atorch.auto.engine.sg_algo.hebo.design_space.design_space import DesignSpace
+
+
+class ToyExample(Acquisition):
+    def __init__(self, constr_v=1.0):
+        super().__init__(None)
+        self.constr_v = constr_v
+
+    @property
+    def num_obj(self):
+        return 1
+
+    @property
+    def num_constr(self):
+        return 1
+
+    def eval(self, x, xe):
+        # minimize L2norm(x) s.t. L2norm(x) > constr_v
+        out = (xe**2).sum(axis=1).reshape(-1, 1)
+        constr = self.constr_v - out
+        return np.concatenate([out, constr], axis=1)
+
+
+def obj(x: pd.DataFrame) -> np.ndarray:
+    return x["x0"].values.astype(float).reshape(-1, 1) ** 2
+
+
+class HEBOTest(unittest.TestCase):
+    def setUp(self):
+        warnings.filterwarnings("ignore", category=DeprecationWarning)
+
+    @unittest.skipIf(torch.cuda.is_available(), "run on cpu only")
+    def test_design_sapce(self):
+        space = DesignSpace().parse([{"name": "x3", "type": "cat", "categories": ["a", "b", "c"]}])
+        self.assertEqual(space.numeric_names, [])
+        self.assertEqual(space.enum_names, ["x3"])
+        self.assertEqual(space.para_names, space.numeric_names + space.enum_names)
+        self.assertEqual(space.num_paras, 1)
+        self.assertEqual(space.num_numeric, 0)
+        self.assertEqual(space.num_categorical, 1)
+        samp = space.sample(10)
+        x, xe = space.transform(samp)
+        _, xe_ = space.transform(space.inverse_transform(x, xe))
+        self.assertEqual((xe_ == xe).all(), True)
+        self.assertEqual(space.paras["x3"].is_discrete, True)
+        self.assertEqual(space.paras["x3"].is_discrete_after_transform, True)
+        for _, para in space.paras.items():
+            self.assertEqual(
+                para.is_discrete == (type(para.sample(1).tolist()[0]) != float),
+                True,
+            )
+            if para.is_discrete_after_transform:
+                samp = para.sample(5)
+                x = para.transform(samp)
+                self.assertEqual((x == x.round()).all(), True)
+
+    @unittest.skipIf(torch.cuda.is_available(), "run on cpu only")
+    def test_models(self):
+        from atorch.auto.engine.sg_algo.hebo.models import model_factory
+
+        Xc = None
+        Xe = np.random.randint(low=0, high=2, size=(50, 1))
+        y = Xe.astype(float)
+        model = model_factory.get_model("gpy", 0, 1, 1, num_uniqs=[2], num_epochs=1)
+        model.fit(Xc, Xe, y + 1e-2 * np.random.randn(y.shape[0], y.shape[1]))
+        py, ps2 = model.predict(Xc, Xe)
+        y = y.reshape(-1)
+        py = py.reshape(-1)
+        self.assertEqual(y.shape == py.shape, True)
+        self.assertEqual(np.isfinite(py).all(), True)
+        self.assertEqual((ps2 > 0).all(), True)
+        y = y.reshape([-1, 1])
+        model = model_factory.get_model("rf", 0, 1, 1, num_uniqs=[2], num_epochs=1)
+        model.fit(Xc, Xe, y + 1e-2 * np.random.randn(y.shape[0], y.shape[1]))
+        py, ps2 = model.predict(Xc, Xe)
+        y = y.reshape(-1)
+        py = py.reshape(-1)
+        self.assertEqual(y.shape == py.shape, True)
+        self.assertEqual(np.isfinite(py).all(), True)
+        self.assertEqual((ps2 > 0).all(), True)
+
+    @unittest.skipIf(torch.cuda.is_available(), "run on cpu only")
+    def test_acq(self):
+        from atorch.auto.engine.sg_algo.hebo.models import model_factory
+
+        X = np.random.randn(10, 1)
+        y = X
+        model = model_factory.get_model("rf", 1, 0, 1, num_epochs=10)
+        model.fit(X, None, y)
+        acq = Mean(model, best_y=0.0)
+        acq_v = acq(X, None)
+        assert acq.num_obj == 1
+        assert acq.num_constr == 0
+        acq = Sigma(model, best_y=0.0)
+        acq_v = acq(X, None)
+        assert acq.num_obj == 1
+        assert acq.num_constr == 0
+        acq = MACE(model, best_y=0.0)
+        acq_v = acq(X, None)
+        assert np.isfinite(acq_v).all()
+        assert acq.num_obj == 3
+        assert acq.num_constr == 0
+
+    @unittest.skipIf(torch.cuda.is_available(), "run on cpu only")
+    def test_acq_optimizer(self):
+        from atorch.auto.engine.sg_algo.hebo.acq_optimizers import evolution_optimizer
+
+        constr_v = 1.0
+        space = DesignSpace().parse([{"name": "x1", "type": "cat", "categories": ["a", "b"]}])
+        acq = ToyExample(constr_v=constr_v)
+        opt = evolution_optimizer.EvolutionOpt(space, acq, pop=10, sobol_init="sobol")
+        rec = opt.optimize(initial_suggest=space.sample(3))
+        x, xe = space.transform(rec)
+        self.assertAlmostEqual(acq(x, xe)[:, 0], 1.0, 0.01)
+
+    @unittest.skipIf(torch.cuda.is_available(), "run on cpu only")
+    def test_hebo(self):
+        from atorch.auto.engine.sg_algo.hebo.optimizers.hebo import HEBO
+
+        space = DesignSpace().parse(
+            [
+                {
+                    "name": "x0",
+                    "type": "cat",
+                    "categories": [i for i in range(10)],
+                }
+            ]
+        )
+        opt = HEBO(space)
+        num_suggest = 0
+        for i in range(2):
+            num_suggest = 2 if opt.support_parallel_opt else 1
+            rec = opt.suggest(n_suggestions=num_suggest)
+            y = obj(rec)
+            opt.observe(rec, y)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/atorch/atorch/tests/common_tests/log_util_test.py
+++ b/atorch/atorch/tests/common_tests/log_util_test.py
@@ -1,0 +1,24 @@
+import time
+import unittest
+
+from atorch.common.log_utils import Timer, TimeStats
+
+
+class LogUitlTests(unittest.TestCase):
+    def test_timer(self):
+        timer = Timer("test")
+        timer.start()
+        time.sleep(1)
+        timer.end()
+        self.assertAlmostEqual(timer.elapsed_time, 1, places=1)
+
+        timestate = TimeStats("test")
+        timestate[timer.name] = timer.elapsed_time
+        with Timer("forward", timestate):
+            time.sleep(1)
+
+        self.assertAlmostEqual(timestate["forward"], 1, places=1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/atorch/atorch/tests/common_tests/manual_tp_test.py
+++ b/atorch/atorch/tests/common_tests/manual_tp_test.py
@@ -1,0 +1,188 @@
+import os
+import unittest
+
+import torch
+import torch.multiprocessing as mp
+import torch.nn.functional as F
+from transformers.models.gpt2.configuration_gpt2 import GPT2Config
+from transformers.models.gpt2.modeling_gpt2 import GPT2Model
+
+import atorch
+from atorch.common.log_utils import default_logger as logger
+from atorch.common.util_func import find_free_port
+from atorch.distributed.distributed import create_parallel_group, parallel_group
+from atorch.modules.distributed_modules.cross_entropy import vocab_parallel_cross_entropy
+from atorch.modules.distributed_modules.layers import _initialize_affine_weight
+from atorch.modules.distributed_modules.mappings import copy_to_group
+from atorch.modules.distributed_modules.randomizer import init_randomizer
+from atorch.utils.manual_tp_utils import TPInfo, hf_init_weights_custom_fn, tp_manual_shard_custom_fn
+from atorch.utils.meta_model_utils import build_recorded_module, record_module_init
+from atorch.utils.version import torch_version
+
+logger.setLevel("INFO")
+os.environ["NCCL_DEBUG"] = "ERROR"
+
+
+def _weight_align(tp_model, ref_model):
+    sd = ref_model.state_dict()
+    new_sd = dict()
+    for k, tensor in sd.items():
+        if k.endswith("attn.c_attn.weight"):
+            new_tensor = torch.empty(tensor.shape[1] // 2, tensor.shape[0], device=tensor.device)
+            _initialize_affine_weight(new_tensor, tensor.shape[1] // 2, 0, stride=3, master_weight=tensor.t())
+            new_sd[k] = new_tensor
+        elif k.endswith("attn.c_attn.bias"):
+            new_tensor = torch.empty(tensor.shape[0] // 2, device=tensor.device)
+            _initialize_affine_weight(new_tensor, tensor.shape[0] // 2, 0, stride=3, master_weight=tensor)
+            new_sd[k] = new_tensor
+        elif k.endswith("mlp.c_fc.bias"):
+            new_tensor = torch.empty(tensor.shape[0] // 2, device=tensor.device)
+            _initialize_affine_weight(new_tensor, tensor.shape[0] // 2, 0, master_weight=tensor)
+            new_sd[k] = new_tensor
+        elif k.endswith("mlp.c_fc.weight"):
+            new_tensor = torch.empty(tensor.shape[1] // 2, tensor.shape[0], device=tensor.device)
+            _initialize_affine_weight(new_tensor, tensor.shape[1] // 2, 0, master_weight=tensor.t())
+            new_sd[k] = new_tensor
+        elif k.endswith("attn.c_proj.weight") or k.endswith("mlp.c_proj.weight"):
+            new_tensor = torch.empty(tensor.shape[1], tensor.shape[0] // 2, device=tensor.device)
+            _initialize_affine_weight(new_tensor, tensor.shape[0] // 2, 1, master_weight=tensor.t())
+            new_sd[k] = new_tensor
+        elif k.endswith("wte.weight"):
+            new_tensor = torch.empty(tensor.shape[0] // 2, tensor.shape[1], device=tensor.device)
+            _initialize_affine_weight(new_tensor, tensor.shape[0] // 2, 0, master_weight=tensor)
+            new_sd[k] = new_tensor
+        else:
+            new_sd[k] = tensor
+    tp_model.load_state_dict(new_sd)
+
+
+def get_gpt2_tpinfo():
+    gpt2_tpinfo = TPInfo()
+    gpt2_tpinfo.shard_col({"attn.c_attn": {"stride": 3}}, "mlp.c_fc")
+    gpt2_tpinfo.shard_row("attn.c_proj", "mlp.c_proj")
+    gpt2_tpinfo.shard_vocab("wte")
+    gpt2_tpinfo.replic_drop("resid_dropout", "mlp.dropout", "drop")
+    gpt2_tpinfo.parallel_drop("attn_dropout")
+    gpt2_tpinfo.shrink({".attn": {"embed_dim", "split_size", "num_heads"}})
+    return gpt2_tpinfo
+
+
+def _run_manual_tp(rank):
+    os.environ["LOCAL_RANK"] = str(rank)
+    os.environ["RANK"] = str(rank)
+    os.environ["WORLD_SIZE"] = "4"
+    res = atorch.init_distributed("nccl", set_cuda_device_using_local_rank=True)
+    if not res:
+        raise Exception("init failed")
+    create_parallel_group(([("tensor", 2), ("data", 2)], None))
+    init_randomizer()
+    device = torch.cuda.current_device()
+    gpt2_config = GPT2Config(
+        resid_pdrop=0.0,
+        embd_pdrop=0.0,
+        attn_pdrop=0.0,
+        n_embd=256,
+        n_head=4,
+        n_layer=3,
+        n_positions=512,
+        vocab_size=50000,
+    )
+
+    # tp model
+    with record_module_init():
+        meta_model = GPT2Model(gpt2_config)
+    hf_init_weights_custom_fn(meta_model)
+    tp_manual_shard_custom_fn(meta_model, get_gpt2_tpinfo())
+    tp_model = build_recorded_module(meta_model).to(device)
+
+    # ref model
+    torch.manual_seed(1234)
+    torch.cuda.manual_seed(1234)
+    ref_model = GPT2Model(gpt2_config).to(device)
+    _weight_align(tp_model, ref_model)
+
+    # compute
+    torch.manual_seed(1234)
+    torch.cuda.manual_seed(1234)
+    input_ids = torch.randint(50, 40000, (2, 512), device=device)
+    position_ids = torch.arange(0, 512, dtype=torch.long, device=device)
+    attention_mask = torch.randint(0, 2, (2, 512), device=device)
+    labels = torch.randint(50, 40000, (2, 512), device=device)
+    loss_mask = torch.randint(0, 2, (2, 512), device=device)
+
+    # out
+    ref_out = ref_model(input_ids=input_ids, position_ids=position_ids, attention_mask=attention_mask).last_hidden_state
+    tp_out = tp_model(input_ids=input_ids, position_ids=position_ids, attention_mask=attention_mask).last_hidden_state
+
+    # ref loss
+    ref_logits = F.linear(ref_out, ref_model.wte.weight)
+    ref_losses = torch.nn.CrossEntropyLoss(reduction="none")(ref_logits.view(-1, ref_logits.size(-1)), labels.view(-1))
+    ref_loss = torch.sum(ref_losses * loss_mask.view(-1))
+    if loss_mask.sum().item() > 0:
+        ref_loss = ref_loss / loss_mask.sum()
+
+    # tp loss
+    tp_out = copy_to_group(tp_out, group=parallel_group("tensor"))  # VocabParalleEmb need copy last out to group
+    tp_logits = F.linear(tp_out, tp_model.wte.weight)
+    tp_losses = vocab_parallel_cross_entropy(tp_logits, labels).view(-1)
+    tp_loss = torch.sum(tp_losses * loss_mask.view(-1))
+    if loss_mask.sum().item() > 0:
+        tp_loss = tp_loss / loss_mask.sum()
+
+    # backward
+    tp_loss.backward()
+    ref_loss.backward()
+
+    # loss compare
+    assert torch.all(torch.isclose(tp_out, ref_out, atol=1e-5))
+
+    # grad compare
+    for k, param in ref_model.named_parameters():
+        ref_grad = param.grad.detach().clone()
+        tp_grad = dict(tp_model.named_parameters())[k].grad.detach().clone()
+        if k.endswith("attn.c_attn.weight"):
+            new_tensor = torch.empty(ref_grad.shape[1] // 2, ref_grad.shape[0], device=ref_grad.device)
+            _initialize_affine_weight(new_tensor, ref_grad.shape[1] // 2, 0, stride=3, master_weight=ref_grad.t())
+        elif k.endswith("attn.c_attn.bias"):
+            new_tensor = torch.empty(ref_grad.shape[0] // 2, device=ref_grad.device)
+            _initialize_affine_weight(new_tensor, ref_grad.shape[0] // 2, 0, stride=3, master_weight=ref_grad)
+        elif k.endswith("mlp.c_fc.bias"):
+            new_tensor = torch.empty(ref_grad.shape[0] // 2, device=ref_grad.device)
+            _initialize_affine_weight(new_tensor, ref_grad.shape[0] // 2, 0, master_weight=ref_grad)
+        elif k.endswith("mlp.c_fc.weight"):
+            new_tensor = torch.empty(ref_grad.shape[1] // 2, ref_grad.shape[0], device=ref_grad.device)
+            _initialize_affine_weight(new_tensor, ref_grad.shape[1] // 2, 0, master_weight=ref_grad.t())
+        elif k.endswith("attn.c_proj.weight") or k.endswith("mlp.c_proj.weight"):
+            new_tensor = torch.empty(ref_grad.shape[1], ref_grad.shape[0] // 2, device=ref_grad.device)
+            _initialize_affine_weight(new_tensor, ref_grad.shape[0] // 2, 1, master_weight=ref_grad.t())
+        elif k.endswith("wte.weight"):
+            new_tensor = torch.empty(ref_grad.shape[0] // 2, ref_grad.shape[1], device=ref_grad.device)
+            _initialize_affine_weight(new_tensor, ref_grad.shape[0] // 2, 0, master_weight=ref_grad)
+        else:
+            new_tensor = ref_grad
+        assert torch.all(torch.isclose(new_tensor, tp_grad, atol=1e-5)), f"ref_grad: {new_tensor} \ntp_grad: {tp_grad}"
+
+    atorch.reset_distributed()
+
+
+class TestManualTP(unittest.TestCase):
+    @unittest.skipIf(
+        torch.cuda.device_count() < 4 or torch_version() < (2, 0, 0),
+        "run with cpu or gpu_num >=4, torch 2.0 needed for torch.device context manager.",
+    )
+    def test_manual_tp(self):
+
+        world_size = 4
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = str(find_free_port())
+        mp.spawn(
+            _run_manual_tp,
+            nprocs=world_size,
+            join=True,
+        )
+        os.environ["MASTER_ADDR"] = ""
+        os.environ["MASTER_PORT"] = ""
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/atorch/atorch/tests/common_tests/megatron_attn_test.py
+++ b/atorch/atorch/tests/common_tests/megatron_attn_test.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python
+# coding=utf-8
+import copy
+import os
+import unittest
+
+import torch
+import torch.multiprocessing as mp
+from transformers.models.bert.configuration_bert import BertConfig
+from transformers.models.bert.modeling_bert import BertAttention
+from transformers.models.clip.configuration_clip import CLIPTextConfig
+from transformers.models.clip.modeling_clip import CLIPAttention
+
+import atorch
+from atorch.common.log_utils import default_logger as logger
+from atorch.common.util_func import find_free_port
+from atorch.distributed.distributed import create_parallel_group
+from atorch.modules.distributed_modules.transformer import MegatronBertAttention, MegatronCLIPAttention
+
+logger.setLevel("INFO")
+os.environ["NCCL_DEBUG"] = "ERROR"
+
+
+def init_dist(rank, world_size):
+    os.environ["LOCAL_RANK"] = str(rank)
+    os.environ["RANK"] = str(rank)
+    os.environ["WORLD_SIZE"] = str(world_size)
+    os.environ["NPROC_PER_NODE"] = str(world_size)
+
+    atorch.init_distributed("nccl")
+    torch.cuda.device(atorch.local_rank())
+    parallel_config = ([("model", world_size)], None)
+
+    create_parallel_group(parallel_config)
+
+
+def _run_megatron_bert_attn(rank, world_size):
+    init_dist(rank, world_size)
+    config = [("tensor", world_size)]
+    create_parallel_group((config, None))
+    pg, ranks = atorch.distributed.distributed.parallel_group_and_ranks("tensor")
+
+    device = torch.device("cuda:{}".format(atorch.local_rank()))
+    torch.cuda.set_device(device)
+
+    bert_config = {
+        "attention_probs_dropout_prob": 0.1,
+        "hidden_dropout_prob": 0.1,
+        "hidden_size": 1024,
+        "initializer_range": 0.02,
+        "intermediate_size": 4096,
+        "layer_norm_eps": 1e-12,
+        "max_position_embeddings": 512,
+        "num_attention_heads": 16,
+        "num_hidden_layers": 24,
+        "pad_token_id": 0,
+        "position_embedding_type": "absolute",
+        "vocab_size": 30522,
+    }
+    config = BertConfig(**bert_config)
+    torch.manual_seed(1)
+
+    bert_attn = BertAttention(config=config)
+    bert_attn_copy = copy.deepcopy(bert_attn)
+    megatron_attn = MegatronBertAttention(orig_module=bert_attn, process_group=pg, ranks=ranks, defer_init=False)
+
+    input_ = torch.ones((2, 8, 1024)).to(device)
+    bert_attn_copy.to(device)
+    megatron_attn.to(device)
+    input_ = input_.to(device)
+    bert_attn_copy.eval()
+    megatron_attn.eval()
+    parallel_out = megatron_attn(input_)
+    out = bert_attn_copy(input_)
+    atorch.reset_distributed()
+    assert torch.norm(parallel_out[0] - out[0], p=-1) == 0
+
+
+def _run_megatron_clip_attn(rank, world_size):
+    init_dist(rank, world_size)
+    config = [("tensor", world_size)]
+    create_parallel_group((config, None))
+    pg, ranks = atorch.distributed.distributed.parallel_group_and_ranks("tensor")
+
+    device = torch.device("cuda:{}".format(atorch.local_rank()))
+    torch.cuda.set_device(device)
+    clip_config = {
+        "hidden_size": 1024,
+    }
+    config = CLIPTextConfig(**clip_config)
+    torch.manual_seed(1)
+
+    clip_attn = CLIPAttention(config=config)
+    print(config)
+    ranks = [0, 1]
+    clip_attn_copy = copy.deepcopy(clip_attn)
+    megatron_clip_attn = MegatronCLIPAttention(orig_module=clip_attn, process_group=pg, ranks=ranks, defer_init=False)
+    input_ = torch.ones((2, 16, 1024))
+    clip_attn_copy.to(device)
+    megatron_clip_attn.to(device)
+    input_ = input_.to(device)
+    clip_attn_copy.eval()
+    megatron_clip_attn.eval()
+    parallel_out, _ = megatron_clip_attn(input_)
+    out, _ = clip_attn_copy(input_)
+    assert torch.norm(parallel_out - out, p=-1) == 0
+    atorch.reset_distributed()
+
+
+class TestMegatronOperator(unittest.TestCase):
+    @unittest.skipIf(torch.cuda.device_count() < 2, "run with gpu_num >=2")
+    def test_megatron_bert_attn(self):
+        os.environ["MASTER_ADDR"] = "localhost"  #
+        os.environ["MASTER_PORT"] = str(find_free_port())
+        world_size = 2
+        mp.spawn(
+            _run_megatron_bert_attn,
+            args=(world_size,),
+            nprocs=world_size,
+            join=True,
+        )
+
+    @unittest.skipIf(torch.cuda.device_count() < 2, "run with gpu_num >=2")
+    def test_megatron_clip_attn(self):
+        world_size = 2
+        os.environ["MASTER_ADDR"] = "localhost"  #
+        os.environ["MASTER_PORT"] = str(find_free_port())
+        mp.spawn(
+            _run_megatron_clip_attn,
+            args=(world_size,),
+            nprocs=world_size,
+            join=True,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/atorch/atorch/tests/common_tests/megatron_glm_test.py
+++ b/atorch/atorch/tests/common_tests/megatron_glm_test.py
@@ -1,0 +1,618 @@
+import copy
+import os
+import unittest
+
+import torch
+import torch.multiprocessing as mp
+from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+
+import atorch
+from atorch.common.util_func import find_free_port
+from atorch.distributed.distributed import (
+    ParallelGroupContextManager,
+    create_parallel_group,
+    parallel_group,
+    parallel_group_and_ranks,
+    reset_distributed,
+)
+from atorch.modules.distributed_modules.transformer import (
+    MegatronGLMBlock,
+    MegatronGLMMLP,
+    MegatronGLMModel,
+    MegatronGLMSelfAttention,
+    MegatronGLMStack,
+)
+from atorch.tests.glm.modeling_glm import GLMBlock, GLMConfig, GLMModel, GLMStack, SelfAttention
+
+
+def init_dist(rank, world_size):
+    os.environ["LOCAL_RANK"] = str(rank)
+    os.environ["RANK"] = str(rank)
+    os.environ["WORLD_SIZE"] = str(world_size)
+    os.environ["NPROC_PER_NODE"] = str(world_size)
+
+    if torch.cuda.is_available():
+        atorch.init_distributed("nccl")
+    else:
+        atorch.init_distributed("gloo")
+
+    torch.cuda.device(atorch.local_rank())
+
+
+def _run_megatron_glm_stack(rank, world_size):
+    init_dist(rank, world_size)
+    create_parallel_group(([("tensor", 2)], None))
+    if torch.cuda.is_available():
+        device = torch.device(atorch.local_rank())
+    else:
+        device = torch.device("cpu")
+    # layers
+    # hidden_size
+    # num_attention_heads
+    # attention_dropout_prob
+    # output_dropout_prob
+    # layernorm_epsilon
+    # init_method
+    # output_layer_init_method
+
+    config = [2, 1024, 8, 200, 0.5, 0.5, 0.5, None]
+    torch.manual_seed(1)
+    glm_stack = GLMStack(*config)
+    ranks = [0, 1]
+    glm_stack_copy = copy.deepcopy(glm_stack)
+    pg, ranks = parallel_group_and_ranks("tensor")
+    megatron_glm_stack = MegatronGLMStack(
+        *config, orig_module=glm_stack, process_group=pg, ranks=ranks, defer_init=False
+    )
+    input_ = torch.ones((2, 16, 1024), dtype=torch.long).to(device)
+    attention_masks = torch.ones((2, 1, 16, 16), dtype=torch.long).to(device)
+    position_ids = torch.ones((2, 16), dtype=torch.long).to(device)
+    glm_stack_copy.to(device)
+    megatron_glm_stack.to(device)
+    input_ = input_.to(device)
+    glm_stack_copy.eval()
+    megatron_glm_stack.eval()
+    ltor_mask = torch.ones(2, 1, 16, 16).to(device)
+
+    glm_stack_block = glm_stack_copy.layers[0].eval()
+
+    megatron_stack_block = megatron_glm_stack.layers[0].eval()
+
+    if rank == 0:
+        r = (
+            glm_stack_block.attention.query_key_value.weight[0:512, :]
+            - megatron_stack_block.attention.query_key_value.weight[0:512, :]
+        )
+        assert torch.norm(r, p=-1) == 0
+    else:
+        r = (
+            glm_stack_block.attention.query_key_value.weight[512:1024, :]
+            - megatron_stack_block.attention.query_key_value.weight[0:512, :]
+        )
+        assert torch.norm(r, p=-1) == 0
+    hidden_states = torch.ones(2, 16, 1024).to(device)
+    res1 = glm_stack_block.input_layernorm(hidden_states)
+    res2 = megatron_stack_block.input_layernorm(hidden_states)
+    assert torch.norm(res1 - res2, p=-1) == 0
+
+    attention_output1 = glm_stack_block.attention(res1, ltor_mask)
+    attention_output2 = megatron_stack_block.attention(res2, ltor_mask)
+    assert torch.norm(attention_output1 - attention_output2, p=-1) == 0
+
+    layernorm_input1 = res1 + attention_output1
+    layernorm_input2 = res2 + attention_output2
+
+    assert torch.norm(layernorm_input1 - layernorm_input2, p=-1) == 0
+    layernorm_output1 = glm_stack_block.post_attention_layernorm(layernorm_input1)
+    layernorm_output2 = megatron_stack_block.post_attention_layernorm(layernorm_input2)
+    assert torch.norm(layernorm_output1 - layernorm_output2, p=-1) == 0
+
+    output1 = glm_stack_block(hidden_states, ltor_mask)
+    output2 = megatron_stack_block(hidden_states, ltor_mask)
+    assert torch.norm(output1 - output2, p=-1) == 0
+
+    out, _ = glm_stack_copy(input_, position_ids, attention_masks)
+    parallel_out, _ = megatron_glm_stack(input_, position_ids, attention_masks)
+
+    assert torch.norm(out - parallel_out, p=-1) == 0
+
+    # assert torch.norm(r, p=-1) == 0
+    reset_distributed()
+
+
+def _run_megatron_glm_block(rank, world_size):
+    init_dist(rank, world_size)
+    create_parallel_group(([("tensor", 2)], None))
+    if torch.cuda.is_available():
+        device = torch.device(atorch.local_rank())
+    else:
+        device = torch.device("cpu")
+
+    # hidden_size
+    # num_attention_heads
+    # attention_dropout_prob
+    # output_dropout_prob
+    # layernorm_epsilon
+    # init_method
+    # output_layer_init_method
+    config = [1024, 8, 0.5, 0.5, 0.5, None, None]
+    torch.manual_seed(1)
+    glm_block = GLMBlock(*config)
+    ranks = [0, 1]
+    pg, ranks = parallel_group_and_ranks("tensor")
+    glm_block_copy = copy.deepcopy(glm_block)
+    megatron_glm_block = MegatronGLMBlock(orig_module=glm_block, process_group=pg, ranks=ranks, defer_init=False)
+    input_ = torch.ones((2, 16, 1024)).to(device)
+    ltor_mask = torch.ones(2, 1, 16, 16).to(device)
+    glm_block_copy.to(device)
+    megatron_glm_block.to(device)
+    input_ = input_.to(device)
+    glm_block_copy.eval()
+    megatron_glm_block.eval()
+
+    out = glm_block_copy(input_, ltor_mask)
+    parallel_out = megatron_glm_block(input_, ltor_mask)
+
+    r = parallel_out - out
+    assert torch.norm(r, p=-1) == 0
+    reset_distributed()
+
+
+def _run_megatron_glm_attn_no_rotary(rank, world_size):
+    init_dist(rank, world_size)
+    create_parallel_group(([("tensor", 2)], None))
+    pg, ranks = parallel_group_and_ranks("tensor")
+    if torch.cuda.is_available():
+        device = torch.device(atorch.local_rank())
+    else:
+        device = torch.device("cpu")
+
+    config = [1024, 8, 0.5, 0.5, None]
+    # hidden_size, num_attention_heads, attention_dropout_prob, output_dropout_prob, init_method
+    torch.manual_seed(1)
+    self_attn = SelfAttention(*config)
+    ranks = [0, 1]
+    self_attn_copy = copy.deepcopy(self_attn)
+    megatron_self_attn = MegatronGLMSelfAttention(
+        orig_module=self_attn, process_group=pg, ranks=ranks, defer_init=False
+    )
+    input_ = torch.rand((2, 16, 1024)).to(device)
+    ltor_mask = torch.randint(0, 2, (2, 1, 16, 16)).to(device)
+    self_attn_copy.to(device)
+    megatron_self_attn.to(device)
+    input_ = input_.to(device)
+    self_attn_copy.eval()
+
+    megatron_self_attn.eval()
+    if rank == 0:
+        r = self_attn_copy.query_key_value.weight[0:512, :] - megatron_self_attn.query_key_value.weight[0:512, :]
+        assert torch.norm(r, p=2) == 0
+        r = (
+            self_attn_copy.query_key_value.weight[1024 + 0 : 1024 + 512, :]
+            - megatron_self_attn.query_key_value.weight[512 + 0 : 512 + 512, :]
+        )
+        assert torch.norm(r, p=2) == 0
+        r = (
+            self_attn_copy.query_key_value.weight[1024 * 2 + 0 : 1024 * 2 + 512, :]
+            - megatron_self_attn.query_key_value.weight[512 * 2 + 0 : 512 * 2 + 512, :]
+        )
+        assert torch.norm(r, p=2) == 0
+        r = self_attn_copy.dense.weight[:, 0:512] - megatron_self_attn.dense.weight
+        assert torch.norm(r, p=2) == 0
+    else:
+        r = self_attn_copy.query_key_value.weight[512:1024, :] - megatron_self_attn.query_key_value.weight[0:512, :]
+        assert torch.norm(r, p=2) == 0
+        r = (
+            self_attn_copy.query_key_value.weight[1024 + 512 : 1024 + 1024, :]
+            - megatron_self_attn.query_key_value.weight[512 + 0 : 512 + 512, :]
+        )
+        assert torch.norm(r, p=2) == 0
+        r = (
+            self_attn_copy.query_key_value.weight[1024 * 2 + 512 : 1024 * 2 + 1024, :]
+            - megatron_self_attn.query_key_value.weight[512 * 2 + 0 : 512 * 2 + 512, :]
+        )
+        assert torch.norm(r, p=2) == 0
+        r = self_attn_copy.dense.weight[:, 512:1024] - megatron_self_attn.dense.weight
+        assert torch.norm(r, p=2) == 0
+
+    out = self_attn_copy(input_, ltor_mask)
+    parallel_out = megatron_self_attn(input_, ltor_mask)
+
+    r = parallel_out - out
+
+    assert r.abs().max() < 5e-6
+
+    ranks = [0, 1]
+
+    input_ = torch.ones((2, 16, 1024)).to(device)
+    ltor_mask = torch.ones((2, 1, 16, 16)).to(device)
+    out = self_attn_copy.half()(input_.half(), ltor_mask.half())
+    parallel_out = megatron_self_attn.half()(input_.half(), ltor_mask.half())
+    assert r.abs().max() < 5e-6
+
+    reset_distributed()
+
+
+def _run_megatron_glm_attn_rotary(rank, world_size):
+    init_dist(rank, world_size)
+    create_parallel_group(([("tensor", 2)], None))
+    pg, ranks = parallel_group_and_ranks("tensor")
+    if torch.cuda.is_available():
+        device = torch.device(atorch.local_rank())
+    else:
+        device = torch.device("cpu")
+
+    config = [1024, 8, 0.5, 0.5, None]
+    # hidden_size, num_attention_heads, attention_dropout_prob, output_dropout_prob, init_method
+    torch.manual_seed(1)
+    self_attn = SelfAttention(*config, use_rotary=True)
+    assert self_attn.use_rotary is True
+    ranks = [0, 1]
+    self_attn_copy = copy.deepcopy(self_attn)
+
+    # input_ = torch.rand((2, 16, 1024)).to(device)
+    # ltor_mask = torch.randint(0,2, (2,1,16,16)).to(device)
+    input_ = torch.ones((1, 16, 1024)).to(device)
+    ltor_mask = torch.ones((1, 1, 16, 16)).to(device)
+    position_ids = torch.arange(0, 16, dtype=torch.long, device=device)
+    block_position_ids = torch.zeros(16, dtype=torch.long, device=device)
+    position_ids = torch.stack((position_ids, block_position_ids), dim=0).unsqueeze(0)
+
+    megatron_self_attn = MegatronGLMSelfAttention(
+        orig_module=self_attn,
+        process_group=pg,
+        ranks=ranks,
+        defer_init=False,
+        use_rotary=True,
+    ).to(device)
+    megatron_self_attn.eval()
+    self_attn_copy.eval()
+
+    parallel_out = megatron_self_attn(input_, ltor_mask, position_ids=position_ids)
+
+    out = self_attn_copy.to(device)(input_, ltor_mask, position_ids=position_ids)
+    res = parallel_out - out
+    assert res.abs().max() < 1e-6
+
+    self_attn = SelfAttention(*config, use_rotary=True, use_fa=True)
+    assert self_attn.use_fa is True
+    assert self_attn.use_rotary is True
+    self_attn_copy = copy.deepcopy(self_attn)
+
+    megatron_self_attn = MegatronGLMSelfAttention(
+        orig_module=self_attn,
+        process_group=pg,
+        ranks=ranks,
+        defer_init=False,
+        use_fa=True,
+        use_rotary=True,
+    ).to(device)
+    assert megatron_self_attn.use_fa is True
+    assert megatron_self_attn.use_rotary is True
+    megatron_self_attn.eval()
+    self_attn_copy.eval()
+    out = self_attn_copy.to(device)(input_, ltor_mask, position_ids=position_ids)
+    assert megatron_self_attn.use_rotary is True
+    assert megatron_self_attn.use_fa is True
+    parallel_out = megatron_self_attn(input_, ltor_mask, position_ids=position_ids)
+
+    res = parallel_out - out
+    assert res.abs().max() <= 1e-5
+    reset_distributed()
+
+
+class TestMegatronAttnNoRotary(unittest.TestCase):
+    @unittest.skipIf(torch.cuda.device_count() <= 2, "run with gpu_num >=2")
+    def test_megatron_glm_attn(self):
+        os.environ["MASTER_ADDR"] = "localhost"  #
+        os.environ["MASTER_PORT"] = str(find_free_port())
+        world_size = 2
+        mp.spawn(
+            _run_megatron_glm_attn_no_rotary,
+            args=(world_size,),
+            nprocs=world_size,
+            join=True,
+        )
+
+
+class TestMegatronAttnRotary(unittest.TestCase):
+    @unittest.skipIf(torch.cuda.device_count() < 2, "run with cpu or gpu_num >=2")
+    def test_megatron_glm_attn(self):
+        os.environ["MASTER_ADDR"] = "localhost"  #
+        os.environ["MASTER_PORT"] = str(find_free_port())
+        world_size = 2
+        mp.spawn(
+            _run_megatron_glm_attn_rotary,
+            args=(world_size,),
+            nprocs=world_size,
+            join=True,
+        )
+
+
+class TestMegatronGLMBlock(unittest.TestCase):
+    @unittest.skipIf(torch.cuda.device_count() < 2, "run with gpu_num >=2")
+    def test_megatron_glm_block(self):
+        os.environ["MASTER_ADDR"] = "localhost"  #
+        os.environ["MASTER_PORT"] = str(find_free_port())
+        world_size = 2
+        mp.spawn(
+            _run_megatron_glm_block,
+            args=(world_size,),
+            nprocs=world_size,
+            join=True,
+        )
+
+
+class TestMegatronGLMStack(unittest.TestCase):
+    @unittest.skipIf(torch.cuda.device_count() < 2, "run with cpu or gpu_num >=2")
+    def test_megatron_glm_stack(self):
+        os.environ["MASTER_ADDR"] = "localhost"  #
+        os.environ["MASTER_PORT"] = str(find_free_port())
+        world_size = 2
+        mp.spawn(
+            _run_megatron_glm_stack,
+            args=(world_size,),
+            nprocs=world_size,
+            join=True,
+        )
+
+
+def _run_glm_model(rank, world_size):
+
+    init_dist(rank, world_size)
+    create_parallel_group(([("tensor", 2)], None))
+
+    if torch.cuda.is_available():
+        device = torch.device(atorch.local_rank())
+    else:
+        device = torch.device("cpu")
+    config = GLMConfig()
+    config.num_layers = 1
+    config.output_predict = True
+    torch.manual_seed(0)
+    glm_model = GLMModel(config).to(device)
+
+    class FakeInput:
+        input_ids = torch.ones((4, 10), dtype=torch.long).to(device)
+        attention_mask = torch.ones((4, 10)).to(device)
+
+    glm_model_copy = copy.deepcopy(glm_model)
+    glm_model_copy.eval()
+
+    h1 = glm_model_copy.word_embeddings(FakeInput.input_ids)
+    pg, ranks = parallel_group_and_ranks("tensor")
+    megatron_glm_model = MegatronGLMModel(
+        glm_model.config, orig_module=glm_model, process_group=pg, ranks=ranks, defer_init=False
+    ).to(device)
+    assert len(megatron_glm_model.transformer.layers) == config.num_layers
+    h2 = megatron_glm_model.word_embeddings(FakeInput.input_ids)
+    rh = h1 - h2
+    assert torch.norm(rh, p=1) == 0
+    megatron_glm_model.eval()
+
+    input_shape = FakeInput.input_ids.shape
+
+    position_ids = torch.arange(0, input_shape[-1], dtype=torch.long, device=device)
+    block_position_ids = torch.zeros(input_shape[-1], dtype=torch.long, device=device)
+    position_ids = torch.stack((position_ids, block_position_ids), dim=0).unsqueeze(0)
+    attention_mask = torch.ones((input_shape[0], input_shape[1]), dtype=torch.long, device=device)
+
+    r1 = glm_model_copy.transformer(h1, position_ids, attention_mask)
+
+    r2 = megatron_glm_model.transformer(h1, position_ids, attention_mask)
+
+    # r1[1], r2[1] is mems
+    assert torch.norm(r1[1][1] - r2[1][1], p=-1) == 0
+    assert torch.norm(r1[1][0] - r2[1][0], p=-1) == 0
+    # r1[0], r2[0] is last hidden states
+    assert torch.norm(r2[0] - r1[0], p=-1) == 0
+    assert torch.norm(r1[0] - r2[0], p=-1) == 0
+
+    res2 = megatron_glm_model(input_ids=FakeInput.input_ids, attention_mask=FakeInput.attention_mask)
+    res1 = glm_model_copy(input_ids=FakeInput.input_ids, attention_mask=FakeInput.attention_mask)
+    assert torch.norm(res1.logits - res2.logits, p=-1) == 0
+    assert torch.norm(res1.last_hidden_states - res2.last_hidden_states, p=-1) == 0
+
+    reset_distributed()
+
+
+def _run_glm_model_fsdp_to_tp(rank, world_size):
+    init_dist(rank, world_size)
+    torch.manual_seed(1)
+    config = GLMConfig()
+    config.output_predict = True
+    if torch.cuda.is_available():
+        device = atorch.local_rank()
+        torch.cuda.set_device(device)
+    else:
+        device = "cpu"
+    glm_model = GLMModel(config).to(device)
+    create_parallel_group(([("tensor", 2)], None))
+    create_parallel_group(([("data", 2)], None))
+
+    fsdp_model = FSDP(glm_model, parallel_group("data")).to(atorch.local_rank())
+    fsdp_model.eval()
+
+    class FakeInput:
+        input_ids = torch.ones((4, 10), dtype=torch.long).to(device)
+        attention_mask = torch.ones((4, 10)).to(device)
+
+    with torch.no_grad():
+        res1 = fsdp_model(input_ids=FakeInput.input_ids, attention_mask=FakeInput.attention_mask)
+
+    for _ in range(3):
+        pg, ranks = parallel_group_and_ranks("tensor")
+        with FSDP.summon_full_params(fsdp_model):
+            megatron_glm_model = MegatronGLMModel(
+                fsdp_model.config,
+                orig_module=fsdp_model,
+                process_group=pg,
+                ranks=ranks,
+                defer_init=False,
+                orig_module_dst_device="cpu",
+            ).to(device)
+
+        class FakeInput:
+            input_ids = torch.ones((4, 10), dtype=torch.long).to(device)
+            attention_mask = torch.ones((4, 10)).to(device)
+
+        res2 = megatron_glm_model(input_ids=FakeInput.input_ids, attention_mask=FakeInput.attention_mask)
+    res = torch.norm(res1.last_hidden_states - res2.last_hidden_states, p=-1)
+    assert res == 0
+    reset_distributed()
+
+
+def _run_glm_mlp_fsdp_to_hp_hybrid(rank, world_size):
+    init_dist(rank, world_size)
+    from atorch.tests.glm.modeling_glm import MLP
+
+    glm_model = MLP(4, 0.1, None)
+    if torch.cuda.is_available():
+        device = atorch.local_rank()
+        torch.cuda.set_device(device)
+    else:
+        device = "cpu"
+
+    create_parallel_group(([("data", 4)], None))
+
+    fsdp_model = FSDP(glm_model, parallel_group("data")).to(atorch.local_rank())
+    fsdp_model.eval()
+    inputs = torch.ones((4, 4)).to(device)
+    prefix_name = "inference"
+    with ParallelGroupContextManager(prefix_name):
+        # Note: transformation of glm from FSDP to TP must be
+        # under the scope of ParallelGroupContextManager(prefix_name)
+        create_parallel_group(([("tensor", 2), ("data", 2)], None))
+        pg, ranks = parallel_group_and_ranks("tensor")
+        with FSDP.summon_full_params(fsdp_model):
+            megatron_glm_model = MegatronGLMMLP(
+                orig_module=fsdp_model,
+                process_group=pg,
+                ranks=ranks,
+                defer_init=False,
+            ).to(device)
+            megatron_glm_model.eval()
+            res1 = megatron_glm_model(inputs)
+    res2 = fsdp_model(inputs)
+    res = torch.norm(res1 - res2, p=-1)
+    print(res)
+    reset_distributed()
+    # to be developed
+    # assert res == 0
+
+
+def _run_glm_model_fsdp_to_tp_hybrid(rank, world_size):
+    init_dist(rank, world_size)
+    torch.manual_seed(1)
+    config = GLMConfig()
+    config.num_layers = 2
+    config.output_predict = True
+    if torch.cuda.is_available():
+        device = atorch.local_rank()
+        torch.cuda.set_device(device)
+    else:
+        device = "cpu"
+    glm_model = GLMModel(config).to(device)
+    prefix_name = "inference"
+    with ParallelGroupContextManager(prefix_name):
+        create_parallel_group(([("tensor", 2), ("data", 2)], None))
+    create_parallel_group(([("data", 4)], None))
+
+    fsdp_model = FSDP(glm_model, parallel_group("data")).to(atorch.local_rank())
+    fsdp_model.eval()
+
+    class FakeInput:
+        input_ids = torch.ones((4, 10), dtype=torch.long).to(device)
+        attention_mask = torch.ones((4, 10)).to(device)
+
+    with torch.no_grad():
+        res1 = fsdp_model(input_ids=FakeInput.input_ids, attention_mask=FakeInput.attention_mask)
+
+    for _ in range(2):
+        with ParallelGroupContextManager(prefix_name):
+            pg, ranks = parallel_group_and_ranks("tensor")
+            # Note: transformation of glm from FSDP to TP must be
+            # under the scope of ParallelGroupContextManager(prefix_name)
+            with FSDP.summon_full_params(fsdp_model):
+                megatron_glm_model = MegatronGLMModel(
+                    fsdp_model.config,
+                    orig_module=fsdp_model,
+                    process_group=pg,
+                    ranks=ranks,
+                    defer_init=False,
+                    orig_module_dst_device="cpu",
+                ).to(device)
+
+            class FakeInput:
+                input_ids = torch.ones((4, 10), dtype=torch.long).to(device)
+                attention_mask = torch.ones((4, 10)).to(device)
+
+            res2 = megatron_glm_model(input_ids=FakeInput.input_ids, attention_mask=FakeInput.attention_mask)
+            res = torch.norm(res1.last_hidden_states - res2.last_hidden_states, p=-1)
+            assert res == 0
+    reset_distributed()
+
+
+class TestGLMModel(unittest.TestCase):
+    @unittest.skipIf(torch.cuda.device_count() < 2, "run with gpu_num >=2")
+    def test_run_glm_model(self):
+
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = str(find_free_port())
+        world_size = 2
+        mp.spawn(
+            _run_glm_model,
+            args=(world_size,),
+            nprocs=world_size,
+            join=True,
+        )
+
+
+class TestGLMModelFSDPtoTP(unittest.TestCase):
+    @unittest.skipIf(torch.cuda.device_count() < 2, "gpu_num >=2")
+    def test_run_glm_model_fsdp_to_tp(self):
+
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = str(find_free_port())
+        world_size = 2
+        mp.spawn(
+            _run_glm_model_fsdp_to_tp,
+            args=(world_size,),
+            nprocs=world_size,
+            join=True,
+        )
+
+
+class TestGLMMLPFSDPtoTPHybrid(unittest.TestCase):
+    @unittest.skipIf(torch.cuda.device_count() < 4, "run with gpu_num >=4")
+    def test_run_glm_mlp_fsdp_to_hybrid_tp(self):
+
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = str(find_free_port())
+        world_size = 4
+        mp.spawn(
+            _run_glm_mlp_fsdp_to_hp_hybrid,
+            args=(world_size,),
+            nprocs=world_size,
+            join=True,
+        )
+
+
+class TestGLMModelFSDPtoTPHybrid(unittest.TestCase):
+    # to be fixed
+    @unittest.skipIf(torch.cuda.device_count() < 4, "run with gpu_num >=4")
+    def test_run_glm_model_fsdp_to_hybrid_tp(self):
+
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = str(find_free_port())
+        world_size = 4
+        mp.spawn(
+            _run_glm_model_fsdp_to_tp_hybrid,
+            args=(world_size,),
+            nprocs=world_size,
+            join=True,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/atorch/atorch/tests/common_tests/megatron_mlp_test.py
+++ b/atorch/atorch/tests/common_tests/megatron_mlp_test.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python
+# coding=utf-8
+import copy
+import os
+import unittest
+
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+from torch.distributed.distributed_c10d import _get_default_group
+from transformers.activations import gelu
+
+import atorch
+from atorch.common.log_utils import default_logger as logger
+from atorch.common.util_func import find_free_port
+from atorch.distributed.distributed import _DistributedContext, create_parallel_group
+from atorch.modules.distributed_modules.layers import ColumnParallelLinear, RowParallelLinear, _initialize_affine_weight
+from atorch.modules.distributed_modules.transformer import MegatronGLMMLP
+
+logger.setLevel("INFO")
+os.environ["NCCL_DEBUG"] = "ERROR"
+
+
+def init_dist(rank, world_size):
+    os.environ["LOCAL_RANK"] = str(rank)
+    os.environ["RANK"] = str(rank)
+    os.environ["WORLD_SIZE"] = str(world_size)
+    os.environ["NPROC_PER_NODE"] = str(world_size)
+    if torch.cuda.is_available():
+        atorch.init_distributed("nccl")
+    else:
+        atorch.init_distributed("gloo")
+
+
+def _run_row_paralle_linear(rank, world_size):
+    init_dist(rank, world_size)
+    config = [("tensor", world_size)]
+    create_parallel_group((config, None))
+    pg, ranks = atorch.distributed.distributed.parallel_group_and_ranks("tensor")
+
+    if torch.cuda.is_available():
+        device = torch.device(atorch.local_rank())
+    else:
+        device = torch.device("cpu")
+
+    linear = torch.nn.Linear(4, 2).to(device)
+    empty_weight = torch.empty(size=linear.weight.shape, device=device)
+    empty_weight.copy_(linear.weight)
+
+    ranks = [i for i in range(world_size)]
+    row_parallel_linear = RowParallelLinear(orig_module=linear, process_group=pg, ranks=ranks, defer_init=False).to(
+        device
+    )
+
+    if rank == 0:
+        assert torch.norm(empty_weight[:, :2] - row_parallel_linear.weight, p=-1) == 0
+    elif rank == 1:
+        assert torch.norm(empty_weight[:, 2:] - row_parallel_linear.weight, p=-1) == 0
+    atorch.reset_distributed()
+
+
+def _run_column_paralle_linear(rank, world_size):
+    init_dist(rank, world_size)
+
+    if torch.cuda.is_available():
+        device = torch.device(atorch.local_rank())
+    else:
+        device = torch.device("cpu")
+
+    config = [("tensor", world_size)]
+    create_parallel_group((config, None))
+    pg, ranks = atorch.distributed.distributed.parallel_group_and_ranks("tensor")
+
+    # init_dist(rank, world_size)
+    torch.manual_seed(1)
+    linear = torch.nn.Linear(4, 2).to(device)
+    linear_copy = copy.deepcopy(linear)
+    empty_weight = torch.empty(size=linear.weight.shape, device=device)
+    empty_weight.copy_(linear.weight)
+
+    column_parallel_linear = ColumnParallelLinear(
+        orig_module=linear, process_group=pg, ranks=ranks, defer_init=False
+    ).to(device)
+
+    if rank == 0:
+        assert torch.norm(empty_weight[:1, :] - column_parallel_linear.weight, p=2) == 0
+    elif rank == 1:
+        assert torch.norm(empty_weight[1:, :] - column_parallel_linear.weight, p=2) == 0
+
+    inputs = torch.ones(1, 4).to(device)
+    out1 = linear_copy(inputs)
+    out2 = column_parallel_linear(inputs)
+    print(out1, out2)
+    atorch.reset_distributed()
+
+
+def _run_megatron_mlp(rank, world_size):
+    init_dist(rank, world_size)
+    config = [("tensor", world_size)]
+    create_parallel_group((config, None))
+    pg = _get_default_group()
+    ranks = [i for i in range(world_size)]
+    torch.manual_seed(1)
+
+    class GLMMLP(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.dense_h_to_4h = torch.nn.Linear(4, 2)
+            self.dense_4h_to_h = torch.nn.Linear(2, 4)
+            self.dropout = torch.nn.Dropout(1)
+
+        def forward(self, x):
+            x = self.dense_h_to_4h(x)
+            x = gelu(x)
+            x = self.dense_4h_to_h(x)
+            x = self.dropout(x)
+            return x
+
+    if torch.cuda.is_available():
+        device = torch.device(atorch.local_rank())
+    else:
+        device = torch.device("cpu")
+    mlp = GLMMLP().to(device)
+    parameter_size = [p.numel() for p in mlp.parameters()]
+    parameter_shape = [p.size() for p in mlp.parameters()]
+    all_params = [torch.flatten(p) for p in mlp.parameters()]
+    all_params = torch.cat(all_params)
+    dist.broadcast(all_params, src=0)
+    # broadcast
+    acc = 0
+    for shape, num, p in zip(parameter_shape, parameter_size, mlp.parameters()):
+        start = acc
+        end = acc + num
+        p.data = all_params[start:end].view(shape)
+
+    copy_mlp = copy.deepcopy(mlp)
+
+    mgatron_glm_mlp = MegatronGLMMLP(
+        output_dropout_prob=1, orig_module=mlp, ranks=ranks, process_group=pg, defer_init=False
+    ).to(device)
+
+    if rank == 0:
+        assert torch.norm(copy_mlp.dense_h_to_4h.weight[:1, :] - mgatron_glm_mlp.dense_h_to_4h.weight, p=-1) == 0
+        assert torch.norm(copy_mlp.dense_4h_to_h.weight[:, :1] - mgatron_glm_mlp.dense_4h_to_h.weight, p=-1) == 0
+
+    copy_mlp.eval()
+    mgatron_glm_mlp.eval()
+
+    input_x = torch.tensor([[1.0, 2.0, 2.0, 2.0], [1.0, 2.0, 2.0, 2.0], [1.0, 2.0, 2.0, 2.0], [1.0, 2.0, 2.0, 2.0]]).to(
+        device
+    )
+
+    y_mlp = copy_mlp(input_x)
+    y_megatron_glm_mlp = mgatron_glm_mlp(input_x)
+
+    res = torch.norm(y_mlp - y_megatron_glm_mlp, p=1)
+    atorch.reset_distributed()
+    assert res == 0
+
+
+class TestInitializeAffineWeight(unittest.TestCase):
+    def test_initialize_affine_weight(self):
+        name = "tensor"
+        _DistributedContext.PARALLEL_RANK = {}
+        _DistributedContext.PARALLEL_GROUP_SIZE = {}
+        _DistributedContext.PARALLEL_RANK["tensor"] = 0
+        _DistributedContext.PARALLEL_GROUP_SIZE["tensor"] = 2
+        master_weight = torch.tensor([1, 2, 3, 4])
+        weight = torch.empty(2)
+        _initialize_affine_weight(
+            weight, per_partition_size=2, master_weight=master_weight, partition_dim=-1, group_name=name
+        )
+        _DistributedContext.PARALLEL_RANK = None
+        _DistributedContext.PARALLEL_GROUP_SIZE = None
+        assert torch.norm(weight - master_weight[0:2], p=-1) == 0
+
+
+class TestRowParallelLinear(unittest.TestCase):
+    @unittest.skipIf(torch.cuda.device_count() < 2, "run with gpu_num >=2")
+    def test_row_paralle_linear(self):
+
+        world_size = 2
+        os.environ["MASTER_ADDR"] = "localhost"  #
+        os.environ["MASTER_PORT"] = str(find_free_port())
+        mp.spawn(
+            _run_row_paralle_linear,
+            args=(world_size,),
+            nprocs=world_size,
+            join=True,
+        )
+        os.environ["MASTER_ADDR"] = ""
+        os.environ["MASTER_PORT"] = ""
+
+
+class TestColumnParallelLinear(unittest.TestCase):
+    @unittest.skipIf(torch.cuda.device_count() < 2, "run with gpu_num >=2")
+    def test_column_paralle_linear(self):
+
+        world_size = 2
+        os.environ["MASTER_ADDR"] = "localhost"  #
+        os.environ["MASTER_PORT"] = str(find_free_port())
+        mp.spawn(
+            _run_column_paralle_linear,
+            args=(world_size,),
+            nprocs=world_size,
+            join=True,
+        )
+        os.environ["MASTER_ADDR"] = ""
+        os.environ["MASTER_PORT"] = ""
+
+
+class TestMegatronMLP(unittest.TestCase):
+    @unittest.skipIf(torch.cuda.device_count() < 2, "run with cpu or gpu_num >=2")
+    def test_megatron_mlp(self):
+
+        world_size = 2
+        os.environ["MASTER_ADDR"] = "localhost"  #
+        os.environ["MASTER_PORT"] = str(find_free_port())
+        mp.spawn(
+            _run_megatron_mlp,
+            args=(world_size,),
+            nprocs=world_size,
+            join=True,
+        )
+        os.environ["MASTER_ADDR"] = ""
+        os.environ["MASTER_PORT"] = ""
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/atorch/atorch/tests/common_tests/megatron_vocab_test.py
+++ b/atorch/atorch/tests/common_tests/megatron_vocab_test.py
@@ -1,0 +1,281 @@
+import copy
+import os
+import unittest
+
+import torch
+import torch.multiprocessing as mp
+import torch.nn.functional as F
+from torch.nn import init
+from torch.nn.parameter import Parameter
+
+import atorch
+from atorch.common.util_func import find_free_port
+from atorch.distributed.distributed import create_parallel_group
+from atorch.modules.distributed_modules.cross_entropy import vocab_parallel_cross_entropy
+from atorch.modules.distributed_modules.layers import ParallelEmbedding, VocabParallelEmbedding
+
+
+def init_dist(rank, world_size):
+    os.environ["LOCAL_RANK"] = str(rank)
+    os.environ["RANK"] = str(rank)
+    os.environ["WORLD_SIZE"] = str(world_size)
+    os.environ["NPROC_PER_NODE"] = str(world_size)
+
+    if torch.cuda.is_available():
+        atorch.init_distributed("nccl")
+    else:
+        atorch.init_distributed("gloo")
+    parallel_config = ([("model", world_size)], None)
+
+    create_parallel_group(parallel_config)
+
+
+class VocabEmbedding(torch.nn.Module):
+    """Embedding parallelized in the vocabulary dimension.
+    This is mainly adapted from torch.nn.Embedding and all the default
+    values are kept.
+    Arguments:
+        num_embeddings: vocabulary size.
+        embedding_dim: size of hidden state.
+        init_method: method to initialize weights.
+    """
+
+    def __init__(self, config):
+        super(VocabEmbedding, self).__init__()
+        # Keep the input dimensions.
+        self.num_embeddings = config.vocab_size
+        self.embedding_dim = config.hidden_size
+        # Set the detauls for compatibility.
+        self.padding_idx = None
+        self.max_norm = None
+        self.norm_type = 2.0
+        self.scale_grad_by_freq = False
+        self.sparse = False
+        self._weight = None
+
+        self.vocab_start_index = 0
+        self.vocab_end_index = self.num_embeddings
+
+        # Allocate weights.
+        self.weight = Parameter(torch.Tensor(self.num_embeddings, self.embedding_dim))
+        # And initialize.
+        init.xavier_normal_(self.weight)
+
+    def forward(self, input_):
+        # Get the embeddings.
+        output = F.embedding(
+            input_, self.weight, self.padding_idx, self.max_norm, self.norm_type, self.scale_grad_by_freq, self.sparse
+        )
+        return output
+
+
+def _run_megatron_vocab_parallel_embedding(rank, world_size):
+
+    init_dist(rank, world_size)
+    config = [("tensor", world_size)]
+    create_parallel_group((config, None))
+    pg, ranks = atorch.distributed.distributed.parallel_group_and_ranks("tensor")
+
+    if torch.cuda.is_available():
+        device = torch.device(atorch.local_rank())
+    else:
+        device = torch.device("cpu")
+
+    class Config:
+        vocab_size = 1024
+        embedding_dim = 2048
+        hidden_size = 1024
+
+    torch.manual_seed(0)
+    vocab_embedding = VocabEmbedding(Config).to(device)
+    vocab_embedding_copy = copy.deepcopy(vocab_embedding)
+
+    parallel_vocab_embedding = VocabParallelEmbedding(
+        orig_module=vocab_embedding, process_group=pg, ranks=ranks, defer_init=False
+    ).to(device)
+    if rank == 0:
+        r = vocab_embedding_copy.weight[0:512, :] - parallel_vocab_embedding.weight[:, :]
+        assert torch.norm(r, p=-1) == 0
+    elif rank == 1:
+        r = vocab_embedding_copy.weight[512:1024, :] - parallel_vocab_embedding.weight[:, :]
+        assert torch.norm(r, p=-1) == 0
+    input_ids = torch.tensor([0, 513], dtype=torch.long).to(device)
+
+    embed1 = vocab_embedding_copy(input_ids)
+    embed2 = parallel_vocab_embedding(input_ids)
+    assert torch.norm(embed1 - embed2, p=-1) == 0
+    atorch.reset_distributed()
+
+
+def _run_megatron_vocab_parallel_cross_entropy(rank, world_size):
+
+    init_dist(rank, world_size)
+    config = [("tensor", world_size)]
+    create_parallel_group((config, None))
+    pg, ranks = atorch.distributed.distributed.parallel_group_and_ranks("tensor")
+
+    if torch.cuda.is_available():
+        device = torch.device(atorch.local_rank())
+    else:
+        device = torch.device("cpu")
+
+    class Config:
+        vocab_size = 1024
+        embedding_dim = 2048
+        hidden_size = 1024
+
+    torch.manual_seed(0)
+    vocab_embedding = VocabEmbedding(Config).to(device)
+    vocab_embedding_copy = copy.deepcopy(vocab_embedding)
+
+    parallel_vocab_embedding = VocabParallelEmbedding(
+        orig_module=vocab_embedding, process_group=pg, ranks=ranks, defer_init=False
+    ).to(device)
+
+    batch_size = 4
+    seq_len = 512
+    torch.manual_seed(1)
+    ref_last_hidden_states = torch.randn((batch_size, seq_len, Config.hidden_size), device=device, requires_grad=True)
+    tp_last_hidden_states = copy.deepcopy(ref_last_hidden_states)
+    ref_logits = F.linear(ref_last_hidden_states, vocab_embedding_copy.weight)
+    tp_logits = F.linear(tp_last_hidden_states, parallel_vocab_embedding.weight)
+
+    torch.manual_seed(2)
+    labels = torch.randint(
+        low=0,
+        high=Config.vocab_size,
+        size=(
+            batch_size,
+            seq_len,
+        ),
+        device=device,
+    )
+    loss_mask = (
+        torch.randn(
+            (
+                batch_size,
+                seq_len,
+            ),
+            device=device,
+        )
+        > 0
+    )
+
+    # ref loss
+    ref_losses = torch.nn.CrossEntropyLoss(reduction="none")(ref_logits.view(-1, ref_logits.size(-1)), labels.view(-1))
+    ref_loss = torch.sum(ref_losses * loss_mask.view(-1))
+    if loss_mask.sum().item() > 0:
+        ref_loss = ref_loss / loss_mask.sum()
+    ref_loss.backward()
+
+    # tp loss
+    tp_losses = vocab_parallel_cross_entropy(tp_logits, labels)
+    loss_mask = loss_mask.view(-1)
+    tp_loss = torch.sum(tp_losses.view(-1) * loss_mask)
+    if loss_mask.sum().item() > 0:
+        tp_loss = tp_loss / loss_mask.sum()
+    tp_loss.backward()
+
+    # check
+    assert torch.all(torch.isclose(ref_loss, tp_loss))
+    assert torch.all(
+        torch.isclose(
+            vocab_embedding_copy.weight.grad.chunk(world_size, dim=0)[rank], parallel_vocab_embedding.weight.grad
+        )
+    )
+    atorch.reset_distributed()
+
+
+def _run_megatron_parallel_embedding(rank, world_size):
+
+    init_dist(rank, world_size)
+    config = [("tensor", world_size)]
+    create_parallel_group((config, None))
+    pg, ranks = atorch.distributed.distributed.parallel_group_and_ranks("tensor")
+
+    if torch.cuda.is_available():
+        device = torch.device(atorch.local_rank())
+    else:
+        device = torch.device("cpu")
+
+    class Config:
+        vocab_size = 1024
+        embedding_dim = 2048
+        hidden_size = 1024
+
+    torch.manual_seed(0)
+    vocab_embedding = VocabEmbedding(Config).to(device)
+    vocab_embedding_copy = copy.deepcopy(vocab_embedding)
+
+    parallel_vocab_embedding = ParallelEmbedding(
+        orig_module=vocab_embedding, process_group=pg, ranks=ranks, defer_init=False
+    ).to(device)
+    if rank == 0:
+        r = vocab_embedding_copy.weight[:, 0:512] - parallel_vocab_embedding.weight[:, :]
+        assert torch.norm(r, p=-1) == 0
+    elif rank == 1:
+        r = vocab_embedding_copy.weight[:, 512:1024] - parallel_vocab_embedding.weight[:, :]
+        assert torch.norm(r, p=-1) == 0
+    input_ids = torch.tensor([0, 513], dtype=torch.long).to(device)
+
+    embed1 = vocab_embedding_copy(input_ids)
+    embed2 = parallel_vocab_embedding(input_ids)
+
+    if rank == 0:
+        r = embed1[:, 0:512] - embed2[:, 0:512]
+        assert torch.norm(r, p=-1) == 0
+    elif rank == 1:
+        r = embed1[:, 512:1024] - embed2[:, 512:1024]
+        assert torch.norm(r, p=-1) == 0
+
+    res = torch.norm(embed1 - embed2, p=1)
+    assert res == 0
+
+    atorch.reset_distributed()
+
+
+class TestVocabParallelEmbedding(unittest.TestCase):
+    @unittest.skipIf(torch.cuda.device_count() < 2, "run with gpu_num >=2")
+    def test_run_megatron_vocab_parallel_embedding(self):
+        os.environ["MASTER_ADDR"] = "localhost"  #
+        os.environ["MASTER_PORT"] = str(find_free_port())
+        world_size = 2
+        mp.spawn(
+            _run_megatron_vocab_parallel_embedding,
+            args=(world_size,),
+            nprocs=world_size,
+            join=True,
+        )
+
+
+class TestVocabParallelCrossEntropy(unittest.TestCase):
+    @unittest.skipIf(torch.cuda.device_count() < 2, "run with gpu_num >=2")
+    def test_run_megatron_vocab_parallel_embedding(self):
+        os.environ["MASTER_ADDR"] = "localhost"  #
+        os.environ["MASTER_PORT"] = str(find_free_port())
+        world_size = 2
+        mp.spawn(
+            _run_megatron_vocab_parallel_cross_entropy,
+            args=(world_size,),
+            nprocs=world_size,
+            join=True,
+        )
+
+
+class TestParallelEmbedding(unittest.TestCase):
+    @unittest.skipIf(torch.cuda.device_count() < 2, "run with gpu_num >=2")
+    def test_run_megatron_parallel_embedding(self):
+
+        os.environ["MASTER_ADDR"] = "localhost"  #
+        os.environ["MASTER_PORT"] = str(find_free_port())
+        world_size = 2
+        mp.spawn(
+            _run_megatron_parallel_embedding,
+            args=(world_size,),
+            nprocs=world_size,
+            join=True,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/atorch/atorch/tests/common_tests/meta_init_test.py
+++ b/atorch/atorch/tests/common_tests/meta_init_test.py
@@ -1,0 +1,211 @@
+import copy
+import math
+import os
+import tempfile
+import unittest
+from collections import defaultdict
+
+import torch
+import torch.multiprocessing as mp
+import torch.nn as nn
+
+import atorch
+from atorch.auto.accelerate import auto_accelerate
+from atorch.common.util_func import find_free_port
+from atorch.utils.meta_model_utils import init_empty_weights_with_disk_offload, reload_meta_module
+from atorch.utils.version import torch_version
+
+
+def init_dist(rank, world_size):
+    os.environ["LOCAL_RANK"] = str(rank)
+    os.environ["RANK"] = str(rank)
+    os.environ["WORLD_SIZE"] = str(world_size)
+    os.environ["NPROC_PER_NODE"] = str(world_size)
+    if torch.cuda.is_available():
+        atorch.init_distributed("nccl")
+    else:
+        atorch.init_distributed("gloo")
+
+
+def init_bert_params(module):
+    def normal_(data):
+        data.copy_(data.normal_(mean=0.0, std=0.02).to(data.device))
+
+    if isinstance(module, nn.Linear):
+        normal_(module.weight.data)
+        if module.bias is not None:
+            module.bias.data.zero_()
+    elif isinstance(module, nn.Embedding):
+        normal_(module.weight.data)
+        if module.padding_idx is not None:
+            module.weight.data[module.padding_idx].zero_()
+    elif isinstance(module, MultiwayNetwork):
+        normal_(module.A.weight.data)
+        normal_(module.B.weight.data)
+
+
+class MultiwayNetwork(nn.Module):
+    def __init__(self, module, dim=1):
+        super().__init__()
+        self.dim = dim
+        self.A = module
+        self.B = copy.deepcopy(module)
+        self.B.reset_parameters()
+        self.split_position = -1
+        self.p = nn.Parameter(torch.tensor(1.0))
+
+    def forward(self, x, **kwargs):
+        if self.split_position == -1:
+            return self.A(x, **kwargs)
+        if self.split_position == 0:
+            return self.B(x, **kwargs)
+        x1, x2 = torch.split(
+            x,
+            [self.split_position, x.size(self.dim) - self.split_position],
+            dim=self.dim,
+        )
+        # x1, x2 = x[:self.split_position], x[self.split_position:]
+        y1, y2 = self.A(x1, **kwargs), self.B(x2, **kwargs)
+        return torch.cat([y1, y2], dim=self.dim)
+
+
+class FFN(nn.Module):
+    def __init__(self, dim, nlayers):
+        super().__init__()
+        self.fc1 = nn.Linear(dim, dim)
+        self.layers = nn.ModuleList([])
+        for i in range(nlayers):
+            self.layers.append(MultiwayNetwork(nn.Linear(dim, dim)))
+        self.layers.apply(init_bert_params)
+        self.ln = MultiwayNetwork(nn.LayerNorm(dim))
+
+    def forward(self, x):
+        x = self.fc1(x)
+        for layer in self.layers:
+            x = layer(x)
+        return self.ln(x)
+
+
+class HoldModule(nn.Module):
+    def __init__(
+        self,
+        modules,
+    ):
+        super().__init__()
+        self.mods = nn.ModuleList(modules)
+
+    def forward(self, x):
+        for module in self.mods:
+            x = module(x)
+        return x
+
+
+class MyModel(nn.Module):
+    def __init__(self, nlayers, dim):
+        super().__init__()
+        self.ffn = FFN(dim, nlayers)
+        self.ffn2 = FFN(dim, nlayers)
+        self.ln = nn.LayerNorm(dim)
+        self.layers = HoldModule([self.ffn, self.ffn2])
+        init_scale = math.sqrt(math.log(nlayers * 2))
+        self.p = nn.Parameter(torch.tensor(1.0))
+        for name, p in self.named_parameters():
+            if "bias" in name:
+                p.data.zero_()
+            elif "weight" in name:
+                p.data.mul_(init_scale)
+
+    def forward(self, x):
+        return self.ln(self.layers(x))
+
+
+class TestMetaInit(unittest.TestCase):
+    embed_dim = 10
+
+    def setUp(self) -> None:
+        return super().setUp()
+
+    def test_init_MWN_params(self):
+        with init_empty_weights_with_disk_offload(ignore_tie_weights=False):
+            model = MyModel(5, self.embed_dim)
+            for name, params in model.named_parameters():
+                self.assertTrue(params.device.type == "cpu")
+            for _, p in model.layers.mods[0].named_parameters():
+                p.requires_grad_(False)
+        for _, p in model.layers.mods[0].named_parameters():
+            self.assertFalse(p.requires_grad)
+        device2name = defaultdict(list)
+        self.assertEqual(3, len(list(model.ffn.layers[0].modules())))  # self,A,B
+        for name, params in model.named_parameters():
+            device2name[params.device.type].append(name)
+        for name, params in model.named_parameters():
+            self.assertTrue(params.device.type == "meta")
+
+        self.assertEqual(1, len(model._parameters))  # p
+        for name in model._parameters:
+            self.assertTrue(name in device2name["meta"])
+        mod1 = nn.Linear(10, 10)
+        mod2 = copy.deepcopy(mod1)
+
+        reload_meta_module(model, "cpu")
+        for _, p in model.layers.mods[0].named_parameters():
+            self.assertFalse(p.requires_grad)
+        self.assertFalse(mod2 in [mod1])
+
+    def test_init_MWN_params2(self):
+        with tempfile.TemporaryFile() as fp:
+            with init_empty_weights_with_disk_offload(ignore_tie_weights=True):
+                model = MyModel(5, self.embed_dim)
+                torch.save(model.state_dict(), fp)
+            fp.seek(0)
+            sd = torch.load(fp, map_location="cpu")
+            model.load_state_dict(sd)
+        device2name = defaultdict(list)
+        for name, params in model.named_parameters():
+            device2name[params.device].append(name)
+        for name, params in model.named_parameters():
+            self.assertTrue(params.device.type == "meta")
+        # reload_meta_module(model, "cpu")
+
+
+def _test_init_auto_accelerate(rank, world_size):
+    init_dist(rank, world_size)
+    embed_dim = 10
+    with init_empty_weights_with_disk_offload(ignore_tie_weights=False):
+        model = MyModel(5, embed_dim)
+    # simulate requires_grad=False
+    for _, p in model.layers.mods[0].named_parameters():
+        p.requires_grad_(False)
+    reload_meta_module(model, "cpu")
+    # TODO: fix when using "atorch_wrap_cls": (MultiwayNetwork,)  the test fails
+    auto_accelerate(
+        model,
+        load_strategy=[
+            (
+                "fsdp",
+                {"atorch_wrap_cls": {"nn.Linear"}, "use_orig_params": True},
+            )
+        ],
+    )
+
+    atorch.reset_distributed()
+
+
+class TestInitAutoAccelerate(unittest.TestCase):
+    @unittest.skipIf(
+        torch.cuda.device_count() < 2 or torch_version() < (2, 0, 0), "run with gpu_num >=2 torch.version > 2.0"
+    )
+    def test_init_auto_accelerate(self):
+        world_size = 2
+        os.environ["MASTER_ADDR"] = "localhost"  #
+        os.environ["MASTER_PORT"] = str(find_free_port())
+        mp.spawn(
+            _test_init_auto_accelerate,
+            args=(world_size,),
+            nprocs=world_size,
+            join=True,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/atorch/atorch/tests/common_tests/meta_module_test.py
+++ b/atorch/atorch/tests/common_tests/meta_module_test.py
@@ -1,0 +1,123 @@
+import os
+import unittest
+
+import torch
+import torch.multiprocessing as mp
+
+try:
+    from transformers import GPTNeoXConfig
+    from transformers.models.gpt_neox.modeling_gpt_neox import GPTNeoXForCausalLM
+except ImportError:
+    GPTNeoXForCausalLM = None
+    GPTNeoXConfig = None
+
+
+import atorch
+from atorch.common.util_func import find_free_port
+from atorch.distributed.distributed import create_parallel_group, destroy_parallel_group, parallel_group
+from atorch.modules.distributed_modules.layers import ColumnParallelLinear
+from atorch.modules.distributed_modules.materialize_modules import materialize_modules_to_device
+from atorch.utils.meta_model_utils import init_empty_weights_with_disk_offload, reload_meta_module
+
+
+class MyModule(torch.nn.Module):
+    def __init__(self, vocab_size, hidden_size):
+        super().__init__()
+        self.emb_in = torch.nn.Embedding(vocab_size, hidden_size)
+        self.layer0 = torch.nn.Linear(hidden_size, hidden_size, bias=False)
+        self.emb_out = torch.nn.Linear(hidden_size, vocab_size, bias=False)
+        self._post_init()
+
+    def _post_init(self):
+        self.emb_in.weight = self.emb_out.weight
+
+    def forward(self, tokens):
+        return self.emb_out(self.layer0(self.emb_in(tokens)))
+
+
+def init_distributed(rank, world_size):
+
+    if not torch.distributed.is_initialized():
+        os.environ["LOCAL_RANK"] = str(rank)
+        os.environ["RANK"] = str(rank)
+        os.environ["WORLD_SIZE"] = str(world_size)
+        os.environ["NPROC_PER_NODE"] = str(world_size)
+        if torch.cuda.is_available():
+            atorch.init_distributed("nccl")
+            torch.cuda.set_device(rank)
+        else:
+            atorch.init_distributed("gloo")
+    if parallel_group("tensor") is None:
+        gpu_partition = ([("tensor", world_size)], None)
+        create_parallel_group(gpu_partition)
+
+
+def run_tp_materialize(rank, world_size):
+    init_distributed(rank, world_size)
+    with init_empty_weights_with_disk_offload(ignore_tie_weights=False):
+        model = torch.nn.Linear(64, 64)
+
+    tp_model = ColumnParallelLinear(orig_module=model)
+    device = f"cuda:{rank}"
+    # make sure tp can reload
+    materialize_modules_to_device(tp_model, device=device)
+
+
+class TestMetaUtils(unittest.TestCase):
+    def tearDown(self):
+        destroy_parallel_group()
+        return super().tearDown()
+
+    @unittest.skipIf(torch.cuda.is_available(), "cpu test")
+    def test_init_and_reload(self):
+        with init_empty_weights_with_disk_offload(ignore_tie_weights=False):
+            model = MyModule(8, 4)
+
+        assert id(model.emb_in.weight) == id(model.emb_out.weight)
+        reload_meta_module(model)
+        assert id(model.emb_in.weight) == id(model.emb_out.weight)
+
+    @unittest.skipIf(torch.cuda.is_available() or GPTNeoXForCausalLM is None, "cpu test")
+    def test_offload_reload(self):
+        with init_empty_weights_with_disk_offload(ignore_tie_weights=False):
+            config = {
+                "hidden_size": 32,
+                "intermediate_size": 128,
+                "num_attention_heads": 2,
+                "num_hidden_layers": 2,
+                "vocab_size": 512,
+            }
+            config = GPTNeoXConfig(**config)
+            model = GPTNeoXForCausalLM(config)
+
+        input_ids = torch.randint(
+            low=0,
+            high=512,
+            size=(16, 24),
+            dtype=torch.long,
+        )
+        labels = torch.rand(16, 24).long()
+        input_batch = {"input_ids": input_ids, "labels": labels}
+        materialize_modules_to_device(model)
+        model(**input_batch)
+
+    @unittest.skipIf(
+        (not torch.cuda.is_available() or torch.cuda.device_count() < 2),
+        "Must have at least 2 GPUs for tp test",
+    )
+    def test_tp_reload(self):
+        world_size = 2
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = str(find_free_port())
+        mp.spawn(
+            run_tp_materialize,
+            args=(world_size,),
+            nprocs=world_size,
+            join=True,
+        )
+        os.environ["MASTER_ADDR"] = ""
+        os.environ["MASTER_PORT"] = ""
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/atorch/atorch/tests/common_tests/mixed_parallel_test.py
+++ b/atorch/atorch/tests/common_tests/mixed_parallel_test.py
@@ -1,0 +1,237 @@
+"""This is to verify that pipe model has the same behavior as the normal modules,
+in composition with amp.
+
+"""
+import copy
+import os
+import random
+import unittest
+
+import numpy as np
+import torch
+import torch.distributed.rpc as torch_rpc
+import torch.multiprocessing as mp
+from torch.nn import MSELoss
+from torch.utils.data import Dataset
+
+import atorch
+from atorch.auto.model_context import ModelContext
+from atorch.common.util_func import find_free_port
+from atorch.distributed.distributed import destroy_parallel_group, parallel_group_and_ranks, parallel_rank
+from atorch.modules.distributed_modules.compilers.pipe_compiler.distributed_pippy_compiler import (
+    DeviceSafeDriver,
+    SafeStage,
+)
+from atorch.utils.meta_model_utils import deepcopy_checkpoint_name
+from atorch.utils.version import torch_version
+
+
+def seed_everything(seed=42):
+    random.seed(seed)  # Python's random module
+    np.random.seed(seed)  # Numpy
+    torch.manual_seed(seed)  # PyTorch
+
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed(seed)  # CUDA
+        torch.backends.cudnn.deterministic = True
+        torch.backends.cudnn.benchmark = False
+
+
+class MyModule(torch.nn.Module):
+    def __init__(self, in_features, out_features, bias=True):
+        super().__init__()
+        self.layer = torch.nn.Linear(in_features, out_features, bias=bias)
+        self.layers = torch.nn.ModuleList([torch.nn.Linear(out_features, out_features, bias=bias) for _ in range(16)])
+
+    def forward(self, input_):
+        data = torch.nn.functional.gelu(self.layer(input_[0]))
+        for op in self.layers:
+            data = op(data)
+            data = torch.nn.functional.gelu(data)
+        return data
+
+
+class ToyDataset(Dataset):
+    def __init__(self, size):
+        self.size = size
+
+    def __len__(self):
+        return self.size
+
+    def __getitem__(self, idx):
+        return torch.ones((7, 32)), torch.zeros((7, 16))
+
+
+def prepare_input(data, device):
+    return data[0].to(device), data[1].to(device)
+
+
+def my_loss_func(data, outputs):
+    loss_fct = MSELoss()
+    loss = loss_fct(outputs.view(-1), data[-1].view(-1))
+    return loss
+
+
+def create_model_context(data_size=512, batch_size=16, loss_func=None):
+    model = MyModule(32, 16, True)
+    dataset = ToyDataset(data_size)
+    model_context = ModelContext(
+        model=model,
+        optim_func=torch.optim.SGD,
+        dataset=dataset,
+        prepare_input=prepare_input,
+        dataloader_args={"batch_size": batch_size, "drop_last": True},
+        optim_args={"lr": 0.001},
+        loss_func=loss_func,
+    )
+    return model_context
+
+
+def generate_mixed_configs(model_context, mixed_config=dict()):
+    """Allowing pipe_configs gives us the flexibility to test different schedules"""
+    from atorch.auto.opt_lib.mixed_parallel_optimization import MixedParallelOptimization
+
+    mixed_opt = MixedParallelOptimization()
+    status, best_config, model_context = mixed_opt.tune(model_context, config=mixed_config, strategy=None)
+    assert status, "MixedParallelOptimization failed to tune"
+    return best_config
+
+
+def init_distributed(rank, world_size):
+    # set random state
+    seed_everything()
+
+    if not torch.distributed.is_initialized():
+        os.environ["LOCAL_RANK"] = str(rank)
+        os.environ["RANK"] = str(rank)
+        os.environ["WORLD_SIZE"] = str(world_size)
+        os.environ["NPROC_PER_NODE"] = str(world_size)
+        if torch.cuda.is_available():
+            atorch.init_distributed("nccl")
+            torch.cuda.set_device(rank)
+        else:
+            atorch.init_distributed("gloo")
+
+
+def run_two_steps_return_the_last(rank, model_context):
+    model = model_context.model
+    dataloader = model_context.dataloader
+    loss_func = model_context.loss_func
+    if loss_func is not None:
+        optimizer = model_context.optim
+    prepare_input = model_context.prepare_input
+    device = f"cuda:{rank}" if torch.cuda.is_available() else "cpu"
+
+    pipe_rank = parallel_rank("pipe")
+    _, pipe_ranks = parallel_group_and_ranks("pipe")
+    for step, batch in enumerate(dataloader):
+        batch = prepare_input(batch, device)
+        if isinstance(model, DeviceSafeDriver):
+            if pipe_rank == 0 or pipe_rank == "0":
+                outputs = model(batch)
+                if loss_func is not None:
+                    loss = loss_func(batch, outputs)
+                    loss.backward()
+                    optimizer.step()
+                    optimizer.zero_grad()
+                if step == 2:
+                    return outputs if loss_func is None else loss
+            else:
+                return torch.zeros((1,))
+        else:
+            outputs = model(batch)
+            if loss_func is not None:
+                loss = loss_func(batch, outputs)
+                loss.backward()
+                optimizer.step()
+                optimizer.zero_grad()
+            if step == 2:
+                # For PipeStage mode the last stage returns the loss
+                if isinstance(model, SafeStage):
+                    if rank == pipe_ranks[-1]:
+                        return outputs if loss_func is None else loss
+                    else:
+                        return torch.zeros((1,))
+                else:
+                    return outputs if loss_func is None else loss
+
+
+# Leave the AMP test to pure pipeline
+def run_mixed_parallel(rank, world_size, mixed_config=dict(), loss_func=None):
+    from atorch.auto.opt_lib.mixed_parallel_optimization import MixedParallelOptimization
+
+    init_distributed(rank, world_size)
+    model_context = create_model_context(loss_func=loss_func)
+    model_context_copy = copy.deepcopy(model_context)
+    deepcopy_checkpoint_name(model_context_copy.model, model_context.model)
+    if torch.cuda.is_available():
+        model_context.model.cuda()
+        model_context_copy.model.cuda()
+    # the result is deterministic on each rank
+    best_config = generate_mixed_configs(model_context_copy, mixed_config)
+
+    MixedParallelOptimization.apply_wrapper(model_context_copy, "mp", best_config)
+    model_context_copy.apply_wrappers(is_pre_wrapper=True)
+    model_context.update_dataloader()
+    model_context_copy.update_dataloader()
+    if loss_func is not None:
+        model_context.update_optim()
+        model_context_copy.update_optim()
+    model_context_copy.apply_wrappers(is_pre_wrapper=False)
+
+    outputs = run_two_steps_return_the_last(rank, model_context)
+
+    mixed_outputs = run_two_steps_return_the_last(rank, model_context_copy)
+
+    outputs = (
+        torch.zeros((1,))
+        if mixed_outputs.device == torch.device("cpu") and torch.all(mixed_outputs == torch.zeros((1,)))
+        else outputs
+    )
+
+    if loss_func is not None:
+        chunks = mixed_config["pipe_config"].get("chunks", 1)
+        mixed_outputs /= chunks
+    torch_rpc.api._wait_all_workers()
+    assert torch.allclose(
+        outputs, mixed_outputs, rtol=1e-4, atol=1e-4
+    ), f"Expected: ({outputs.shape}) {outputs} but mixed outputs ({mixed_outputs.shape}): {mixed_outputs}"
+    destroy_parallel_group()
+
+
+class TestMixedMLP(unittest.TestCase):
+    def tearDown(self):
+        destroy_parallel_group()
+        return super().tearDown()
+
+    @unittest.skipIf(
+        not torch.cuda.is_available() or torch.cuda.device_count() < 4 or torch_version() < (2, 0, 0),
+        "Must have at least 2 GPUs for gpu pipeline test",
+    )
+    def test_pipe_ddp_train(self):
+        world_size = 4
+        # test interleaved/microbatching schedule
+        # TODO test interleaved mode again later
+        mixed_config = {
+            "parallel_mode": ([("pipe", 2), ("data", 2)], None),
+            "prop_mode": "interpreter",
+            "use_fake_mode": False,
+            "pipe_config": {"use_c10d": True, "chunks": 4, "nstages": 2},
+            "tesnor_config": {"shard_planner": "base"},
+        }
+        loss_func = my_loss_func
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = str(find_free_port())
+        os.environ["CUDA_DEVICE_MAX_CONNECTIONS"] = "1"
+        mp.spawn(
+            run_mixed_parallel,
+            args=(world_size, mixed_config, loss_func),
+            nprocs=world_size,
+            join=True,
+        )
+        os.environ["MASTER_ADDR"] = ""
+        os.environ["MASTER_PORT"] = ""
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/atorch/atorch/tests/common_tests/model_context_test.py
+++ b/atorch/atorch/tests/common_tests/model_context_test.py
@@ -1,0 +1,175 @@
+import os
+import unittest
+
+import torch
+from torch.utils.data import Dataset
+from torch.utils.data.distributed import DistributedSampler
+
+import atorch
+from atorch.auto.model_context import ModelContext
+from atorch.data import ShmDataloader
+from atorch.distributed.distributed import _DistributedContext, create_parallel_group
+from atorch.tests.toy_modules.toy_module import ToyDataset, create_model_context, run_train
+from atorch.tests.utils.test_utils import run_multi_process_init_distributed
+from atorch.utils.version import torch_version
+
+
+class ModelContextTest(unittest.TestCase):
+    def run_test_with_device(self, device, data_size=16, batch_size=2):
+        context = create_model_context(data_size=data_size, batch_size=batch_size)
+        context.update_dataloader()
+        context.update_optim()
+        context.model.to(device)
+        num = run_train(
+            context.model, context.dataloader, context.optim, context.prepare_input, context.loss_func, device
+        )
+        self.assertEqual(num, data_size / batch_size)
+        context.update_dataloader(extra_args={"batch_size": 4})
+
+        def multi_output_loss_func(input, output):
+            loss = context.loss_func(input, output)
+            return loss, True
+
+        num = run_train(
+            context.model, context.dataloader, context.optim, context.prepare_input, multi_output_loss_func, device
+        )
+        self.assertEqual(num, data_size / 4)
+
+    @unittest.skipIf(not torch.cuda.is_available(), "No gpu available for cuda tests")
+    def test_gpu(self):
+        device = "cuda"
+        self.run_test_with_device(device)
+
+    @unittest.skipIf(torch.cuda.is_available(), "test only on cpu")
+    def test_cpu(self):
+        device = "cpu"
+        self.run_test_with_device(device)
+
+    def test_optim_param_func(self):
+        context = create_model_context(data_size=16, batch_size=2, use_optim_param_func=True)
+        context.update_dataloader()
+        optimizer = context.create_optim()
+        weight_decay_set = set()
+        for group in optimizer.param_groups:
+            weight_decay_set.add(group["weight_decay"])
+        self.assertEqual(weight_decay_set, {0.0, 0.01})
+
+    def test_find_unused_parameters(self):
+        context = create_model_context(data_size=16, batch_size=2)
+        self.assertFalse(context.find_unused_parameters)
+        context = create_model_context(data_size=16, batch_size=2, extra_args={"find_unused_parameters": True})
+        self.assertTrue(context.find_unused_parameters)
+
+    def test_dataloader_shuffle(self):
+        class TestDataset(Dataset):
+            def __init__(self, size):
+                self.size = size
+
+            def __len__(self):
+                return self.size
+
+            def __getitem__(self, idx):
+                return torch.Tensor([idx]), torch.Tensor([idx])
+
+        dataset = TestDataset(16)
+
+        context = create_model_context(
+            data_size=16, batch_size=2, dataset=dataset, distributed_sampler_cls=DistributedSampler
+        )
+        # hack to pretend that data parallel size is 2, rank = 1
+        _DistributedContext.PARALLEL_GROUP_SIZE = {}
+        _DistributedContext.PARALLEL_GROUP_SIZE["data"] = 2
+        _DistributedContext.PARALLEL_RANK = {}
+        _DistributedContext.PARALLEL_RANK["data"] = 1
+        dataloader = context.create_dataloader()
+        data_e0 = [data for data in dataloader]
+        data_e0b = [data for data in dataloader]
+        self.assertEqual(data_e0, data_e0b)
+        dataloader.set_epoch(1)
+        data_e1 = [data for data in dataloader]
+        self.assertNotEqual(data_e0, data_e1)
+        _DistributedContext.PARALLEL_GROUP_SIZE = None
+        _DistributedContext.PARALLEL_RANK = None
+
+
+class ModelContextWrapperTest(unittest.TestCase):
+    def setUp(self):
+        self.context = create_model_context(data_size=2, batch_size=1)
+
+    def test_adjust_ddp_and_zero2_wrapper(self):
+        self.context.add_wrapper("zero2", None, None, is_pre_wrapper=False)
+        self.context.add_wrapper("ddp", None, None, is_pre_wrapper=False)
+        wrappers = self.context.post_wrappers
+        self.assertIn("zero2", wrappers)
+        self.assertIn("ddp", wrappers)
+        self.context.adjust_wrappers()
+        wrappers = self.context.post_wrappers
+        self.assertIn("zero2", wrappers)
+        self.assertNotIn("ddp", wrappers)
+
+    def test_adjust_dynamo_and_fsdp_wrapper(self):
+        self.context.add_wrapper("native_dynamo", None, None, is_pre_wrapper=True)
+        self.context.add_wrapper("fsdp", None, None, is_pre_wrapper=True)
+        self.context.adjust_wrappers()
+        wrapper_names = [name for name, _ in self.context.pre_wrappers.items()]
+        wrappers_order = [wrapper_names.index("fsdp"), wrapper_names.index("native_dynamo")]
+        self.assertListEqual(wrappers_order, [0, 1])
+
+    def test_adjust_dynamo_and_ddp_wrapper(self):
+        self.context.add_wrapper("native_dynamo", None, None, is_pre_wrapper=True)
+        self.context.add_wrapper("ddp", None, None, is_pre_wrapper=False)
+        self.context.adjust_wrappers()
+        wrapper_names = [name for name, _ in self.context.post_wrappers.items()]
+        wrappers_order = [wrapper_names.index("ddp"), wrapper_names.index("native_dynamo")]
+        self.assertListEqual(wrappers_order, [0, 1])
+
+
+def use_shm_dataloader_func():
+    if torch.cuda.is_available():
+        atorch.init_distributed("nccl")
+    else:
+        atorch.init_distributed("gloo")
+
+    parallel_config = ([("model", 2), ("data", 1)], None)
+    create_parallel_group(parallel_config)
+
+    os.environ["ENABLE_SHM_DATALOADER"] = "True"
+    d_size = 4
+    batch_size = 2
+    dataset = ToyDataset(size=d_size, data_size=2, output_size=2)
+    dataloader_args = {"batch_size": batch_size, "drop_last": True}
+    context = ModelContext(
+        dataset=dataset,
+        dataloader_args=dataloader_args,
+    )
+
+    dataloader = context.create_dataloader()
+    assert isinstance(dataloader, ShmDataloader)
+    assert dataloader.shm_context.rank == atorch.distributed.rank()
+    for _ in range(2):
+        count = 0
+        total_0 = total_1 = 0
+        for batch in dataloader:
+            count += 1
+            for i in range(batch_size):
+                total_0 += batch[0][i][0].item()
+                total_1 += batch[1][i][0].item()
+            torch.distributed.barrier()
+        assert count == d_size // batch_size
+        assert total_0 == d_size * (d_size - 1) // 2
+        assert total_1 == d_size
+        assert count == d_size / batch_size
+
+    atorch.reset_distributed()
+
+
+@unittest.skipIf(torch_version() >= (2, 0, 0), "to be fixed")
+class ModelContextShmDataloaderTest(unittest.TestCase):
+    @unittest.skipIf(torch.cuda.is_available(), "Skip on gpu as cpu test covers it.")
+    def test_use_shm_dataloader(self):
+        code_path = os.path.abspath(__file__)
+        run_multi_process_init_distributed(nproc=2, training_script=code_path)
+
+
+if __name__ == "__main__":
+    use_shm_dataloader_func()

--- a/atorch/atorch/tests/common_tests/module_replace_optimization_test.py
+++ b/atorch/atorch/tests/common_tests/module_replace_optimization_test.py
@@ -1,0 +1,110 @@
+import copy
+import os
+import unittest
+
+import torch
+
+from atorch.auto.auto_accelerate_context import AutoAccelerateContext
+from atorch.auto.opt_lib.module_replace_optimization import ModuleReplaceOptimization, _check_model_params_device
+from atorch.modules.transformer.layers import BertAttentionFA, MultiheadAttentionFA
+from atorch.normalization import LayerNorm as ApexLayerNorm
+from atorch.tests.toy_modules.toy_module import create_model_context
+
+try:
+    from transformers.modeling_bert import BertAttention, BertConfig, BertLayer  # 3.5
+except (ModuleNotFoundError, ImportError):
+    from transformers.models.bert.modeling_bert import BertAttention, BertConfig, BertLayer  # 4.17
+
+from torch.nn import LayerNorm, Module, MultiheadAttention, TransformerEncoderLayer
+
+
+class TestModule(Module):
+    def __init__(self):
+        super().__init__()
+        bertconf = BertConfig()
+        self.layer1 = BertLayer(bertconf)
+        self.layer2 = TransformerEncoderLayer(bertconf.hidden_size, bertconf.num_attention_heads)
+
+
+class ModuleReplaceOptimizationTest(unittest.TestCase):
+    def setUp(self):
+        self.model_context = create_model_context()
+        self.model_context.model = TestModule()
+        self.module_replace_config = {
+            "HF_BertAttention_FA": {"need_src_module": True},
+            "LayerNorm_Apex": {"init_from_attr": True},
+        }
+        # set fp16 for fa replace not popped
+        AutoAccelerateContext.add_ac_attr("half_precision_dtype", {AutoAccelerateContext.counter: torch.float16})
+
+    @unittest.skipIf(not torch.cuda.is_available(), "cuda is not available")
+    def test_module_replace_optimization(self):
+        module_replace_optimization = ModuleReplaceOptimization()
+        mc = copy.deepcopy(self.model_context)
+
+        self.assertIsInstance(mc.model.layer1.attention, BertAttention)
+        self.assertIsInstance(mc.model.layer2.self_attn, MultiheadAttention)
+        self.assertIsInstance(mc.model.layer1.output.LayerNorm, LayerNorm)
+        self.assertIsInstance(mc.model.layer2.norm1, LayerNorm)
+
+        mc = module_replace_optimization.apply_wrapper(mc, "module_replace", self.module_replace_config)
+        self.assertIsInstance(mc.model.layer1.attention, BertAttentionFA)
+        self.assertIsInstance(mc.model.layer2.self_attn, MultiheadAttention)
+        self.assertIsInstance(mc.model.layer1.output.LayerNorm, ApexLayerNorm)
+        self.assertIsInstance(mc.model.layer2.norm1, ApexLayerNorm)
+
+    @unittest.skipIf(not torch.cuda.is_available(), "cuda is not available")
+    def test_module_replace_default_optimization(self):
+        module_replace_optimization = ModuleReplaceOptimization()
+        mc = copy.deepcopy(self.model_context)
+
+        self.assertIsInstance(mc.model.layer1.attention, BertAttention)
+        self.assertIsInstance(mc.model.layer2.self_attn, MultiheadAttention)
+        self.assertIsInstance(mc.model.layer1.output.LayerNorm, LayerNorm)
+        self.assertIsInstance(mc.model.layer2.norm1, LayerNorm)
+
+        # test default replace config
+        mc = module_replace_optimization.apply_wrapper(mc, "module_replace", None)
+        self.assertIsInstance(mc.model.layer1.attention, BertAttentionFA)
+        self.assertIsInstance(mc.model.layer2.self_attn, MultiheadAttentionFA)
+        self.assertIsInstance(mc.model.layer1.output.LayerNorm, ApexLayerNorm)
+        self.assertIsInstance(mc.model.layer2.norm1, ApexLayerNorm)
+
+    @unittest.skipIf(not torch.cuda.is_available(), "Must have gpu for mutli device test")
+    def test_multi_devices_gpu(self):
+        # trigger empty replacement
+        module_replace_optimization = ModuleReplaceOptimization()
+        mc = copy.deepcopy(self.model_context)
+        mc.model.to("cuda:0")
+
+        # test default replace config
+        # multi-device
+        mc.model.layer1.to("cpu")
+        mc = module_replace_optimization.apply_wrapper(mc, "module_replace", {})
+        post_replacement_devices = _check_model_params_device(mc.model)
+        self.assertCountEqual(post_replacement_devices, ["cpu"])
+        self.assertTrue(
+            list(post_replacement_devices)[0] == "cpu" or list(post_replacement_devices)[0] == torch.device("cpu")
+        )
+
+    def test_multi_devices_cpu(self):
+        # trigger empty replacement
+        module_replace_optimization = ModuleReplaceOptimization()
+        mc = copy.deepcopy(self.model_context)
+
+        # test default replace config
+        # multi-device
+        if not os.path.isdir(_MetaModeContext.offload_path):
+            os.makedirs(_MetaModeContext.offload_path)
+
+        mc.model.layer1.to("meta")
+        mc = module_replace_optimization.apply_wrapper(mc, "module_replace", {})
+        post_replacement_devices = _check_model_params_device(mc.model)
+        self.assertCountEqual(post_replacement_devices, ["meta"])
+        self.assertTrue(
+            list(post_replacement_devices)[0] == "meta" or list(post_replacement_devices)[0] == torch.device("meta")
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/atorch/atorch/tests/common_tests/moe_test.py
+++ b/atorch/atorch/tests/common_tests/moe_test.py
@@ -1,0 +1,136 @@
+import os
+import tempfile
+import unittest
+
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+from atorch.common.log_utils import default_logger as logger
+from atorch.modules.moe import Experts, MOELayer, SwitchGate, TopkGate
+
+logger.setLevel("ERROR")
+os.environ["NCCL_DEBUG"] = "ERROR"
+
+
+def _run_SwitchGate_moe(rank, world_size, tmp_file):
+    if torch.cuda.is_available():
+        torch.cuda.set_device(rank)
+        device = torch.device(f"cuda:{rank}")
+        backend = "nccl"
+    else:
+        device = torch.device("cpu")
+        backend = "gloo"
+    dist.init_process_group(
+        init_method="file://" + tmp_file,
+        rank=rank,
+        backend=backend,
+        world_size=world_size,
+    )
+
+    # build moe
+    s, b, z, e, m = 100, 32, 4, 48, 64
+    input_tensor = torch.rand(s, b, m).to(device)
+    gate = SwitchGate(m, e, need_l_aux=True)
+    assert e % world_size == 0
+    experts = Experts(e // world_size, m, 128)
+    moe_ori = MOELayer(gate, experts, num_prototypes=z).to(device)
+    moe_dispatchV2 = MOELayer(gate, experts, num_prototypes=z, dispatchV2=True).to(device)
+    moe_outer_batch = MOELayer(gate, experts, num_prototypes=z, outer_batch=True).to(device)
+    moe_outer_batch_dispatchV2 = MOELayer(gate, experts, num_prototypes=z, outer_batch=True, dispatchV2=True).to(device)
+
+    # forward
+    out_ori = moe_ori(input_tensor)
+    out_dispatchV2 = moe_dispatchV2(input_tensor)
+    l_aux_ori = moe_ori.l_aux
+    l_aux_dispatchV2 = moe_dispatchV2.l_aux
+    out_outer_batch = moe_outer_batch(input_tensor)
+    out_outer_batch_dispatchV2 = moe_outer_batch_dispatchV2(input_tensor)
+    l_aux_outer_batch = moe_outer_batch.l_aux
+    l_aux_outer_batch_dispatchV2 = moe_outer_batch_dispatchV2.l_aux
+
+    # assert dispatchV2 consistency, isclose for torch float precision
+    assert torch.all(torch.isclose(out_ori, out_dispatchV2)), (out_ori - out_dispatchV2).abs().max()
+    assert l_aux_ori == l_aux_dispatchV2
+    assert torch.all(torch.isclose(out_outer_batch, out_outer_batch_dispatchV2)), (
+        (out_outer_batch - out_outer_batch_dispatchV2).abs().max()
+    )
+    assert l_aux_outer_batch == l_aux_outer_batch_dispatchV2
+    dist.destroy_process_group()
+
+
+def _run_TopkGate_moe(rank, world_size, tmp_file):
+    if torch.cuda.is_available():
+        torch.cuda.set_device(rank)
+        device = torch.device(f"cuda:{rank}")
+        backend = "nccl"
+    else:
+        device = torch.device("cpu")
+        backend = "gloo"
+    dist.init_process_group(
+        init_method="file://" + tmp_file,
+        rank=rank,
+        backend=backend,
+        world_size=world_size,
+    )
+
+    # build moe
+    s, b, z, e, m = 100, 32, 4, 48, 64
+    input_tensor = torch.rand(s, b, m).to(device)
+    gate = TopkGate(m, e, k=2, need_l_aux=True)
+    assert e % world_size == 0
+    experts = Experts(e // world_size, m, 128)
+    moe_ori = MOELayer(gate, experts, num_prototypes=z).to(device)
+    moe_dispatchV2 = MOELayer(gate, experts, num_prototypes=z, dispatchV2=True).to(device)
+
+    # forward
+    out_ori = moe_ori(input_tensor)
+    out_dispatchV2 = moe_dispatchV2(input_tensor)
+    l_aux_ori = moe_ori.l_aux
+    l_aux_dispatchV2 = moe_dispatchV2.l_aux
+
+    # assert dispatchV2 consistency, isclose for torch float precision
+    assert torch.all(torch.isclose(out_ori, out_dispatchV2)), (out_ori - out_dispatchV2).abs().max()
+    assert l_aux_ori == l_aux_dispatchV2
+    dist.destroy_process_group()
+
+
+class TestMOELayer(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.mkstemp()[1]
+
+    def tearDown(self):
+        try:
+            os.remove(self.temp)
+        except FileNotFoundError:
+            pass
+
+    @unittest.skipIf(
+        not torch.cuda.is_available() or torch.cuda.device_count() < 2,
+        "No gpu available for cuda tests",
+    )
+    def test_SwitchGate_moe(self):
+        world_size = 2
+        mp.spawn(
+            _run_SwitchGate_moe,
+            args=(world_size, self.temp),
+            nprocs=world_size,
+            join=True,
+        )
+
+    @unittest.skipIf(
+        not torch.cuda.is_available() or torch.cuda.device_count() < 2,
+        "No gpu available for cuda tests",
+    )
+    def test_TopkGate_moe(self):
+        world_size = 2
+        mp.spawn(
+            _run_TopkGate_moe,
+            args=(world_size, self.temp),
+            nprocs=world_size,
+            join=True,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/atorch/atorch/tests/common_tests/mup_test.py
+++ b/atorch/atorch/tests/common_tests/mup_test.py
@@ -1,0 +1,383 @@
+import math
+import unittest
+
+import torch
+from torch import nn
+from torch.nn import Linear
+
+from atorch.mup.infshape import InfDim, InfShape, zip_infshape
+from atorch.mup.module import MupLinear, MupModule, OutputLayer, QKVLayer, QLayer
+from atorch.mup.optim import MuAdam, MuSGD
+from atorch.mup.shape import get_infshapes, get_shapes, make_base_shapes, save_base_shapes, set_base_shapes
+
+
+def _init_model(model, std=0.02):
+    for param in model.parameters():
+        if len(param.shape) >= 2:
+            nn.init.normal_(param, std=std)
+    return model
+
+
+def _generate_MLP(width, bias=True, batchnorm=False, device="cpu"):
+    mods = [
+        Linear(1024, width, bias=bias, device=device),
+        nn.ReLU(),
+        Linear(width, width, bias=bias, device=device),
+        nn.ReLU(),
+        Linear(width, 10, bias=bias, device=device),
+    ]
+    if batchnorm:
+        mods.insert(1, nn.BatchNorm1d(width, device=device))
+        mods.insert(4, nn.BatchNorm1d(width, device=device))
+    model = nn.Sequential(*mods)
+    return model
+
+
+class MySequential(nn.Sequential, MupModule):
+    pass
+
+
+def _generate_mup_MLP(width, bias=True, batchnorm=False, sampler="normal", device="cpu", **kwargs):
+    mods = [
+        MupLinear(1024, width, bias=bias, sampler=sampler, device=device, **kwargs),
+        nn.ReLU(),
+        MupLinear(width, width, bias=bias, sampler=sampler, device=device, **kwargs),
+        nn.ReLU(),
+        OutputLayer(width, 10, bias=bias, sampler=sampler, device=device, **kwargs),
+    ]
+    if batchnorm:
+        mods.insert(1, nn.BatchNorm1d(width, device=device))
+        mods.insert(4, nn.BatchNorm1d(width, device=device))
+    model = MySequential(*mods)
+    return model
+
+
+class TestInfShape(unittest.TestCase):
+    def test_infshape(self):
+        infshape = InfShape([InfDim(None, 100), InfDim(128, 1024), InfDim(128, 128)])
+        self.assertEqual(infshape.ninf(), 1)
+        self.assertEqual(infshape.width_mult(), 8)
+
+    def test_zip_infshape(self):
+        infshape = zip_infshape([64, 128, 1024], [32, 128, 2048], fin_if_same=True)
+        self.assertEqual(infshape.width_mult(), 2)
+        infshape = zip_infshape([64, 128, 1024], [32, 128, 2048], fin_if_same=False)
+        self.assertEqual(infshape.width_mult(), 2)
+
+
+class TestShape(unittest.TestCase):
+    def test_save_base_shape(self):
+        model = _generate_mup_MLP(256, batchnorm=True)
+        save_base_shapes(model, file=None)
+
+    def test_make_base_shape(self):
+        model = _generate_mup_MLP(256, bias=True, batchnorm=True)
+        delta_model = _generate_mup_MLP(128, bias=True, batchnorm=True)
+        make_base_shapes(model, delta_model)
+
+    def _get_mlp_infshapes(self):
+        base_model = _generate_mup_MLP(64, True, True)
+        target_model = _generate_mup_MLP(128, True, True)
+        set_base_shapes(target_model, base_model)
+        return get_infshapes(target_model)
+
+    def _get_mlp_infshapes_with_meta_device(self):
+        base_model = _generate_mup_MLP(64, True, True, device="meta")
+        target_model = _generate_mup_MLP(128, True, True, device="meta")
+        set_base_shapes(target_model, base_model)
+        return get_infshapes(target_model)
+
+    def _get_mlp_infshapes_with_delta_model(self):
+        base_model = _generate_mup_MLP(64, True, True)
+        delta_model = _generate_mup_MLP(65, True, True)
+        target_model = _generate_mup_MLP(128, True, True)
+        set_base_shapes(target_model, base_model, delta=delta_model)
+        return get_infshapes(target_model)
+
+    def _get_mlp_infshapes_via_make(self):
+        base_model = _generate_mup_MLP(64, True, True)
+        delta_model = _generate_mup_MLP(65, True, True)
+        base_infshapes = make_base_shapes(base_model, delta_model)
+        target_model = _generate_mup_MLP(128, True, True)
+        set_base_shapes(target_model, base_infshapes)
+        return get_infshapes(target_model)
+
+    def _get_mlp_infshapes_via_get_shapes(self):
+        base_model = _generate_mup_MLP(64, True, True)
+        target_model = _generate_mup_MLP(128, True, True)
+        set_base_shapes(target_model, get_shapes(base_model))
+        return get_infshapes(target_model)
+
+    def _get_mlp_infshapes_bad(self):
+        base_model = _generate_mup_MLP(64, True, True)
+        target_model = _generate_mup_MLP(128, True, True)
+        set_base_shapes(target_model, base_model, delta=base_model)
+        return get_infshapes(target_model)
+
+    def test_set_base_shape(self):
+        self.assertEqual(self._get_mlp_infshapes(), self._get_mlp_infshapes_with_meta_device())
+        self.assertEqual(self._get_mlp_infshapes(), self._get_mlp_infshapes_with_delta_model())
+        self.assertEqual(self._get_mlp_infshapes(), self._get_mlp_infshapes_via_make())
+        self.assertEqual(self._get_mlp_infshapes(), self._get_mlp_infshapes_via_get_shapes())
+        self.assertNotEqual(self._get_mlp_infshapes(), self._get_mlp_infshapes_bad())
+
+
+class TestInitialization(unittest.TestCase):
+    def test_muplinear_const(self):
+        layer = MupLinear(64, 256, bias=False, sampler="normal", std=0.02)
+        layer.weight.infshape = InfShape([InfDim(128, 256), InfDim(32, 64)])
+        layer.mup_initial(mode="sp")
+        self.assertAlmostEqual(layer.weight.mean().item(), 0.0, delta=0.001)
+        self.assertAlmostEqual(layer.weight.std().item(), 0.02, delta=0.001)
+        layer.mup_initial(mode="mup")
+        self.assertAlmostEqual(layer.weight.mean().item(), 0.0, delta=0.001)
+        self.assertAlmostEqual(layer.weight.std().item(), 0.02 / math.sqrt(2), delta=0.001)
+
+        layer = MupLinear(64, 256, bias=False, sampler="uniform", a=-1.0, b=1.0)
+        layer.weight.infshape = InfShape([InfDim(128, 256), InfDim(32, 64)])
+        layer.mup_initial(mode="sp")
+        self.assertLessEqual(layer.weight.abs().max().item(), 1.0)
+        layer.mup_initial(mode="mup")
+        self.assertLessEqual(layer.weight.abs().max().item(), 1.0 / math.sqrt(2))
+
+    def test_muplinear_xavier(self):
+        layer = MupLinear(64, 256, bias=False, sampler="xavier_normal", gain=0.5)
+        layer.weight.infshape = InfShape([InfDim(128, 256), InfDim(32, 64)])
+        layer.mup_initial(mode="sp")
+        self.assertAlmostEqual(layer.weight.mean().item(), 0.0, delta=0.001)
+        self.assertAlmostEqual(layer.weight.std().item(), 0.5 * math.sqrt(2.0 / (64 + 256)), delta=0.001)
+        layer.mup_initial(mode="mup")
+        self.assertAlmostEqual(layer.weight.mean().item(), 0.0, delta=0.001)
+        self.assertAlmostEqual(layer.weight.std().item(), 0.5 * math.sqrt(2.0 / (64 + 256)), delta=0.001)
+
+        layer = MupLinear(64, 256, bias=False, sampler="xavier_uniform", gain=0.5)
+        layer.weight.infshape = InfShape([InfDim(128, 256), InfDim(32, 64)])
+        layer.mup_initial(mode="sp")
+        self.assertLessEqual(layer.weight.abs().max().item(), 0.5 * math.sqrt(6.0 / (64 + 256)))
+        layer.mup_initial(mode="mup")
+        self.assertLessEqual(layer.weight.abs().max().item(), 0.5 * math.sqrt(6.0 / (64 + 256)))
+
+    def test_muplinear_kaiming(self):
+        # normal, infdim = 2
+        layer = MupLinear(64, 256, bias=False, sampler="kaiming_normal", a=0)
+        layer.weight.infshape = InfShape([InfDim(128, 256), InfDim(32, 64)])
+        layer.mup_initial(mode="sp")
+        self.assertAlmostEqual(layer.weight.mean().item(), 0.0, delta=0.01)
+        self.assertAlmostEqual(layer.weight.std().item(), math.sqrt(2.0 / 64), delta=0.01)
+        layer.mup_initial(mode="mup")
+        self.assertAlmostEqual(layer.weight.mean().item(), 0.0, delta=0.01)
+        self.assertAlmostEqual(layer.weight.std().item(), math.sqrt(2.0 / 64), delta=0.01)
+
+        # normal, infdim = 1
+        layer = MupLinear(64, 256, bias=False, sampler="kaiming_normal", a=0)
+        layer.weight.infshape = InfShape([InfDim(256, 256), InfDim(32, 64)])
+        layer.mup_initial(mode="sp")
+        self.assertAlmostEqual(layer.weight.mean().item(), 0.0, delta=0.01)
+        self.assertAlmostEqual(layer.weight.std().item(), math.sqrt(2.0 / 64), delta=0.01)
+        layer.mup_initial(mode="mup")
+        self.assertAlmostEqual(layer.weight.mean().item(), 0.0, delta=0.01)
+        self.assertAlmostEqual(layer.weight.std().item(), math.sqrt(4.0 / 64), delta=0.01)
+
+        # uniform
+        layer = MupLinear(64, 256, bias=False, sampler="kaiming_uniform", a=0)
+        layer.weight.infshape = InfShape([InfDim(128, 256), InfDim(32, 64)])
+        layer.mup_initial(mode="sp")
+        self.assertLessEqual(layer.weight.abs().max().item(), math.sqrt(3.0 * 2.0 / 64))
+        layer.mup_initial(mode="mup")
+        self.assertLessEqual(layer.weight.abs().max().item(), math.sqrt(3.0 * 2.0 / 64))
+
+    def test_muplinear_with_bias(self):
+        layer = MupLinear(64, 256, bias=True, bias_zero_init=True)
+        layer.weight.infshape = InfShape([InfDim(128, 256), InfDim(32, 64)])
+        layer.mup_initial(mode="sp")
+        self.assertAlmostEqual(layer.bias.mean().item(), 0.0, delta=0.001)
+        self.assertAlmostEqual(layer.bias.std().item(), 0.0, delta=0.001)
+        layer.mup_initial(mode="mup")
+        self.assertAlmostEqual(layer.bias.mean().item(), 0.0, delta=0.001)
+        self.assertAlmostEqual(layer.bias.std().item(), 0.0, delta=0.001)
+
+        layer = MupLinear(64, 256, bias=True, bias_zero_init=False)
+        layer.weight.infshape = InfShape([InfDim(128, 256), InfDim(32, 64)])
+        layer.mup_initial(mode="sp")
+        self.assertLessEqual(layer.bias.max().item(), 1 / math.sqrt(64))
+        layer.mup_initial(mode="mup")
+        self.assertLessEqual(layer.bias.max().item(), math.sqrt(2) / math.sqrt(64))
+
+    def test_muplinear_with_given_init_method(self):
+        def init_method(std):
+            def init_(tensor):
+                return nn.init.normal_(tensor, mean=0.0, std=std)
+
+            return init_
+
+        layer = MupLinear(
+            64, 256, bias=True, init_weight_method=init_method(0.001), init_bias_method=init_method(0.002)
+        )
+        layer.weight.infshape = InfShape([InfDim(128, 256), InfDim(32, 64)])
+        layer.mup_initial(mode="sp")
+        self.assertAlmostEqual(layer.weight.std().item(), 0.001, delta=0.001)
+        self.assertAlmostEqual(layer.bias.std().item(), 0.002, delta=0.001)
+        layer.mup_initial(mode="mup")
+        self.assertAlmostEqual(layer.weight.std().item(), 0.001, delta=0.001)
+        self.assertAlmostEqual(layer.bias.std().item(), 0.002, delta=0.001)
+
+    def test_qkvlayer(self):
+        dim = 64
+        layer = QKVLayer(dim, dim * 3, q_zero_init=True)
+        layer.weight.infshape = InfShape([InfDim(dim / 2 * 3, dim * 3), InfDim(dim / 2, dim)])
+        layer.mup_initial(mode="sp")
+        self.assertEqual(layer.weight.data[:dim, :].sum().item(), 0.0)
+        self.assertNotEqual(layer.weight.data[dim : dim * 3, :].sum().item(), 0.0)
+        layer.mup_initial(mode="mup")
+        self.assertEqual(layer.weight.data[:dim, :].sum().item(), 0.0)
+        self.assertNotEqual(layer.weight.data[dim : dim * 3, :].sum().item(), 0.0)
+
+    def test_qlayer(self):
+        dim = 64
+        layer = QLayer(dim, dim * 3, q_zero_init=True)
+        layer.weight.infshape = InfShape([InfDim(dim / 2 * 3, dim * 3), InfDim(dim / 2, dim)])
+        layer.mup_initial(mode="sp")
+        self.assertEqual(layer.weight.data.sum().item(), 0.0)
+        layer.mup_initial(mode="mup")
+        self.assertEqual(layer.weight.data.sum().item(), 0.0)
+
+        layer = QLayer(dim, dim * 3, q_zero_init=False)
+        layer.mup_initial(mode="sp")
+        self.assertNotEqual(layer.weight.data.sum().item(), 0.0)
+
+    def test_output_layer(self):
+        dim = 64
+        layer = OutputLayer(dim, 100, weight_zero_init=True)
+        layer.weight.infshape = InfShape([InfDim(100, 100), InfDim(dim / 2, dim)])
+        layer.mup_initial(mode="sp")
+        self.assertEqual(layer.weight.sum().item(), 0.0)
+        layer.mup_initial(mode="mup")
+        self.assertEqual(layer.weight.sum().item(), 0.0)
+
+        layer = OutputLayer(
+            dim, 100, bias=True, weight_zero_init=False, bias_zero_init=False, sampler="normal", std=0.02
+        )
+        layer.weight.infshape = InfShape([InfDim(100, 100), InfDim(dim / 2, dim)])
+        layer.set_width_mult()
+        self.assertEqual(layer._width_mult, 2.0)
+        layer.mup_initial(mode="sp")
+        self.assertAlmostEqual(layer.weight.std().item(), 0.02, delta=0.001)
+        self.assertLessEqual(layer.bias.abs().max().item(), 1.0 / math.sqrt(64))
+        layer.mup_initial(mode="mup")
+        self.assertAlmostEqual(layer.weight.std().item(), 0.02 * math.sqrt(2.0), delta=0.001)
+        self.assertLessEqual(layer.bias.abs().max().item(), math.sqrt(2.0) / math.sqrt(64))
+
+    def test_mlp_with_sp_init(self):
+        # normal model
+        torch.manual_seed(0)
+        model = _generate_MLP(64, bias=True, batchnorm=False)
+        _init_model(model, std=0.02)
+        # mup model
+        torch.manual_seed(0)
+        mup_model = _generate_mup_MLP(64, bias=True, batchnorm=False, sampler="normal", std=0.02, bias_zero_init=False)
+        set_base_shapes(mup_model, None)
+        mup_model.mup_initial(mode="sp")
+
+        diff = 0.0
+        for (_, mp), (_, p) in zip(mup_model.named_parameters(), model.named_parameters()):
+            diff += (mp - p).abs().sum().item()
+        self.assertEqual(diff, 0.0)
+
+    def test_mlp_with_mup_init_at_base_width(self):
+        # normal model
+        torch.manual_seed(0)
+        model = _generate_MLP(64, bias=True, batchnorm=False)
+        _init_model(model, std=0.02)
+        # mup model
+        torch.manual_seed(0)
+        mup_model = _generate_mup_MLP(64, bias=True, batchnorm=False, sampler="normal", std=0.02, bias_zero_init=False)
+        set_base_shapes(mup_model, None)
+        mup_model.mup_initial(mode="mup")
+
+        diff = 0.0
+        for (_, mp), (_, p) in zip(mup_model.named_parameters(), model.named_parameters()):
+            diff += (mp - p).abs().sum().item()
+        self.assertEqual(diff, 0.0)
+
+    def test_mlp_with_mup_init_at_diff_width(self):
+        # normal model
+        torch.manual_seed(0)
+        model = _generate_MLP(64, bias=True, batchnorm=False)
+        _init_model(model, std=0.02)
+        # mup model
+        torch.manual_seed(0)
+        mup_model = _generate_mup_MLP(64, bias=True, batchnorm=False, sampler="normal", std=0.02, bias_zero_init=False)
+        base_model = _generate_mup_MLP(32, bias=True, batchnorm=False, sampler="normal", std=0.02, bias_zero_init=False)
+        set_base_shapes(mup_model, base_model)
+        mup_model.mup_initial(mode="mup")
+
+        same_name = ["0.weight", "0.bias"]
+        scale_down_name = ["2.weight"]
+        scale_up_name = ["2.bias", "4.weight", "4.bias"]
+        for (name, mp), (_, p) in zip(mup_model.named_parameters(), model.named_parameters()):
+            with self.subTest(name=name):
+                if name in same_name:
+                    self.assertAlmostEqual(mp.std().item(), p.std().item(), delta=0.001)
+                elif name in scale_down_name:
+                    self.assertAlmostEqual(mp.std().item(), p.std().item() / math.sqrt(2), delta=0.001)
+                elif name in scale_up_name:
+                    self.assertAlmostEqual(mp.std().item(), p.std().item() * math.sqrt(2), delta=0.001)
+
+
+class TestMuOptim(unittest.TestCase):
+    def _train(self, input, target, model, optimizer):
+        if torch.cuda.is_available():
+            input = input.cuda()
+            target = target.cuda()
+            model = model.cuda()
+
+        def closure():
+            output = model(input)
+            loss = nn.CrossEntropyLoss()(output, target)
+            loss.backward()
+            return loss
+
+        initial_value = closure().item()
+        for _ in range(10):
+            loss = optimizer.step(closure)
+            optimizer.zero_grad()
+
+        self.assertLess(loss.item(), initial_value)
+
+    @unittest.skipIf(not torch.cuda.is_available(), "no gpu found here.")
+    def test_MuSGD(self):
+        # 定义模型
+        model = _generate_mup_MLP(64, bias=True, batchnorm=True, sampler="normal", std=0.02, bias_zero_init=False)
+        base_model = _generate_mup_MLP(32, bias=True, batchnorm=True, sampler="normal", std=0.02, bias_zero_init=False)
+        set_base_shapes(model, base_model)
+        model.mup_initial(mode="mup")
+        # 定义优化器
+        opt = MuSGD(model.parameters(), lr=0.1, weight_decay=0.0)
+
+        self._train(
+            input=torch.randn([2, 1024]),
+            target=torch.tensor([0, 1]),
+            model=model,
+            optimizer=opt,
+        )
+
+    @unittest.skipIf(not torch.cuda.is_available(), "no gpu found here.")
+    def test_MuAdam(self):
+        # 定义模型
+        model = _generate_mup_MLP(64, bias=True, batchnorm=True, sampler="normal", std=0.02, bias_zero_init=False)
+        base_model = _generate_mup_MLP(32, bias=True, batchnorm=True, sampler="normal", std=0.02, bias_zero_init=False)
+        set_base_shapes(model, base_model)
+        model.mup_initial(mode="mup")
+        # 定义优化器
+        opt = MuAdam(model.parameters(), lr=0.1, weight_decay=0.0)
+
+        self._train(
+            input=torch.randn([2, 1024]),
+            target=torch.tensor([0, 1]),
+            model=model,
+            optimizer=opt,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/atorch/atorch/tests/common_tests/normalization_test.py
+++ b/atorch/atorch/tests/common_tests/normalization_test.py
@@ -1,0 +1,109 @@
+import random
+import unittest
+
+import torch
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import TestCase
+
+import atorch
+
+
+class TestNNDeviceType(TestCase):
+    def _test_LayerNorm_general(self, device, dtype=torch.float):
+        for i in range(2, 6):
+            shape = torch.randint(3, 6, (i,), dtype=torch.long).tolist()
+            x = torch.empty(*shape, device=device, dtype=dtype).uniform_(0, 10)
+            normalized_ndim = random.randint(1, i - 1)  # inclusive
+            normalized_shape = shape[-normalized_ndim:]
+            unnormalized_shape = shape[:-normalized_ndim]
+
+            # test that LN normalizes to mean 0 and stddev 1
+            ln = atorch.normalization.LayerNorm(normalized_shape, eps=0).to(device, dtype)
+            ln.weight.data.fill_(1)
+            ln.bias.data.fill_(0)
+            output = ln(x)
+            out_reshaped = output.view(*(unnormalized_shape + [-1]))
+            mean = out_reshaped.mean(-1)
+            var = out_reshaped.var(-1, unbiased=False)
+
+            delta = 1e-1 if dtype == torch.bfloat16 else 1e-5
+            self.assertEqual(torch.abs(mean.data).mean(), 0, atol=delta, rtol=0)
+            self.assertEqual(torch.abs(var.data).mean(), 1, atol=delta, rtol=0)
+
+            # test that LN applies weight and bias correctly
+            scale, bias = torch.empty(2).uniform_(0.2, 2).tolist()
+            ln.weight.data.fill_(scale)
+            ln.bias.data.fill_(bias)
+            output = ln(x)
+            out_reshaped = output.view(*(unnormalized_shape + [-1]))
+            mean = out_reshaped.mean(-1)
+            var = out_reshaped.var(-1, unbiased=False)
+            self.assertEqual(torch.abs(mean.data).mean(), bias, atol=delta, rtol=0)
+            self.assertEqual(torch.abs(var.data).mean(), scale**2, atol=delta, rtol=0)
+
+        bad_norm_shape_input_shape = {
+            (): (),
+            (2, 3): (3,),
+            (2,): (1, 2, 3),
+            (10,): (2, 3),
+            10: (2, 3),
+        }
+        for norm_shape, input_shape in bad_norm_shape_input_shape.items():
+            ln = atorch.normalization.LayerNorm(norm_shape)
+            input = torch.empty(input_shape, device=device, dtype=dtype).uniform_(0, 10)
+            self.assertRaises(RuntimeError, lambda: ln(input))
+
+    def _test_LayerNorm_cuda_half(self, device):
+        input = torch.empty(2, 3, 3, 2, device=device, dtype=torch.half).random_(1, 10).requires_grad_(True)
+        m = atorch.normalization.LayerNorm([3, 2]).to(device, torch.half)
+        output = m(input)
+        output.sum().backward()
+        self.assertEqualTypeString(output, input)
+
+    @unittest.skipIf(True, "Failed on gpu")
+    def test_LayerNorm_general(self, device):
+        self._test_LayerNorm_general(device)
+
+        # TODO(ya): BFloat16
+        # if self.device_type == 'cuda' or self.device_type == 'cpu':
+        #    self._test_LayerNorm_general(device, dtype=torch.bfloat16)
+
+        if self.device_type == "cuda":
+            self._test_LayerNorm_cuda_half(device)
+
+    @unittest.skipIf(True, "Failed on gpu")
+    def test_LayerNorm_numeric(self, device):
+        def layer_norm_ref(X, gamma, beta, normalized_shape, eps):
+            feature_size = torch.prod(torch.tensor(normalized_shape))
+            X_view = X.view(-1, feature_size)
+            mean = X_view.mean(dim=-1, keepdim=True)
+            var = X_view.var(dim=-1, unbiased=False, keepdim=True)
+            Y = (X_view - mean) / torch.sqrt(var + eps)
+            Y = Y * gamma.view(-1) + beta.view(-1)
+            return Y.view(*X.size())
+
+        normalized_shape = [256, 256, 144]
+        layer_norm = atorch.normalization.LayerNorm(normalized_shape).float().to(device)
+        # layer_norm = nn.LayerNorm(normalized_shape).float().to(device)
+        X = torch.rand(2, *normalized_shape, dtype=torch.float32, device=device)
+
+        Y = layer_norm(X)
+        Y_ref = layer_norm_ref(
+            X,
+            layer_norm.weight.data,
+            layer_norm.bias.data,
+            normalized_shape,
+            layer_norm.eps,
+        )
+        self.assertEqual(Y, Y_ref, rtol=0, atol=1e-2)
+
+        if self.device_type == "cuda":
+            layer_norm.cpu()
+            Y_cpu = layer_norm(X.cpu())
+            self.assertEqual(Y_cpu, Y, rtol=0, atol=1e-2)
+
+
+instantiate_device_type_tests(TestNNDeviceType, globals())
+
+if __name__ == "__main__":
+    unittest.main()

--- a/atorch/atorch/tests/common_tests/npu_test.py
+++ b/atorch/atorch/tests/common_tests/npu_test.py
@@ -1,0 +1,54 @@
+import unittest
+from itertools import product
+
+import torch
+
+
+class NPUPatchTest(unittest.TestCase):
+    @unittest.skipIf(not torch.cuda.is_available(), "we test npu patch on gpu/npu environment")
+    def test_npu_patch(self):
+        # can execute on gpu environment
+        from atorch import npu  # noqa
+
+        device = torch.device("cuda")
+        self.assertIsNotNone(torch.cuda.get_device_capability(device))
+
+    @unittest.skipIf(not torch.cuda.is_available(), "we test npu patch on gpu/npu environment")
+    def test_empty(self):
+        # can execute on gpu environment
+        from atorch import npu  # noqa
+
+        tensor = torch.randn(10, 10, device="cuda", dtype=torch.float32)
+        tensor_16 = torch.empty_like(tensor, dtype=torch.float16)
+        self.assertEqual(tensor_16.dtype, torch.float16)
+
+    @unittest.skipIf(not torch.cuda.is_available(), "we test npu patch on gpu/npu environment")
+    def test_vertor_norm(self):
+        # can execute on gpu environment
+        from atorch import npu  # noqa
+
+        tensor = torch.empty((10, 10), dtype=torch.float16, device="cuda")
+        torch.linalg.vector_norm(tensor, 2, dtype=torch.float32)
+
+    def test_dtype_diff(self):
+        # scan torch function, find is there have dtype args
+        dtypes = [torch.float16, torch.float32, torch.float64]
+        if torch.cuda.is_available() and torch.cuda.is_bf16_supported():
+            dtypes.append(torch.bfloat16)
+        for from_dtype, to_dtype in product(dtypes, dtypes):
+            with self.subTest("dtype diff", from_dtype=from_dtype, to_dtype=to_dtype):
+                tensor = torch.randn(10, 10, dtype=from_dtype)
+                tensor_t = torch.empty_like(tensor, dtype=to_dtype)
+                self.assertEqual(tensor_t.dtype, to_dtype)
+
+                if torch.cuda.is_available():
+                    from atorch import npu  # noqa
+
+                    tensor = torch.randn(
+                        10,
+                        10,
+                        dtype=from_dtype,
+                        device="cuda",
+                    )
+                    tensor_t = torch.empty_like(tensor, dtype=to_dtype)
+                    self.assertEqual(tensor_t.dtype, to_dtype)

--- a/atorch/atorch/tests/common_tests/optim_test.py
+++ b/atorch/atorch/tests/common_tests/optim_test.py
@@ -1,0 +1,391 @@
+import functools
+import unittest
+from copy import deepcopy
+
+import torch
+from torch.autograd import Variable
+from torch.optim.lr_scheduler import ReduceLROnPlateau
+from torch.testing._internal.common_utils import TestCase
+
+from atorch.utils.import_util import is_torch_npu_available
+
+
+class TestOptim(TestCase):
+    def _build_params_dict_single(self, weight, bias, **kwargs):
+        return [dict(params=bias, **kwargs)]
+
+    def _build_params_dict(self, weight, bias, **kwargs):
+        return [{"params": [weight]}, dict(params=[bias], **kwargs)]
+
+    def _test_basic_cases_template(self, weight, bias, input, constructor, scheduler_constructors):
+        weight = Variable(weight, requires_grad=True)
+        bias = Variable(bias, requires_grad=True)
+        input = Variable(input)
+        optimizer = constructor(weight, bias)
+        schedulers = []
+        for scheduler_constructor in scheduler_constructors:
+            schedulers.append(scheduler_constructor(optimizer))
+
+        # to check if the optimizer can be printed as a string
+        optimizer.__repr__()
+
+        def fn():
+            optimizer.zero_grad()
+            y = weight.mv(input)
+            if y.is_cuda and bias.is_cuda and y.get_device() != bias.get_device():
+                y = y.cuda(bias.get_device())
+            loss = (y + bias).pow(2).sum()
+            loss.backward()
+            return loss
+
+        initial_value = fn().item()
+        for _i in range(200):
+            for scheduler in schedulers:
+                if isinstance(scheduler, ReduceLROnPlateau):
+                    val_loss = fn()
+                    scheduler.step(val_loss)
+                else:
+                    scheduler.step()
+            optimizer.step(fn)
+        self.assertLess(fn().item(), initial_value)
+
+    def _test_state_dict(self, weight, bias, input, constructor):
+        weight = Variable(weight, requires_grad=True)
+        bias = Variable(bias, requires_grad=True)
+        input = Variable(input)
+
+        def fn_base(optimizer, weight, bias):
+            optimizer.zero_grad()
+            i = input_cuda if weight.is_cuda else input
+            loss = (weight.mv(i) + bias).pow(2).sum()
+            loss.backward()
+            return loss
+
+        optimizer = constructor(weight, bias)
+        fn = functools.partial(fn_base, optimizer, weight, bias)
+
+        # Prime the optimizer
+        for _i in range(20):
+            optimizer.step(fn)
+        # Clone the weights and construct new optimizer for them
+        weight_c = Variable(weight.data.clone(), requires_grad=True)
+        bias_c = Variable(bias.data.clone(), requires_grad=True)
+        optimizer_c = constructor(weight_c, bias_c)
+        fn_c = functools.partial(fn_base, optimizer_c, weight_c, bias_c)
+        # Load state dict
+        state_dict = deepcopy(optimizer.state_dict())
+        state_dict_c = deepcopy(optimizer.state_dict())
+        optimizer_c.load_state_dict(state_dict_c)
+        # Make sure state_dict_c isn't modified by merely calling load_state_dict
+        self.assertEqual(state_dict, state_dict_c)
+        # Run both optimizations in parallel
+        for _i in range(20):
+            optimizer.step(fn)
+            optimizer_c.step(fn_c)
+            self.assertEqual(weight, weight_c)
+            self.assertEqual(bias, bias_c)
+
+        # Make sure state dict is deterministic with equal but not
+        # identical parameters
+        self.assertEqual(optimizer.state_dict(), optimizer_c.state_dict())
+        # Make sure repeated parameters have identical representation
+        # in state dict
+        optimizer_c.param_groups.extend(optimizer_c.param_groups)
+        self.assertEqual(
+            optimizer.state_dict()["param_groups"][-1],
+            optimizer_c.state_dict()["param_groups"][-1],
+        )
+
+        # Check that state dict can be loaded even when we cast parameters
+        # to a different type and move to a different device.
+        if not torch.cuda.is_available():
+            return
+
+        input_cuda = Variable(input.data.float().cuda())
+        weight_cuda = Variable(weight.data.float().cuda(), requires_grad=True)
+        bias_cuda = Variable(bias.data.float().cuda(), requires_grad=True)
+        optimizer_cuda = constructor(weight_cuda, bias_cuda)
+        fn_cuda = functools.partial(fn_base, optimizer_cuda, weight_cuda, bias_cuda)
+
+        state_dict = deepcopy(optimizer.state_dict())
+        state_dict_c = deepcopy(optimizer.state_dict())
+        optimizer_cuda.load_state_dict(state_dict_c)
+
+        # Make sure state_dict_c isn't modified by merely calling load_state_dict
+        self.assertEqual(state_dict, state_dict_c)
+
+        for _i in range(20):
+            optimizer.step(fn)
+            optimizer_cuda.step(fn_cuda)
+            self.assertEqual(weight, weight_cuda)
+            self.assertEqual(bias, bias_cuda)
+
+        # validate deepcopy() copies all public attributes
+        def getPublicAttr(obj):
+            return set(k for k in obj.__dict__ if not k.startswith("_"))
+
+        self.assertEqual(getPublicAttr(optimizer), getPublicAttr(deepcopy(optimizer)))
+
+    def _test_basic_cases(
+        self,
+        constructor,
+        scheduler_constructors=None,
+        ignore_multidevice=False,
+    ):
+        if scheduler_constructors is None:
+            scheduler_constructors = []
+        self._test_state_dict(torch.randn(10, 5), torch.randn(10), torch.randn(5), constructor)
+        self._test_basic_cases_template(
+            torch.randn(10, 5),
+            torch.randn(10),
+            torch.randn(5),
+            constructor,
+            scheduler_constructors,
+        )
+        # non-contiguous parameters
+        self._test_basic_cases_template(
+            torch.randn(10, 5, 2)[..., 0],
+            torch.randn(10, 2)[..., 0],
+            torch.randn(5),
+            constructor,
+            scheduler_constructors,
+        )
+        # CUDA
+        if not torch.cuda.is_available():
+            return
+        self._test_basic_cases_template(
+            torch.randn(10, 5).cuda(),
+            torch.randn(10).cuda(),
+            torch.randn(5).cuda(),
+            constructor,
+            scheduler_constructors,
+        )
+        # Multi-GPU
+        if not torch.cuda.device_count() > 1 or ignore_multidevice:
+            return
+        self._test_basic_cases_template(
+            torch.randn(10, 5).cuda(0),
+            torch.randn(10).cuda(1),
+            torch.randn(5).cuda(0),
+            constructor,
+            scheduler_constructors,
+        )
+
+    @unittest.skipIf(not torch.cuda.is_available(), "no gpu found here.")
+    def test_agd(self):
+        from atorch.optimizers import AGD
+
+        optimizer = AGD
+        self._test_basic_cases(lambda weight, bias: optimizer([weight, bias], lr=1e-3))
+        self._test_basic_cases(lambda weight, bias: optimizer([weight, bias], lr=1e-3, delta=1e-8))
+        self._test_basic_cases(lambda weight, bias: optimizer(self._build_params_dict(weight, bias, lr=1e-2), lr=1e-3))
+        self._test_basic_cases(lambda weight, bias: optimizer([weight, bias], lr=1e-3, weight_decay=1))
+        self._test_basic_cases(lambda weight, bias: optimizer([weight, bias], lr=1e-3, weight_decay=1, amsgrad=True))
+        with self.assertRaisesRegex(ValueError, "Invalid weight_decay value: -1"):
+            optimizer(None, lr=1e-2, weight_decay=-1)
+
+    @unittest.skipIf(not torch.cuda.is_available(), "no gpu found here.")
+    def test_q_adamw(self):
+        from atorch.optimizers.low_bit import Q_AdamW
+
+        optimizer = Q_AdamW
+        self._test_basic_cases(lambda weight, bias: optimizer([weight, bias], lr=1e-3))
+        self._test_basic_cases(lambda weight, bias: optimizer(self._build_params_dict(weight, bias, lr=1e-2), lr=1e-3))
+        self._test_basic_cases(lambda weight, bias: optimizer([weight, bias], lr=1e-3, eps=1e-8))
+        self._test_basic_cases(lambda weight, bias: optimizer([weight, bias], lr=1e-3, weight_decay=1e-2))
+        self._test_basic_cases(lambda weight, bias: optimizer([weight, bias], lr=1e-3, q_bits=8))
+        with self.assertRaisesRegex(ValueError, "Invalid q_bits value: 0"):
+            optimizer(None, lr=1e-3, q_bits=0)
+        with self.assertRaisesRegex(ValueError, "Invalid q_bits value: 9"):
+            optimizer(None, lr=1e-3, q_bits=9)
+        with self.assertRaisesRegex(ValueError, "Invalid q_bits value: 3.5"):
+            optimizer(None, lr=1e-3, q_bits=3.5)
+
+    @unittest.skipIf(not torch.cuda.is_available(), "no gpu found here.")
+    def test_q_agd(self):
+        from atorch.optimizers.low_bit import Q_AGD
+
+        optimizer = Q_AGD
+        self._test_basic_cases(lambda weight, bias: optimizer([weight, bias], lr=1e-3))
+        self._test_basic_cases(lambda weight, bias: optimizer(self._build_params_dict(weight, bias, lr=1e-2), lr=1e-3))
+        self._test_basic_cases(lambda weight, bias: optimizer([weight, bias], lr=1e-3, delta=1e-8))
+        self._test_basic_cases(lambda weight, bias: optimizer([weight, bias], lr=1e-3, weight_decay=1e-2))
+        self._test_basic_cases(lambda weight, bias: optimizer([weight, bias], lr=1e-3, amsgrad=True))
+        self._test_basic_cases(lambda weight, bias: optimizer([weight, bias], lr=1e-3, q_bits=8))
+        with self.assertRaisesRegex(ValueError, "Invalid q_bits value: 0"):
+            optimizer(None, lr=1e-3, q_bits=0)
+        with self.assertRaisesRegex(ValueError, "Invalid q_bits value: 9"):
+            optimizer(None, lr=1e-3, q_bits=9)
+        with self.assertRaisesRegex(ValueError, "Invalid q_bits value: 3.5"):
+            optimizer(None, lr=1e-3, q_bits=3.5)
+
+    @unittest.skipIf(not torch.cuda.is_available(), "no gpu found here.")
+    def test_q_came(self):
+        from atorch.optimizers.low_bit import Q_CAME
+
+        optimizer = Q_CAME
+        self._test_basic_cases(lambda weight, bias: optimizer([weight, bias], lr=1e-3))
+        self._test_basic_cases(lambda weight, bias: optimizer(self._build_params_dict(weight, bias, lr=1e-2), lr=1e-3))
+        self._test_basic_cases(lambda weight, bias: optimizer([weight, bias], lr=1e-3, eps=(1e-30, 1e-16)))
+        self._test_basic_cases(lambda weight, bias: optimizer([weight, bias], lr=1e-3, weight_decay=1e-2))
+        self._test_basic_cases(lambda weight, bias: optimizer([weight, bias], lr=1e-3, q_bits=8))
+        with self.assertRaisesRegex(ValueError, "Invalid q_bits value: 0"):
+            optimizer(None, lr=1e-3, q_bits=0)
+        with self.assertRaisesRegex(ValueError, "Invalid q_bits value: 9"):
+            optimizer(None, lr=1e-3, q_bits=9)
+        with self.assertRaisesRegex(ValueError, "Invalid q_bits value: 3.5"):
+            optimizer(None, lr=1e-3, q_bits=3.5)
+
+    @unittest.skipIf(not torch.cuda.is_available(), "no gpu found here.")
+    def test_q_adafactor(self):
+        from atorch.optimizers.low_bit import Q_Adafactor
+
+        optimizer = Q_Adafactor
+        self._test_basic_cases(lambda weight, bias: optimizer([weight, bias], lr=1e-3))
+        self._test_basic_cases(lambda weight, bias: optimizer(self._build_params_dict(weight, bias, lr=1e-2), lr=1e-3))
+        self._test_basic_cases(lambda weight, bias: optimizer([weight, bias], lr=1e-3, eps2=(1e-30, 1e-3)))
+        self._test_basic_cases(lambda weight, bias: optimizer([weight, bias], lr=1e-3, beta1=0.9))
+        self._test_basic_cases(
+            lambda weight, bias: optimizer(
+                [weight, bias], lr=1e-3, weight_decay=1e-2, scale_parameter=False, relative_step=False
+            )
+        )
+        self._test_basic_cases(
+            lambda weight, bias: optimizer(
+                [weight, bias], lr=1e-3, scale_parameter=False, relative_step=False, q_bits=8
+            )
+        )
+        with self.assertRaisesRegex(ValueError, "Invalid q_bits value: 0"):
+            optimizer(None, lr=1e-3, q_bits=0)
+        with self.assertRaisesRegex(ValueError, "Invalid q_bits value: 9"):
+            optimizer(None, lr=1e-3, q_bits=9)
+        with self.assertRaisesRegex(ValueError, "Invalid q_bits value: 3.5"):
+            optimizer(None, lr=1e-3, q_bits=3.5)
+
+    @unittest.skipIf(not is_torch_npu_available(), "no npu found here")
+    def test_npu_adamw(self):
+        from atorch.npu.optim import NpuAdamW
+
+        optimizer = NpuAdamW
+        self._test_basic_cases_template(
+            torch.randn(10, 5).npu(),
+            torch.randn(10).npu(),
+            torch.randn(5).npu(),
+            lambda weight, bias: optimizer([weight, bias], lr=1e-3),
+            [],
+        )
+        self._test_basic_cases_template(
+            torch.randn(10, 5).npu(),
+            torch.randn(10).npu(),
+            torch.randn(5).npu(),
+            lambda weight, bias: optimizer(self._build_params_dict(weight, bias, lr=1e-3), lr=1e-3),
+            [],
+        )
+        self._test_basic_cases_template(
+            torch.randn(10, 5).npu(),
+            torch.randn(10).npu(),
+            torch.randn(5).npu(),
+            lambda weight, bias: optimizer([weight, bias], lr=1e-3, eps=1e-8),
+            [],
+        )
+        self._test_basic_cases_template(
+            torch.randn(10, 5).npu(),
+            torch.randn(10).npu(),
+            torch.randn(5).npu(),
+            lambda weight, bias: optimizer([weight, bias], lr=1e-3, weight_decay=1e-2),
+            [],
+        )
+        with self.assertRaisesRegex(ValueError, "Invalid weight_decay value: -1"):
+            optimizer(None, lr=1e-2, weight_decay=-1)
+
+    @unittest.skipIf(not is_torch_npu_available(), "no npu found here")
+    def test_npu_adamw_compare_with_cpu(self):
+        from atorch.npu.optim import NpuAdamW
+
+        weight_value = torch.randn(10, 5)
+        bias_value = torch.randn(10)
+        input_value = torch.randn(5)
+        weight_cpu = Variable(weight_value, requires_grad=True)
+        bias_cpu = Variable(bias_value, requires_grad=True)
+        input_cpu = Variable(input_value)
+
+        weight_npu = Variable(weight_value.npu(), requires_grad=True)
+        bias_npu = Variable(bias_value.npu(), requires_grad=True)
+        input_npu = Variable(input_value.npu(), requires_grad=True)
+
+        ori_optim = torch.optim.AdamW([weight_cpu, bias_cpu], lr=1e-3)
+        ori_optim.zero_grad()
+        y_cpu = weight_cpu.mv(input_cpu)
+        loss_cpu = (y_cpu + bias_cpu).pow(2).sum()
+        loss_cpu.backward()
+        ori_optim.step()
+
+        npu_optim = NpuAdamW([weight_npu, bias_npu], lr=1e-3)
+        npu_optim.zero_grad()
+        y_npu = weight_npu.mv(input_npu)
+        loss_npu = (y_npu + bias_npu).pow(2).sum()
+        loss_npu.backward()
+        npu_optim.step()
+
+        torch.testing.assert_close(weight_npu.cpu(), weight_cpu)
+        torch.testing.assert_close(bias_npu.cpu(), bias_cpu)
+
+
+class TestSamOptim(TestCase):
+    def setUp(self):
+        class TinyModel(torch.nn.Module):
+            def __init__(self):
+                super(TinyModel, self).__init__()
+                self.linear = torch.nn.Linear(5, 10)
+
+            def forward(self, x):
+                x = self.linear(x)
+                return torch.norm(x)
+
+        self._model_class = TinyModel
+
+    def _test_basic_case_template(self, input, model, optimizer):
+        if torch.cuda.is_available():
+            input = input.cuda()
+            model = model.cuda()
+
+        def closure():
+            loss = model(input)
+            loss.backward()
+            return loss
+
+        initial_value = closure().item()
+        for _ in range(100):
+            loss = optimizer.step(closure)
+            optimizer.zero_grad()
+
+        self.assertLess(loss.item(), initial_value)
+
+    def _test_basic_cases(self, constructor, **args):
+        model = self._model_class()
+        base_opt = torch.optim.SGD(model.parameters(), lr=0.1)
+        self._test_basic_case_template(
+            input=torch.randn(5),
+            model=model,
+            optimizer=constructor(model, base_opt, **args),
+        )
+        model = self._model_class()
+        base_opt = torch.optim.Adam(model.parameters(), lr=0.001)
+        self._test_basic_case_template(
+            input=torch.randn(5),
+            model=model,
+            optimizer=constructor(model, base_opt, **args),
+        )
+
+    @unittest.skipIf(not torch.cuda.is_available(), "no gpu found here.")
+    def test_wsam(self):
+        from atorch.optimizers import WeightedSAM
+
+        self._test_basic_cases(WeightedSAM, rho=0.1)
+        self._test_basic_cases(WeightedSAM, rho=0.1, gamma=0.5)
+        with self.assertRaisesRegex(AssertionError, "Invalid rho, should be non-negative: -1"):
+            WeightedSAM(None, None, rho=-1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/atorch/atorch/tests/common_tests/optimizations_test.py
+++ b/atorch/atorch/tests/common_tests/optimizations_test.py
@@ -1,0 +1,56 @@
+import copy
+import unittest
+
+import torch
+
+from atorch.auto.accelerate import model_transform
+from atorch.auto.auto_accelerate_context import AutoAccelerateContext
+from atorch.auto.opt_lib.optimization_library import OptimizationLibrary
+from atorch.auto.strategy import Strategy
+from atorch.tests.toy_modules.toy_module import create_model_context, run_train
+
+
+class OptimizationsTest(unittest.TestCase):
+    def setUp(self):
+        device = "cuda:0" if torch.cuda.is_available() else "cpu"
+        data_size = 8
+        batch_size = 2
+        model_context = create_model_context(data_size=data_size, batch_size=batch_size, use_optim_param_func=True)
+        model_context.model.to(device)
+        self.mc = model_context
+        self.data_size = data_size
+        self.batch_size = batch_size
+        self.opt_lib = OptimizationLibrary()
+        self.device = device
+
+    def run_test(self, mc, strategy, input_dtype=torch.float32):
+        model_context = model_transform(mc, strategy, self.opt_lib)
+        num = run_train(
+            model_context.model,
+            model_context.dataloader,
+            model_context.optim,
+            model_context.prepare_input,
+            model_context.loss_func,
+            self.device,
+            input_dtype=input_dtype,
+        )
+        self.assertEqual(num, self.data_size // self.batch_size)
+
+    def test_checkpoint(self):
+        module_type = "ToyCustomModule"
+        mc = copy.deepcopy(self.mc)
+        strategy = Strategy([("checkpoint", module_type, False)])
+        self.run_test(mc, strategy)
+
+    @unittest.skipIf(not torch.cuda.is_available(), "half is only supported by gpu")
+    def test_half(self):
+        mc = copy.deepcopy(self.mc)
+        config = "fp16"
+        strategy = Strategy([("half", config, False)])
+        self.run_test(mc, strategy, torch.float16)
+
+        AutoAccelerateContext.counter += 1
+        mc = copy.deepcopy(self.mc)
+        config = "bf16"
+        strategy = Strategy([("half", config, False)])
+        self.run_test(mc, strategy, torch.bfloat16)

--- a/atorch/atorch/tests/common_tests/optimizer_offload_test.py
+++ b/atorch/atorch/tests/common_tests/optimizer_offload_test.py
@@ -1,0 +1,35 @@
+# coding=utf-8
+from __future__ import absolute_import, unicode_literals
+
+import unittest
+
+import torch
+import torch.nn
+
+try:
+    from atorch.optimizers.adam_offload import PartitionAdam
+
+    is_apex_available = True
+except (ModuleNotFoundError, ImportError):
+    is_apex_available = False
+
+
+@unittest.skipIf(not torch.cuda.is_available(), "Offload optimizer need apex and gpu")
+@unittest.skipIf(not is_apex_available, "PartitionAdam import error, need apex and gpu")
+class OffloadOptimizerTest(unittest.TestCase):
+    def test_optimizer_state_dict(self):
+        device = torch.device("cuda")
+        model = torch.nn.Linear(10, 20).to(device)
+        optimizer = PartitionAdam([{"params": model.parameters()}])
+
+        x = torch.randn(10, 10, device=device)
+        y = model(x)
+        dy = torch.randn_like(y)
+        y.backward(dy)
+
+        optimizer.state_dict()
+        optimizer.step()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/atorch/atorch/tests/common_tests/pipeline_parallel_optimization_test.py
+++ b/atorch/atorch/tests/common_tests/pipeline_parallel_optimization_test.py
@@ -1,0 +1,79 @@
+import pkgutil
+import unittest
+
+import torch
+from torch.utils.data import Dataset
+
+from atorch.auto.model_context import ModelContext
+from atorch.auto.opt_lib.pipeline_parallel_optimization import PipelineParallelOptimization
+
+
+class MyModule(torch.nn.Module):
+    def __init__(self, in_features, out_features, bias=True):
+        super().__init__()
+        self.layer = torch.nn.Linear(in_features, out_features, bias=bias)
+        self.layers = torch.nn.ModuleList([torch.nn.Linear(out_features, out_features, bias=bias) for _ in range(16)])
+
+    def forward(self, input_):
+        data = torch.nn.functional.softmax(self.layer(input_[0]), dim=-1)
+        for op in self.layers:
+            data = op(data)
+            data = torch.nn.functional.softmax(data, dim=-1)
+        return data
+
+
+class ToyDataset(Dataset):
+    def __init__(self, size):
+        self.size = size
+
+    def __len__(self):
+        return self.size
+
+    def __getitem__(self, idx):
+        return torch.rand((7, 32)), torch.randn(16)
+
+
+def prepare_input(data, device):
+    return data[0].to(device), data[1].to(device)
+
+
+def create_model_context(data_size=16, batch_size=3):
+    model = MyModule(32, 16, True)
+    dataset = ToyDataset(data_size)
+    model_context = ModelContext(
+        model=model,
+        dataset=dataset,
+        prepare_input=prepare_input,
+        dataloader_args={"batch_size": batch_size, "drop_last": True},
+    )
+    return model_context
+
+
+def _run_pipeline_parallel_optimization(num_nodes=1, num_devices_per_node=2):
+    # This is mock test for PipelineParallelOptimization
+    # Test to make sure TP can generate a splitting (through insert_before_nodes)
+    torch.manual_seed(42)
+
+    model_context = create_model_context()
+
+    parallel_optimization = PipelineParallelOptimization(
+        shard_planner="equal_size",
+        num_nodes=num_nodes,
+        num_devices_per_node=num_devices_per_node,
+        tracer_backend="meta_fx",
+        prop_mode="meta_tracer",
+    )
+
+    status, best_config, model_context = parallel_optimization.tune(model_context, {"pipe_ranks": [0, 1]}, [])
+    compiler_configs = best_config["compiler_configs"]
+    assert status and "insert_before_nodes" in compiler_configs
+
+
+class TestPipelineParallelOptimization(unittest.TestCase):
+    @unittest.skipIf(not pkgutil.find_loader("pippy"), "PiPPy non existent, skip pipe test")
+    def test_pipeline_parallel_optimization(self):
+        _run_pipeline_parallel_optimization()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/atorch/atorch/tests/common_tests/pipeline_test.py
+++ b/atorch/atorch/tests/common_tests/pipeline_test.py
@@ -1,0 +1,532 @@
+"""This is to verify that pipe model has the same behavior as the normal modules,
+in composition with amp.
+
+"""
+import copy
+import os
+import random
+import unittest
+
+import numpy as np
+import torch
+import torch.distributed.rpc as torch_rpc
+import torch.multiprocessing as mp
+from torch.nn import MSELoss
+from torch.utils.data import Dataset
+
+import atorch
+from atorch.auto.model_context import ModelContext
+from atorch.auto.opt_lib.amp_optimization import AmpNativeOptimization
+from atorch.common.util_func import find_free_port
+from atorch.distributed.distributed import create_parallel_group, destroy_parallel_group, parallel_group
+from atorch.modules.distributed_modules.compilers.pipe_compiler.distributed_pippy_compiler import (
+    DeviceSafeDriver,
+    SafeStage,
+)
+from atorch.utils.meta_model_utils import deepcopy_checkpoint_name
+from atorch.utils.pipe_file_utils import atorch_load_pipe_checkpoint, atorch_save_pipe_checkpoint
+from atorch.utils.version import torch_version
+
+
+def seed_everything(seed=42):
+    random.seed(seed)  # Python's random module
+    np.random.seed(seed)  # Numpy
+    torch.manual_seed(seed)  # PyTorch
+
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed(seed)  # CUDA
+        torch.backends.cudnn.deterministic = True
+        torch.backends.cudnn.benchmark = False
+
+
+class MyModule(torch.nn.Module):
+    def __init__(self, in_features, out_features, bias=True):
+        super().__init__()
+        self.layer = torch.nn.Linear(in_features, out_features, bias=bias)
+        self.layers = torch.nn.ModuleList([torch.nn.Linear(out_features, out_features, bias=bias) for _ in range(16)])
+
+    def forward(self, input_):
+        data = torch.nn.functional.gelu(self.layer(input_[0]))
+        for op in self.layers:
+            data = op(data)
+            data = torch.nn.functional.gelu(data)
+        return data
+
+
+class ToyDataset(Dataset):
+    def __init__(self, size):
+        self.size = size
+
+    def __len__(self):
+        return self.size
+
+    def __getitem__(self, idx):
+        return torch.ones((7, 32)), torch.zeros((7, 16))
+
+
+def prepare_input(data, device):
+    return data[0].to(device), data[1].to(device)
+
+
+def my_loss_func(data, outputs):
+    loss_fct = MSELoss()
+    loss = loss_fct(outputs.view(-1), data[-1].view(-1))
+    return loss
+
+
+def create_model_context(data_size=512, batch_size=16, loss_func=None):
+    model = MyModule(32, 16, True)
+    dataset = ToyDataset(data_size)
+    model_context = ModelContext(
+        model=model,
+        optim_func=torch.optim.SGD,
+        dataset=dataset,
+        prepare_input=prepare_input,
+        dataloader_args={"batch_size": batch_size, "drop_last": True},
+        optim_args={"lr": 0.001},
+        loss_func=loss_func,
+    )
+    return model_context
+
+
+def generate_pipe_configs(model_context, pipe_config=dict()):
+    """Allowing pipe_configs gives us the flexibility to test different schedules"""
+    from atorch.auto.opt_lib.pipeline_parallel_optimization import PipelineParallelOptimization
+
+    pipe_opt = PipelineParallelOptimization()
+    status, best_config, model_context = pipe_opt.tune(model_context, config=pipe_config, strategy=[])
+    assert status, "PipelineParallelOptimization failed to tune"
+    return best_config
+
+
+def init_pipe_distributed(rank, world_size):
+    # set random state
+    seed_everything()
+
+    if not torch.distributed.is_initialized():
+        os.environ["LOCAL_RANK"] = str(rank)
+        os.environ["RANK"] = str(rank)
+        os.environ["WORLD_SIZE"] = str(world_size)
+        os.environ["NPROC_PER_NODE"] = str(world_size)
+        if torch.cuda.is_available():
+            atorch.init_distributed("nccl")
+            torch.cuda.set_device(rank)
+        else:
+            atorch.init_distributed("gloo")
+    if parallel_group("pipe") is None:
+        gpu_partition = ([("pipe", world_size)], None)
+        create_parallel_group(gpu_partition)
+
+
+def run_two_steps_return_the_last(rank, model_context):
+    model = model_context.model
+    dataloader = model_context.dataloader
+    loss_func = model_context.loss_func
+    if loss_func is not None:
+        optimizer = model_context.optim
+    prepare_input = model_context.prepare_input
+    device = f"cuda:{rank}" if torch.cuda.is_available() else "cpu"
+
+    for step, batch in enumerate(dataloader):
+        batch = prepare_input(batch, device)
+        if isinstance(model, DeviceSafeDriver):
+            if rank == 0 or rank == "0":
+                outputs = model(batch)
+                if loss_func is not None:
+                    loss = loss_func(batch, outputs)
+                    loss.backward()
+                    optimizer.step()
+                    optimizer.zero_grad()
+                if step == 2:
+                    return outputs if loss_func is None else loss
+            else:
+                return torch.zeros((1,))
+        else:
+            outputs = model(batch)
+            if loss_func is not None:
+                loss = loss_func(batch, outputs)
+                loss.backward()
+                optimizer.step()
+                optimizer.zero_grad()
+            if step == 2:
+                # For PipeStage mode the last stage returns the loss
+                if isinstance(model, SafeStage):
+                    if rank == atorch.world_size() - 1:
+                        return outputs if loss_func is None else loss
+                    else:
+                        return torch.zeros((1,))
+                else:
+                    return outputs if loss_func is None else loss
+
+
+def run_pipeline(rank, world_size, pipe_config=dict(), amp_config=None, loss_func=None):
+    from atorch.auto.opt_lib.pipeline_parallel_optimization import PipelineParallelOptimization
+
+    init_pipe_distributed(rank, world_size)
+    model_context = create_model_context(loss_func=loss_func)
+    model_context_copy = copy.deepcopy(model_context)
+    deepcopy_checkpoint_name(model_context_copy.model, model_context.model)
+    if torch.cuda.is_available():
+        model_context.model.cuda()
+        model_context_copy.model.cuda()
+    # the result is deterministic on each rank
+    best_config = generate_pipe_configs(model_context_copy, pipe_config)
+    if amp_config is not None:
+        best_config["compiler_configs"]["amp_config"] = amp_config
+    PipelineParallelOptimization.apply_wrapper(model_context_copy, "pipe", best_config)
+
+    model_context.update_dataloader()
+    model_context_copy.update_dataloader()
+    if loss_func is not None:
+        model_context.update_optim()
+        model_context_copy.update_optim()
+
+    if amp_config is not None:
+        AmpNativeOptimization.apply_wrapper(model_context, "amp_native", amp_config)
+
+    outputs = run_two_steps_return_the_last(rank, model_context)
+
+    pipe_outputs = run_two_steps_return_the_last(rank, model_context_copy)
+    outputs = (
+        torch.zeros((1,))
+        if pipe_outputs.device == torch.device("cpu") and torch.all(pipe_outputs == torch.zeros((1,)))
+        else outputs
+    )
+    if loss_func is not None:
+        chunks = pipe_config.get("chunks", 1)
+        pipe_outputs /= chunks
+    torch_rpc.api._wait_all_workers()
+    assert torch.allclose(
+        outputs, pipe_outputs, rtol=1e-4, atol=1e-4
+    ), f"Expected: ({outputs.shape}) {outputs} but pipe outputs ({pipe_outputs.shape}): {pipe_outputs}"
+    destroy_parallel_group()
+
+
+def run_save_and_load(rank, world_size, pipe_config=dict(), amp_config=None, loss_func=None):
+    from atorch.auto.opt_lib.pipeline_parallel_optimization import PipelineParallelOptimization
+
+    pipe_config["use_c10d"] = True
+    init_pipe_distributed(rank, world_size)
+    model_context = create_model_context(loss_func=loss_func)
+    deepcopy_checkpoint_name(model_context.model, model_context.model)
+    if torch.cuda.is_available():
+        model_context.model.cuda()
+
+    # the result is deterministic on each rank
+    best_config = generate_pipe_configs(model_context, pipe_config)
+    if amp_config is not None:
+        best_config["compiler_configs"]["amp_config"] = amp_config
+    PipelineParallelOptimization.apply_wrapper(model_context, "pipe", best_config)
+    model_context.update_dataloader()
+    if loss_func is not None:
+        model_context.update_optim()
+
+    optimizer = model_context.optim if loss_func is not None else None
+    # first save model
+    atorch_save_pipe_checkpoint(model_context.model, optimizer=optimizer)
+
+    # Force the submod into meta
+    model_context.model.to("meta")
+
+    device = f"cuda:{rank}" if torch.cuda.is_available() else "cpu"
+    atorch_load_pipe_checkpoint(model_context.model, optim=optimizer, device=device)
+    # Then run a train step to verify the reload success
+    run_two_steps_return_the_last(rank, model_context)
+
+
+class TestPipeMLP(unittest.TestCase):
+    def tearDown(self):
+        destroy_parallel_group()
+        return super().tearDown()
+
+    @unittest.skipIf(True, "Enable CPU test until aci image upgraded")
+    def test_cpu_inference(self):
+        world_size = 2
+        pipe_config = {"nstages": world_size, "chunks": world_size}
+        amp_config = None
+        loss_func = None
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = str(find_free_port())
+        mp.spawn(
+            run_pipeline,
+            args=(world_size, pipe_config, amp_config, loss_func),
+            nprocs=world_size,
+            join=True,
+        )
+        os.environ["MASTER_ADDR"] = ""
+        os.environ["MASTER_PORT"] = ""
+
+    @unittest.skipIf(True, "Enable CPU test until aci image upgraded")
+    def test_cpu_interleaved_inference(self):
+        world_size = 2
+        pipe_config = {"nstages": 2 * world_size, "chunks": world_size}
+        amp_config = None
+        loss_func = None
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = str(find_free_port())
+        mp.spawn(
+            run_pipeline,
+            args=(world_size, pipe_config, amp_config, loss_func),
+            nprocs=world_size,
+            join=True,
+        )
+        os.environ["MASTER_ADDR"] = ""
+        os.environ["MASTER_PORT"] = ""
+
+    @unittest.skipIf(True, "Enable CPU test until aci image upgraded")
+    def test_cpu_train(self):
+        world_size = 2
+        pipe_config = {"nstages": world_size, "chunks": world_size}
+        amp_config = None
+        loss_func = my_loss_func
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = str(find_free_port())
+        mp.spawn(
+            run_pipeline,
+            args=(world_size, pipe_config, amp_config, loss_func),
+            nprocs=world_size,
+            join=True,
+        )
+        os.environ["MASTER_ADDR"] = ""
+        os.environ["MASTER_PORT"] = ""
+
+    @unittest.skipIf(True, "Enable CPU test until aci image upgraded")
+    def test_cpu_interleaved_train(self):
+        world_size = 2
+        pipe_config = {"nstages": 2 * world_size, "chunks": world_size}
+        amp_config = None
+        loss_func = my_loss_func
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = str(find_free_port())
+        mp.spawn(
+            run_pipeline,
+            args=(world_size, pipe_config, amp_config, loss_func),
+            nprocs=world_size,
+            join=True,
+        )
+        os.environ["MASTER_ADDR"] = ""
+        os.environ["MASTER_PORT"] = ""
+
+    @unittest.skipIf(
+        not torch.cuda.is_available() or torch.cuda.device_count() < 2,
+        "Must have at least 2 GPUs for gpu pipeline test",
+    )
+    def test_gpu_inference(self):
+        world_size = 2
+        pipe_config = {"nstages": world_size, "chunks": world_size}
+        amp_config = None
+        loss_func = None
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = str(find_free_port())
+        mp.spawn(
+            run_pipeline,
+            args=(world_size, pipe_config, amp_config, loss_func),
+            nprocs=world_size,
+            join=True,
+        )
+        os.environ["MASTER_ADDR"] = ""
+        os.environ["MASTER_PORT"] = ""
+
+    @unittest.skipIf(
+        not torch.cuda.is_available() or torch.cuda.device_count() < 2,
+        "Must have at least 2 GPUs for gpu pipeline test",
+    )
+    def test_gpu_interleaved_inference(self):
+        world_size = 2
+        pipe_config = {"nstages": 2 * world_size, "chunks": world_size}
+        amp_config = None
+        loss_func = None
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = str(find_free_port())
+        mp.spawn(
+            run_pipeline,
+            args=(world_size, pipe_config, amp_config, loss_func),
+            nprocs=world_size,
+            join=True,
+        )
+        os.environ["MASTER_ADDR"] = ""
+        os.environ["MASTER_PORT"] = ""
+
+    @unittest.skipIf(True, "Test covered in amp mode pipe teset")
+    def test_gpu_train(self):
+        world_size = 2
+        pipe_config = {"nstages": world_size, "chunks": world_size}
+        amp_config = None
+        loss_func = my_loss_func
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = str(find_free_port())
+        mp.spawn(
+            run_pipeline,
+            args=(world_size, pipe_config, amp_config, loss_func),
+            nprocs=world_size,
+            join=True,
+        )
+        os.environ["MASTER_ADDR"] = ""
+        os.environ["MASTER_PORT"] = ""
+
+    @unittest.skipIf(True, "Test covered in amp mode pipe teset")
+    def test_gpu_interleaved_train(self):
+        world_size = 2
+        pipe_config = {"nstages": 2 * world_size, "chunks": world_size}
+        amp_config = None
+        loss_func = my_loss_func
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = str(find_free_port())
+        mp.spawn(
+            run_pipeline,
+            args=(world_size, pipe_config, amp_config, loss_func),
+            nprocs=world_size,
+            join=True,
+        )
+        os.environ["MASTER_ADDR"] = ""
+        os.environ["MASTER_PORT"] = ""
+
+    @unittest.skipIf(
+        not torch.cuda.is_available() or torch.cuda.device_count() < 2,
+        "Must have at least 2 GPUs for gpu pipeline test",
+    )
+    def test_gpu_train_fp16(self):
+        world_size = 2
+        pipe_config = {"nstages": world_size, "chunks": world_size}
+        amp_config = {"dtype": torch.float16, "skip_if_nonfinite": None}
+        loss_func = my_loss_func
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = str(find_free_port())
+        mp.spawn(
+            run_pipeline,
+            args=(world_size, pipe_config, amp_config, loss_func),
+            nprocs=world_size,
+            join=True,
+        )
+        os.environ["MASTER_ADDR"] = ""
+        os.environ["MASTER_PORT"] = ""
+
+    @unittest.skipIf(
+        (not torch.cuda.is_available() or torch.cuda.device_count() < 2) or not torch.cuda.is_bf16_supported(),
+        "Must have at least 2 GPUs for gpu pipeline test",
+    )
+    def test_gpu_train_bf16(self):
+        world_size = 2
+        pipe_config = {"nstages": world_size, "chunks": world_size}
+        amp_config = {"dtype": torch.bfloat16, "skip_if_nonfinite": None}
+        loss_func = my_loss_func
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = str(find_free_port())
+        mp.spawn(
+            run_pipeline,
+            args=(world_size, pipe_config, amp_config, loss_func),
+            nprocs=world_size,
+            join=True,
+        )
+        os.environ["MASTER_ADDR"] = ""
+        os.environ["MASTER_PORT"] = ""
+
+    @unittest.skipIf(
+        (not torch.cuda.is_available() or torch.cuda.device_count() < 2) or not torch.cuda.is_bf16_supported(),
+        "Must have at least 2 GPUs for gpu pipeline test",
+    )
+    def test_gpu_interleaved_train_bf16(self):
+        world_size = 2
+        pipe_config = {"nstages": 2 * world_size, "chunks": world_size}
+        amp_config = {"dtype": torch.bfloat16, "skip_if_nonfinite": None}
+        loss_func = my_loss_func
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = str(find_free_port())
+        mp.spawn(
+            run_pipeline,
+            args=(world_size, pipe_config, amp_config, loss_func),
+            nprocs=world_size,
+            join=True,
+        )
+        os.environ["MASTER_ADDR"] = ""
+        os.environ["MASTER_PORT"] = ""
+
+    @unittest.skipIf(
+        (not torch.cuda.is_available() or torch.cuda.device_count() < 2) or torch_version() < (2, 0, 0),
+        "Must have at least 2 GPUs for gpu pipeline test",
+    )
+    def test_gpu_train_c10d(self):
+        world_size = 2
+        pipe_config = {"nstages": world_size, "chunks": world_size, "use_c10d": True}
+        amp_config = None
+        loss_func = my_loss_func
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = str(find_free_port())
+        mp.spawn(
+            run_pipeline,
+            args=(world_size, pipe_config, amp_config, loss_func),
+            nprocs=world_size,
+            join=True,
+        )
+        os.environ["MASTER_ADDR"] = ""
+        os.environ["MASTER_PORT"] = ""
+
+    @unittest.skipIf(
+        (not torch.cuda.is_available() or torch.cuda.device_count() < 2)
+        or not torch.cuda.is_bf16_supported()
+        or torch_version() < (2, 0, 0)
+        or True,
+        "Skip as it's blocking now",
+    )
+    def test_gpu_train_c10d_bf16(self):
+        world_size = 2
+        pipe_config = {"nstages": world_size, "chunks": world_size, "use_c10d": True}
+        amp_config = {"dtype": torch.bfloat16, "skip_if_nonfinite": None}
+        loss_func = my_loss_func
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = str(find_free_port())
+        mp.spawn(
+            run_pipeline,
+            args=(world_size, pipe_config, amp_config, loss_func),
+            nprocs=world_size,
+            join=True,
+        )
+        os.environ["MASTER_ADDR"] = ""
+        os.environ["MASTER_PORT"] = ""
+
+    @unittest.skipIf(
+        (not torch.cuda.is_available() or torch.cuda.device_count() < 2)
+        or not torch.cuda.is_bf16_supported()
+        or torch_version() < (2, 0, 0)
+        or True,
+        "Skip as it's blocking now",
+    )
+    def test_gpu_train_c10d_interleaved_bf16(self):
+        world_size = 2
+        pipe_config = {"nstages": 2 * world_size, "chunks": world_size, "use_c10d": True}
+        amp_config = {"dtype": torch.bfloat16, "skip_if_nonfinite": None}
+        loss_func = my_loss_func
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = str(find_free_port())
+        mp.spawn(
+            run_pipeline,
+            args=(world_size, pipe_config, amp_config, loss_func),
+            nprocs=world_size,
+            join=True,
+        )
+        os.environ["MASTER_ADDR"] = ""
+        os.environ["MASTER_PORT"] = ""
+
+    @unittest.skipIf(
+        (not torch.cuda.is_available() or torch.cuda.device_count() < 2) or torch_version() < (2, 0, 0),
+        "Must have at least 2 GPUs for gpu pipeline test",
+    )
+    def test_gpu_save_load_c10d(self):
+        world_size = 2
+        pipe_config = {"nstages": world_size, "chunks": world_size, "use_c10d": True}
+        amp_config = None
+        loss_func = my_loss_func
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = str(find_free_port())
+        mp.spawn(
+            run_save_and_load,
+            args=(world_size, pipe_config, amp_config, loss_func),
+            nprocs=world_size,
+            join=True,
+        )
+        os.environ["MASTER_ADDR"] = ""
+        os.environ["MASTER_PORT"] = ""
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/atorch/atorch/tests/common_tests/popen_redirect_io_test.py
+++ b/atorch/atorch/tests/common_tests/popen_redirect_io_test.py
@@ -1,0 +1,27 @@
+# coding=utf-8
+from __future__ import absolute_import, annotations, unicode_literals
+
+import tempfile
+import unittest
+from subprocess import Popen
+
+
+class TestRedirectIO(unittest.TestCase):
+    def testIO(self):
+        """Write stdout/stderr to fd and check result"""
+        with tempfile.NamedTemporaryFile() as stdout, tempfile.NamedTemporaryFile() as stderr:
+            cmd = [
+                "python",
+                "-c",
+                "import sys;print(1, file=sys.stderr, flush=True);print(2, file=sys.stdout, flush=True)",
+            ]
+            process = Popen(cmd, shell=False, stdout=stdout, stderr=stderr, universal_newlines=True)
+            process.wait()
+            stdout.seek(0)
+            stderr.seek(0)
+            self.assertEqual(b"1\n", stderr.readline())
+            self.assertEqual(b"2\n", stdout.readline())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/atorch/atorch/tests/common_tests/preloader_test.py
+++ b/atorch/atorch/tests/common_tests/preloader_test.py
@@ -1,0 +1,142 @@
+import random
+import unittest
+
+import torch
+from torch.utils.data import DataLoader, Dataset
+
+from atorch.data import GpuPreLoader
+
+
+class _TestDataset(Dataset):
+    def __init__(self, data_size=32):
+        self.size = data_size
+        self.a = 0.1
+        self.b = 0.3
+
+    def __len__(self):
+        return self.size
+
+    def __getitem__(self, idx):
+        x = torch.tensor([random.random()])
+        return x, self.a * x + self.b
+
+
+class _TestModel(torch.nn.Module):
+    def __init__(self):
+        super(_TestModel, self).__init__()
+        self.linear = torch.nn.Linear(1, 1)
+
+    def forward(self, x):
+        out = self.linear(x)
+        return out
+
+
+class PreLoadererTest(unittest.TestCase):
+    def setUp(self):
+        self.size = 16
+        self.batch_size = 2
+
+        dataset = _TestDataset(self.size)
+        self.dataloader = DataLoader(dataset, batch_size=self.batch_size)
+        self.model = _TestModel()
+
+    def test_preloader_cpu(self):
+        device = "cpu"
+
+        dataloader = GpuPreLoader(self.dataloader, device=device)
+        self.assertEqual(len(dataloader), self.size / self.batch_size)
+
+        for _ in range(2):
+            for it, data in enumerate(dataloader):
+                for d in data:
+                    self.assertEqual(d.device, torch.device(device))
+            self.assertEqual(it, len(dataloader) - 1)
+
+    def test_preloader_cpu_with_post_processing(self):
+        device = "cpu"
+        model = _TestModel()
+
+        def process(data):
+            return model(data[0])
+
+        dataloader = GpuPreLoader(self.dataloader, device=device, post_processing=process)
+        self.assertEqual(len(dataloader), self.size / self.batch_size)
+
+        for data, process_output in dataloader:
+            for d in data:
+                self.assertEqual(d.device, torch.device(device))
+
+            self.assertEqual(process_output.device, torch.device(device))
+
+    @unittest.skipIf(
+        not torch.cuda.is_available(),
+        "No gpu available for cuda tests",
+    )
+    def test_preloader_cuda(self):
+        device = "cuda:0"
+
+        dataloader = GpuPreLoader(self.dataloader, device=device)
+        self.assertEqual(len(dataloader), self.size / self.batch_size)
+
+        for _ in range(2):
+            for it, data in enumerate(dataloader):
+                for d in data:
+                    self.assertEqual(d.device, torch.device(device))
+            self.assertEqual(it, len(dataloader) - 1)
+
+    @unittest.skipIf(
+        not torch.cuda.is_available(),
+        "No gpu available for cuda tests",
+    )
+    def test_preloader_cuda_with_mask(self):
+        device = "cuda:0"
+        mask = [True, False]
+
+        dataloader = GpuPreLoader(self.dataloader, device=device, mask=mask)
+        self.assertEqual(len(dataloader), self.size / self.batch_size)
+
+        for data in dataloader:
+            self.assertEqual(data[0].device, torch.device(device))
+            self.assertEqual(data[1].device, torch.device("cpu"))
+
+    @unittest.skipIf(
+        not torch.cuda.is_available(),
+        "No gpu available for cuda tests",
+    )
+    def test_preloader_cuda_manual_preload(self):
+        device = "cuda:0"
+
+        dataloader = GpuPreLoader(self.dataloader, device=device, manual_preload=True)
+        self.assertEqual(len(dataloader), self.size / self.batch_size)
+
+        half_size = int(self.size / self.batch_size / 2)
+        for idx, data in enumerate(dataloader):
+            for d in data:
+                self.assertEqual(d.device, torch.device(device))
+            if idx >= half_size:
+                dataloader.preload()
+                self.assertTrue(dataloader.preloaded)
+            else:
+                self.assertFalse(dataloader.preloaded)
+
+    @unittest.skipIf(
+        not torch.cuda.is_available(),
+        "No gpu available for cuda tests",
+    )
+    def test_preloader_gpu_with_post_processing(self):
+        device = "cuda:0"
+        model = _TestModel()
+        model.to(device)
+
+        def process(data):
+            return model(data[0])
+
+        dataloader = GpuPreLoader(self.dataloader, device=device, post_processing=process)
+        self.assertEqual(len(dataloader), self.size / self.batch_size)
+
+        for data, process_output in dataloader:
+            for d in data:
+                self.assertEqual(d.device, torch.device(device))
+
+            dataloader.wait_post_processing()
+            self.assertEqual(process_output.device, torch.device(device))

--- a/atorch/atorch/tests/common_tests/profiler_test.py
+++ b/atorch/atorch/tests/common_tests/profiler_test.py
@@ -1,0 +1,146 @@
+import copy
+import unittest
+from contextlib import contextmanager
+
+import torch
+
+from atorch.normalization import LayerNorm
+from atorch.utils import AProfiler
+from atorch.utils.prof import GlobalContext, _patch_functionals, _reload_functionals
+
+
+class LeNet5(torch.nn.Module):
+    def __init__(self, n_classes):
+        super(LeNet5, self).__init__()
+
+        self.feature_extractor = torch.nn.Sequential(
+            torch.nn.Conv2d(in_channels=1, out_channels=6, kernel_size=5, stride=1),
+            torch.nn.Tanh(),
+            torch.nn.AvgPool2d(kernel_size=2),
+            torch.nn.Conv2d(in_channels=6, out_channels=16, kernel_size=5, stride=1),
+            torch.nn.Tanh(),
+            torch.nn.AvgPool2d(kernel_size=2),
+            torch.nn.Conv2d(in_channels=16, out_channels=120, kernel_size=5, stride=1),
+            torch.nn.Tanh(),
+        )
+
+        self.classifier = torch.nn.Sequential(
+            torch.nn.Linear(in_features=120, out_features=84),
+            LayerNorm(84),
+            torch.nn.Tanh(),
+            torch.nn.Linear(in_features=84, out_features=n_classes),
+        )
+
+    def forward(self, x):
+        x = self.feature_extractor(x)
+        x = torch.flatten(x, 1)
+        logits = self.classifier(x)
+        probs = torch.nn.functional.softmax(logits, dim=-1)
+        return logits, probs
+
+
+def within_range(val, target, tolerance):
+    return abs(val - target) / target < tolerance
+
+
+TOLERANCE = 0.05
+
+device = "cuda:0" if torch.cuda.is_available() else "cpu"
+
+
+@contextmanager
+def patch_context():
+    origin_module_flop_count = copy.deepcopy(GlobalContext.module_flop_count)
+    try:
+        GlobalContext.module_flop_count.append([])
+        _patch_functionals()
+        yield GlobalContext.module_flop_count
+    finally:
+        GlobalContext.module_flop_count = origin_module_flop_count
+        _reload_functionals()
+
+
+class TestProfiler(unittest.TestCase):
+    def test_softmax_compute(self):
+        from atorch.utils.prof import _softmax_flops_compute
+
+        input = torch.randn(2, 1, 32, 32, device=device)
+        flops, mac = _softmax_flops_compute(input)
+        self.assertEqual(flops, 2097152)
+
+    @unittest.skipIf(
+        not torch.cuda.is_available(),
+        "No gpu available for cuda tests",
+    )
+    def test_conv_profiler(self):
+        model = LeNet5(10)
+        model.to(device)
+        batch_size = 1024
+
+        total_steps = 20
+        profile_step = 5
+
+        input = torch.randn(batch_size, 1, 32, 32, device=device)
+
+        prof = AProfiler(model)
+
+        for step in range(total_steps):
+            if step == profile_step:
+                prof.start_profile()
+
+            model(input)
+
+            if step == profile_step:
+                prof.stop_profile()
+                prof.print_model_profile(top_modules=10)
+                params = prof.get_total_params()
+                flops = prof.get_total_flops()
+                macs = prof.get_total_macs()
+                prof.compute_gpu_utilization(10)
+                prof.end_profile()
+                assert within_range(flops, 866076672, TOLERANCE)
+                assert within_range(macs, 426516480, TOLERANCE)
+                assert params == 185622
+
+    @unittest.skipIf(
+        torch.__version__ < (2, 0),
+        "sdp need torch 2.0",
+    )
+    def test_patch_functional(self):
+        batch_size, nheads, seqlen, headdim = 2, 8, 32, 64
+        from torch.nn import LayerNorm
+
+        torch_layer = LayerNorm((seqlen, nheads, headdim))
+        with patch_context():
+            q = k = v = torch.randn(batch_size, seqlen, nheads, headdim)
+            torch.nn.functional.scaled_dot_product_attention(q, k, v)
+
+            torch_layer(q)
+            self.assertListEqual(
+                GlobalContext.module_flop_count[-1], [("scaled_dot_product_attention", 2555968), ("layer_norm", 163840)]
+            )
+
+    @unittest.skipIf(
+        not torch.cuda.is_available() or torch.__version__ < (2, 0),
+        "No gpu available for cuda tests",
+    )
+    def test_patch_functional_gpu2(self):
+        batch_size, nheads, seqlen, headdim = 2, 8, 32, 64
+        from atorch.normalization import AtorchLayerNorm
+
+        atorch_layer = AtorchLayerNorm((seqlen, nheads, headdim))
+        atorch_layer = atorch_layer.to("cuda")
+        with patch_context():
+            q = k = v = torch.randn(batch_size, seqlen, nheads, headdim, device="cuda")
+            torch.nn.functional.scaled_dot_product_attention(q, k, v)
+
+            atorch_layer(q)
+            print("GlobalContext.module_flop_count", GlobalContext.module_flop_count)
+            self.assertListEqual(
+                GlobalContext.module_flop_count[-1],
+                [("scaled_dot_product_attention", 2555968), ("AtorchLayerNormFunc", 163840)],
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/atorch/atorch/tests/common_tests/randomizer_test.py
+++ b/atorch/atorch/tests/common_tests/randomizer_test.py
@@ -1,0 +1,158 @@
+import os
+import unittest
+
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+import atorch
+from atorch.common.log_utils import default_logger as logger
+from atorch.common.util_func import find_free_port
+from atorch.distributed.distributed import create_parallel_group, parallel_group, parallel_group_size, parallel_rank
+from atorch.modules.distributed_modules.randomizer import get_MDPRInstance, get_randomizer, init_randomizer
+
+logger.setLevel("INFO")
+os.environ["NCCL_DEBUG"] = "ERROR"
+
+
+def assert_group(tensor, group_name, same=True):
+    tensor_list = [torch.empty_like(tensor) for _ in range(parallel_group_size(group_name))]
+    tensor_list[parallel_rank(group_name)] = tensor
+    dist.all_gather(tensor_list, tensor, group=parallel_group(group_name))
+    for tensor in tensor_list[1:]:
+        all_same = torch.eq(tensor, tensor_list[0]).all()
+        assert (
+            all_same if same else not all_same
+        ), f"Tensor {'same' if same else 'differet'} check failed:\n\n{tensor}\n\n{tensor_list[0]}"
+
+
+def assert_model(model1, model2):
+    sd1 = model1.state_dict()
+    sd2 = model2.state_dict()
+    for name1, name2 in zip(sd1, sd2):
+        assert name1 == name2
+        assert torch.all(sd1[name1] == sd2[name2])
+
+
+def _run_randomizer(rank):
+    os.environ["LOCAL_RANK"] = str(rank)
+    os.environ["RANK"] = str(rank)
+    os.environ["WORLD_SIZE"] = "4"
+    res = atorch.init_distributed("nccl", set_cuda_device_using_local_rank=True)
+    if not res:
+        raise Exception("init failed")
+    create_parallel_group(([("tensor", 2), ("data", 2)], None))
+    init_randomizer()
+    device = torch.cuda.current_device()
+
+    # cuda weight init
+    with get_randomizer("data").fork():
+        m = torch.nn.Linear(10, 20, device=device)
+    assert_group(m.weight.detach(), "data", same=True)
+    assert_group(m.weight.detach(), "tensor", same=False)
+
+    # cpu weight init
+    with get_randomizer("data", "tensor").fork():
+        m = torch.nn.Linear(10, 20)
+    assert_group(m.weight.detach().to(device), "data", same=True)
+    assert_group(m.weight.detach().to(device), "tensor", same=True)
+
+    # dropout pattern
+    drop = torch.nn.Dropout(0.1)
+    with get_randomizer("tensor").fork():
+        t = drop(torch.ones(10, device=device))
+    assert_group(t, "data", same=False)
+    assert_group(t, "tensor", same=True)
+    # again with former randomizer
+    with get_randomizer("data").fork():
+        t = drop(torch.ones(10, device=device))
+    assert_group(t, "data", same=True)
+    assert_group(t, "tensor", same=False)
+
+    # test whold different
+    drop2 = torch.nn.Dropout(0.1)
+    with get_randomizer().fork():
+        m = torch.nn.Linear(10, 20, device=device)
+        t = drop2(torch.ones(10, device=device))
+    assert_group(m.weight.detach().to(device), "data", same=False)
+    assert_group(m.weight.detach().to(device), "tensor", same=False)
+    assert_group(t, "data", same=False)
+    assert_group(t, "tensor", same=False)
+
+    atorch.reset_distributed()
+
+
+def _run_randomizer_states(rank):
+    os.environ["LOCAL_RANK"] = str(rank)
+    os.environ["RANK"] = str(rank)
+    os.environ["WORLD_SIZE"] = "4"
+    res = atorch.init_distributed("nccl", set_cuda_device_using_local_rank=True)
+    if not res:
+        raise Exception("init failed")
+    create_parallel_group(([("tensor", 2), ("data", 2)], None))
+    init_randomizer()
+    device = torch.cuda.current_device()
+
+    # set up some group
+    with get_randomizer("data").fork():
+        _ = torch.nn.Linear(10, 20, device=device)
+    with get_randomizer("data", "tensor").fork():
+        _ = torch.nn.Linear(10, 20, device=device)
+    with get_randomizer().fork():
+        _ = torch.nn.Linear(10, 20, device=device)
+
+    # get states
+    _stated_randomizers = get_MDPRInstance().get_states()
+    with get_randomizer("data", "tensor").fork():
+        m1 = torch.nn.Linear(10, 20, device=device)
+    with get_randomizer().fork():
+        m2 = torch.nn.Linear(10, 20, device=device)
+
+    # do something else
+    with get_randomizer("data").fork():
+        _ = torch.nn.Dropout(0.1)(torch.ones(10, device=device))
+    with get_randomizer().fork():
+        _ = torch.nn.Dropout(0.1)(torch.ones(10, device=device))
+
+    # set states and compare
+    get_MDPRInstance().set_states(_stated_randomizers)
+    with get_randomizer("data", "tensor").fork():
+        new_m1 = torch.nn.Linear(10, 20, device=device)
+    with get_randomizer().fork():
+        new_m2 = torch.nn.Linear(10, 20, device=device)
+    assert_model(new_m1, m1)
+    assert_model(new_m2, m2)
+
+
+class TestRandomizer(unittest.TestCase):
+    @unittest.skipIf(torch.cuda.device_count() < 4, "run with cpu or gpu_num >=4")
+    def test_randomizer(self):
+
+        world_size = 4
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = str(find_free_port())
+        mp.spawn(
+            _run_randomizer,
+            nprocs=world_size,
+            join=True,
+        )
+        os.environ["MASTER_ADDR"] = ""
+        os.environ["MASTER_PORT"] = ""
+
+    @unittest.skipIf(torch.cuda.device_count() < 4, "run with cpu or gpu_num >=4")
+    def test_randomizer_states(self):
+
+        world_size = 4
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = str(find_free_port())
+        mp.spawn(
+            _run_randomizer_states,
+            nprocs=world_size,
+            join=True,
+        )
+        os.environ["MASTER_ADDR"] = ""
+        os.environ["MASTER_PORT"] = ""
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/atorch/atorch/tests/common_tests/selective_checkpoint_test.py
+++ b/atorch/atorch/tests/common_tests/selective_checkpoint_test.py
@@ -1,0 +1,133 @@
+import os
+import unittest
+
+import pytest
+
+torch = pytest.importorskip("torch", "2.0.9")
+import torch.multiprocessing as mp  # noqa: E402
+from torch.distributed.fsdp import MixedPrecision  # noqa: E402
+from transformers.models.llama.configuration_llama import LlamaConfig  # noqa: E402
+from transformers.models.llama.modeling_llama import LlamaDecoderLayer  # noqa: E402
+
+import atorch  # noqa: E402
+from atorch.auto.accelerate import auto_accelerate  # noqa: E402
+from atorch.common.util_func import find_free_port  # noqa: E402
+
+
+def boot_test(rank, number_layers, pipes, mode):
+    pipe = pipes[rank]
+    os.environ["LOCAL_RANK"] = str(rank)
+    os.environ["RANK"] = str(rank)
+    atorch.init_distributed("nccl", set_cuda_device_using_local_rank=True)
+    torch.manual_seed(1234)
+    llama_config = LlamaConfig(use_cache=False)
+
+    class M(torch.nn.Module):
+        def __init__(self, llama_config):
+            super().__init__()
+            self.linears = torch.nn.ModuleList([LlamaDecoderLayer(llama_config) for i in range(number_layers)])
+
+        def forward(self, x):
+            for layer in self.linears:
+                x = layer(x)[0]
+            return x
+
+    dtype = torch.bfloat16
+    model = M(llama_config)
+    model.cuda()
+    fsdp_config = {
+        "mixed_precision": MixedPrecision(param_dtype=dtype, reduce_dtype=dtype, buffer_dtype=dtype),
+        "limit_all_gathers": True,
+        "use_orig_params": True,
+    }
+    if mode == "origin":
+        checkpoint_config = LlamaDecoderLayer
+    elif mode == "new":
+        checkpoint_config = {
+            "wrap_class": LlamaDecoderLayer,
+        }
+    elif mode == "offload":
+        checkpoint_config = {
+            "wrap_class": LlamaDecoderLayer,
+            "selective_offload": {"offload_args": [("mm.default", [1, 3, 5])], "num_layers": number_layers},
+        }
+    strategy = [
+        "parallel_mode",
+        ("fsdp", fsdp_config),
+        ("checkpoint", checkpoint_config),
+    ]
+    status, result, best_strategy = auto_accelerate(
+        model,
+        optim_func=torch.optim.AdamW,
+        loss_func=lambda x: x,
+        optim_args={"lr": 0.001},
+        load_strategy=strategy,
+        verbose=True,
+        ignore_dryrun_on_load_strategy=True,
+    )
+    assert status
+    model = result.model
+    opt = result.optim
+    b = 4
+    seq = 2048
+    h = 4096
+    loss_fn = torch.nn.CrossEntropyLoss()
+    loss_fn = torch.nn.MSELoss()
+    inp = torch.randn(b, seq, h).cuda().bfloat16() + rank / 10.0
+    target = torch.empty(b, seq, h, dtype=torch.bfloat16).fill_(0.0).cuda()
+    losses = []
+    for i in range(5):
+        opt.zero_grad()
+        logits = model(inp)
+        loss = loss_fn(logits, target)
+        loss.backward()
+        opt.step()
+        losses.append(loss.detach().cpu().item())
+    pipe.send(losses)
+
+
+class SelectiveCheckpointTest(unittest.TestCase):
+    def setUp(self):
+        atorch.reset_distributed()
+
+    def tearDown(self):
+        atorch.reset_distributed()
+
+    @unittest.skipIf(
+        not torch.cuda.is_available() or torch.cuda.device_count() < 2,
+        "Must have at least 2 GPUs for gpu test",
+    )
+    def test_checkpoint(self):
+        """Test origin activation recomputing and offload, compare loss in 5 steps."""
+        world_size = 2
+
+        def run_inner(ckpt_mode):
+            os.environ["WORLD_SIZE"] = str(world_size)
+            os.environ["NPROC_PER_NODE"] = str(world_size)
+            os.environ["MASTER_ADDR"] = "localhost"
+            os.environ["MASTER_PORT"] = str(find_free_port())
+            rank_pipe = [mp.Pipe() for _ in range(world_size)]
+            send, recv = zip(*rank_pipe)
+            number_layer = 2
+            mp.spawn(
+                boot_test,
+                args=(number_layer, send, ckpt_mode),
+                nprocs=world_size,
+                join=True,
+                daemon=False,
+                start_method="spawn",
+            )
+            result = []
+            for rank, pipe in enumerate(recv):
+                result.append(pipe.recv())
+            return result
+
+        result = {}
+        for ckpt_mode in ["origin", "new", "offload"]:
+            result[ckpt_mode] = run_inner(ckpt_mode)
+        for k in result:
+            self.assertListEqual(result["origin"], result[k])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/atorch/atorch/tests/common_tests/semi_auto_acc_test.py
+++ b/atorch/atorch/tests/common_tests/semi_auto_acc_test.py
@@ -1,0 +1,495 @@
+import copy
+import os
+import unittest
+
+import torch
+import torch.multiprocessing as mp
+from deepspeed.runtime.zero.stage_1_and_2 import DeepSpeedZeroOptimizer
+from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+
+import atorch
+from atorch.auto.accelerate import auto_accelerate
+from atorch.auto.opt_lib.zero_optimization import get_skip_match_module_child_wrap_policy
+from atorch.common.util_func import find_free_port
+from atorch.distributed.distributed import parallel_instance_index, parallel_instance_num, world_size
+from atorch.optimizers import BF16Optimizer
+from atorch.tests.toy_modules.toy_module import create_model_context, get_gpt2_module_type, run_train
+from atorch.utils.version import torch_version
+
+
+def run_wraps(model_context):
+    gpt2block_cls = get_gpt2_module_type(module="block")
+    wrap_type_tuple = (gpt2block_cls, torch.nn.LayerNorm)
+    fsdp_config = {
+        "sync_module_states": True,
+        "limit_all_gathers": True,
+        "atorch_wrap_cls": wrap_type_tuple,
+    }
+    strategy = [
+        "parallel_mode",
+        ("fsdp", fsdp_config),
+    ]
+    mc_copy = copy.deepcopy(model_context)
+    status, result, _ = auto_accelerate(
+        model_context.model,
+        model_context.optim_func,
+        model_context.dataset,
+        model_context.loss_func,
+        model_context.prepare_input,
+        model_context.model_input_format,
+        model_context.optim_args,
+        model_context.optim_param_func,
+        model_context.dataloader_args,
+        load_strategy=strategy,
+        ignore_dryrun_on_load_strategy=True,
+    )
+    assert status
+    fsdp_module_counts = {t: 0 for t in wrap_type_tuple}
+    for _, child in result.model.named_modules():
+        if isinstance(child, FSDP):
+            for t in wrap_type_tuple:
+                if isinstance(child.module, t):
+                    fsdp_module_counts[t] += 1
+    assert fsdp_module_counts[wrap_type_tuple[0]] == 3
+    assert fsdp_module_counts[wrap_type_tuple[1]] == 3 * 2 + 1
+
+    model_context = copy.deepcopy(mc_copy)
+    # test get_skip_match_module_child_wrap_policy with module class tuple
+    wrap_policy = get_skip_match_module_child_wrap_policy(wrap_type_tuple)
+    fsdp_config = {
+        "sync_module_states": True,
+        "limit_all_gathers": True,
+        "auto_wrap_policy": wrap_policy,
+    }
+    strategy = [
+        "parallel_mode",
+        ("fsdp", fsdp_config),
+    ]
+    status, result, _ = auto_accelerate(
+        model_context.model,
+        model_context.optim_func,
+        model_context.dataset,
+        model_context.loss_func,
+        model_context.prepare_input,
+        model_context.model_input_format,
+        model_context.optim_args,
+        model_context.optim_param_func,
+        model_context.dataloader_args,
+        load_strategy=strategy,
+        ignore_dryrun_on_load_strategy=True,
+    )
+    assert status
+    fsdp_module_counts = {t: 0 for t in wrap_type_tuple}
+    for _, child in result.model.named_modules():
+        if isinstance(child, FSDP):
+            for t in wrap_type_tuple:
+                if isinstance(child.module, t):
+                    fsdp_module_counts[t] += 1
+    assert fsdp_module_counts[wrap_type_tuple[0]] == 3
+    assert fsdp_module_counts[wrap_type_tuple[1]] == 1
+
+    model_context = mc_copy
+    # test get_skip_match_module_child_wrap_policy with module class and name tuple
+    wrap_type_tuple_name = (gpt2block_cls, "LayerNorm")
+    wrap_policy = get_skip_match_module_child_wrap_policy(wrap_type_tuple_name, model_context.model)
+    fsdp_config = {
+        "sync_module_states": True,
+        "limit_all_gathers": True,
+        "auto_wrap_policy": wrap_policy,
+    }
+    strategy = [
+        "parallel_mode",
+        ("fsdp", fsdp_config),
+    ]
+    status, result, _ = auto_accelerate(
+        model_context.model,
+        model_context.optim_func,
+        model_context.dataset,
+        model_context.loss_func,
+        model_context.prepare_input,
+        model_context.model_input_format,
+        model_context.optim_args,
+        model_context.optim_param_func,
+        model_context.dataloader_args,
+        load_strategy=strategy,
+        ignore_dryrun_on_load_strategy=True,
+    )
+    assert status
+    fsdp_module_counts = {t: 0 for t in wrap_type_tuple}
+    for _, child in result.model.named_modules():
+        if isinstance(child, FSDP):
+            for t in wrap_type_tuple:
+                if isinstance(child.module, t):
+                    fsdp_module_counts[t] += 1
+    assert fsdp_module_counts[wrap_type_tuple[0]] == 3
+    assert fsdp_module_counts[wrap_type_tuple[1]] == 1
+
+
+def run_ds_zero(
+    rank,
+    hidden_size,
+    head_num,
+    layer_num,
+    seq_length,
+    data_size,
+    batch_size,
+):
+    os.environ["LOCAL_RANK"] = str(rank)
+    os.environ["RANK"] = str(rank)
+    backend = "nccl" if torch.cuda.is_available() else "gloo"
+    res = atorch.init_distributed(backend, set_cuda_device_using_local_rank=True)
+    if not res:
+        raise Exception("init failed")
+
+    mc = create_model_context(
+        data_size=data_size,
+        batch_size=batch_size,
+        use_gpt2=True,
+        hidden_size=hidden_size,
+        head_num=head_num,
+        layer_num=layer_num,
+        seq_length=seq_length,
+    )
+
+    def train_with_ds(model_context, dtype, ds_zero, cpu_offload):
+        strategy = ["parallel_mode"]
+        if dtype != torch.float32:
+            strategy.append(("half", "fp16" if dtype == torch.half else "bf16"))
+
+        ds_config = {"use_ds_zero": True}
+        ds_config["cpu_offload"] = cpu_offload
+        if ds_zero == "zero2":
+            ds_config["static_loss_scale"] = 0
+            strategy.append(("zero2", ds_config))
+        else:
+            strategy.append(("zero1", ds_config))
+
+        data_size = len(model_context.dataset)
+
+        status, result, _ = auto_accelerate(
+            model_context.model,
+            model_context.optim_func,
+            model_context.dataset,
+            model_context.loss_func,
+            model_context.prepare_input,
+            model_context.model_input_format,
+            model_context.optim_args,
+            model_context.optim_param_func,
+            model_context.dataloader_args,
+            load_strategy=strategy,
+            ignore_dryrun_on_load_strategy=True,
+        )
+        assert status
+        assert isinstance(result.optim, DeepSpeedZeroOptimizer)
+
+        m_model = result.model
+        m_dataloader = result.dataloader
+        m_optim = result.optim
+        m_prepare_input = result.prepare_input
+        m_loss_func = result.loss_func
+
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+
+        num = run_train(
+            m_model,
+            m_dataloader,
+            m_optim,
+            m_prepare_input,
+            m_loss_func,
+            device,
+            gpt2_model=True,
+            use_optim_backward=result.args["use_optim_backward"],
+        )
+        assert num == data_size // batch_size, f"num={num}"
+
+    dtype_list = [torch.float16, torch.half, torch.float32]
+    cpu_offload_list = [False, True]
+    ds_zero_list = ["zero1", "zero2"]
+
+    for dtype in dtype_list:
+        for ds_zero in ds_zero_list:
+            for cpu_offload in cpu_offload_list:
+                mc_copy = copy.deepcopy(mc)
+                train_with_ds(mc_copy, dtype, ds_zero, cpu_offload)
+
+    atorch.reset_distributed()
+
+
+def run_gpt2_with_strategy(
+    rank,
+    hidden_size,
+    head_num,
+    layer_num,
+    seq_length,
+    data_size,
+    batch_size,
+    use_bf16=False,
+    zero_size=None,
+    bf16_only=False,
+    wrap_test_only=False,
+):
+    os.environ["LOCAL_RANK"] = str(rank)
+    os.environ["RANK"] = str(rank)
+    backend = "nccl" if torch.cuda.is_available() else "gloo"
+    res = atorch.init_distributed(backend, set_cuda_device_using_local_rank=True)
+    if not res:
+        raise Exception("init failed")
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    use_fa = torch.cuda.get_device_capability()[0] >= 8
+    model_context = create_model_context(
+        data_size=data_size,
+        batch_size=batch_size,
+        use_gpt2=True,
+        hidden_size=hidden_size,
+        head_num=head_num,
+        layer_num=layer_num,
+        seq_length=seq_length,
+    )
+
+    if wrap_test_only:
+        run_wraps(model_context)
+        atorch.reset_distributed()
+        return
+
+    if bf16_only:
+        strategy = [("half", "bf16")]
+    else:
+        gpt2block_cls = get_gpt2_module_type(module="block")
+
+        amp_config = {"dtype": torch.bfloat16 if use_bf16 else torch.float16}
+
+        fsdp_config = {
+            "sync_module_states": True,
+            "limit_all_gathers": True,
+            "atorch_wrap_cls": (gpt2block_cls,),
+        }
+        if torch_version() >= (2, 0, 0):
+            fsdp_config["use_orig_params"] = True
+        checkpoint_config = (gpt2block_cls,)
+
+        if zero_size is not None:
+            p_config = ([("data", zero_size)], None, True)
+        else:
+            p_config = None
+        if use_fa:
+            strategy = [
+                ("parallel_mode", p_config),
+                "module_replace",
+                ("amp_native", amp_config),
+                ("fsdp", fsdp_config),
+                ("checkpoint", checkpoint_config),
+            ]
+        else:
+            strategy = [
+                ("parallel_mode", p_config),
+                ("amp_native", amp_config),
+                ("fsdp", fsdp_config),
+                ("checkpoint", checkpoint_config),
+            ]
+
+    status, result, best_strategy = auto_accelerate(
+        model_context.model,
+        model_context.optim_func,
+        model_context.dataset,
+        model_context.loss_func,
+        model_context.prepare_input,
+        model_context.model_input_format,
+        model_context.optim_args,
+        model_context.optim_param_func,
+        model_context.dataloader_args,
+        load_strategy=strategy,
+        ignore_dryrun_on_load_strategy=True,
+    )
+    assert status
+    assert len(best_strategy) == len(strategy)
+    if bf16_only:
+        assert isinstance(result.optim, BF16Optimizer)
+    else:
+        assert not isinstance(result.optim, BF16Optimizer)
+    m_model = result.model
+    m_dataloader = result.dataloader
+    m_optim = result.optim
+    m_prepare_input = result.prepare_input
+    m_loss_func = result.loss_func
+    input_dtype = torch.float32
+
+    num = run_train(
+        m_model, m_dataloader, m_optim, m_prepare_input, m_loss_func, device, input_dtype=input_dtype, gpt2_model=True
+    )
+    assert num == data_size // batch_size, f"num={num}"
+    if not bf16_only:
+        if zero_size is None:
+            assert parallel_instance_num() == 1
+            assert parallel_instance_index() == 0
+        else:
+            assert parallel_instance_num() == world_size() // zero_size
+            assert parallel_instance_index() == rank // zero_size
+            assert m_model.world_size == zero_size
+            assert m_model.rank == rank % zero_size
+
+    atorch.reset_distributed()
+
+
+class LoadStrategyTest(unittest.TestCase):
+    @unittest.skipIf(
+        not torch.cuda.is_available() or torch.cuda.device_count() < 2,
+        "Must have at least 2 GPUs for gpu test",
+    )
+    def test_gpt2_strategy(self):
+        os.environ["WORLD_SIZE"] = str(2)
+        os.environ["NPROC_PER_NODE"] = str(2)
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = str(find_free_port())
+
+        hidden_size = 256
+        head_num = 4
+        layer_num = 3
+        seq_length = 512
+        data_size = 16
+        batch_size = 2
+        mp.spawn(
+            run_gpt2_with_strategy,
+            args=(hidden_size, head_num, layer_num, seq_length, data_size, batch_size, False),
+            nprocs=2,
+            join=True,
+            daemon=False,
+            start_method="spawn",
+        )
+
+    @unittest.skipIf(
+        (not torch.cuda.is_available() or torch.cuda.device_count() < 2) or not torch.cuda.is_bf16_supported(),
+        "Must have at least 2 GPUs with bf16 supported for gpu test",
+    )
+    def test_gpt2_strategy_bf16(self):
+        os.environ["WORLD_SIZE"] = str(2)
+        os.environ["NPROC_PER_NODE"] = str(2)
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = str(find_free_port())
+
+        hidden_size = 256
+        head_num = 4
+        layer_num = 3
+        seq_length = 512
+        data_size = 16
+        batch_size = 4
+        mp.spawn(
+            run_gpt2_with_strategy,
+            args=(hidden_size, head_num, layer_num, seq_length, data_size, batch_size, True),
+            nprocs=2,
+            join=True,
+            daemon=False,
+            start_method="spawn",
+        )
+
+    @unittest.skipIf(
+        (not torch.cuda.is_available() or torch.cuda.device_count() < 4) or not torch.cuda.is_bf16_supported(),
+        "Must have at least 4 GPUs for gpu test",
+    )
+    def test_gpt2_strategy_multi_instance(self):
+        os.environ["WORLD_SIZE"] = str(4)
+        os.environ["NPROC_PER_NODE"] = str(4)
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = str(find_free_port())
+
+        hidden_size = 256
+        head_num = 4
+        layer_num = 3
+        seq_length = 128
+        data_size = 16
+        batch_size = 4
+        mp.spawn(
+            run_gpt2_with_strategy,
+            args=(hidden_size, head_num, layer_num, seq_length, data_size, batch_size, False, 2),
+            nprocs=4,
+            join=True,
+            daemon=False,
+            start_method="spawn",
+        )
+
+    @unittest.skipIf(
+        not torch.cuda.is_available() or not torch.cuda.is_bf16_supported(),
+        "Must have GPU with bf16 supported",
+    )
+    def test_gpt2_bf16_only(self):
+        os.environ["WORLD_SIZE"] = str(1)
+        os.environ["NPROC_PER_NODE"] = str(1)
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = str(find_free_port())
+        hidden_size = 256
+        head_num = 4
+        layer_num = 3
+        seq_length = 128
+        data_size = 16
+        batch_size = 4
+        run_gpt2_with_strategy(
+            0,
+            hidden_size,
+            head_num,
+            layer_num,
+            seq_length,
+            data_size,
+            batch_size,
+            use_bf16=False,
+            zero_size=None,
+            bf16_only=True,
+        )
+
+    @unittest.skipIf(
+        not torch.cuda.is_available() or torch.cuda.device_count() < 2,
+        "Must have at least 2 GPUs for gpu test",
+    )
+    def test_fsdp_wraps(self):
+        os.environ["WORLD_SIZE"] = str(2)
+        os.environ["NPROC_PER_NODE"] = str(2)
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = str(find_free_port())
+
+        hidden_size = 256
+        head_num = 4
+        layer_num = 3
+        seq_length = 512
+        data_size = 16
+        batch_size = 2
+        mp.spawn(
+            run_gpt2_with_strategy,
+            args=(hidden_size, head_num, layer_num, seq_length, data_size, batch_size, False, None, False, True),
+            nprocs=2,
+            join=True,
+            daemon=False,
+            start_method="spawn",
+        )
+
+    @unittest.skipIf(
+        not torch.cuda.is_available() or not torch.cuda.is_bf16_supported(),
+        "Must have GPU with bf16 supported",
+    )
+    def test_ds_zero_bf16(self):
+        os.environ["WORLD_SIZE"] = str(2)
+        os.environ["NPROC_PER_NODE"] = str(2)
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = str(find_free_port())
+        hidden_size = 64
+        head_num = 4
+        layer_num = 2
+        seq_length = 32
+        data_size = 16
+        batch_size = 2
+        mp.spawn(
+            run_ds_zero,
+            args=(
+                hidden_size,
+                head_num,
+                layer_num,
+                seq_length,
+                data_size,
+                batch_size,
+            ),
+            nprocs=2,
+            join=True,
+            daemon=False,
+            start_method="spawn",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/atorch/atorch/tests/common_tests/shm_context_test.py
+++ b/atorch/atorch/tests/common_tests/shm_context_test.py
@@ -1,0 +1,413 @@
+import collections
+import os
+import sys
+import time
+import unittest
+
+import numpy as np
+import torch
+
+import atorch
+from atorch.data import ShmData
+from atorch.data.shm_context import ShmDataContext, create_coworker_shm_context, get_sample_batch
+from atorch.tests.toy_modules.toy_module import ToyDataset
+from atorch.tests.utils.test_utils import (
+    create_sample_batch,
+    run_multi_process_init_distributed,
+    start_coverage,
+    stop_coverage,
+)
+
+
+def context_run_func(task_type):
+    if torch.cuda.is_available():
+        backend = "nccl"
+    else:
+        backend = "gloo"
+    res = atorch.init_distributed(backend)
+    assert res
+    rank = atorch.rank()
+
+    sample_batch = create_sample_batch()
+
+    if task_type == "coworker":
+        num_read_per_batch = 1
+        num_batch_per_step = 1
+        num_coworker_per_node = 1
+        shm_name_prefix = "atorch_test_mp_O1_"
+
+        shm = ShmDataContext(
+            is_master=rank == 0,
+            sample_batch=sample_batch,
+            rank=0 if rank == 0 else rank - 1,
+            num_read_per_batch=num_read_per_batch,
+            num_batch_per_step=num_batch_per_step,
+            num_coworker_per_node=num_coworker_per_node,
+            shm_name_prefix=shm_name_prefix,
+            io_timeout=5,
+        )
+        dsize = 2
+        if rank == 0:
+            batches = [create_sample_batch(value=i + 10, start_v=i + 1) for i in range(dsize)]
+            shm.add_batch(batches)
+            shm.add_batch(None)
+        else:
+            for _ in range(dsize):
+                batch = shm.get_data(0)
+                assert batch is not None
+            batch = shm.get_data(0)
+            assert batch is None
+    else:
+        num_read_per_batch = 1
+        num_batch_per_step = 1
+        shm_name_prefix = "atorch_test_mp_O2_"
+        shm = ShmDataContext(
+            is_master=rank == 0,
+            sample_batch=sample_batch,
+            rank=rank,
+            num_read_per_batch=num_read_per_batch,
+            num_batch_per_step=num_batch_per_step,
+            shm_name_prefix=shm_name_prefix,
+            io_timeout=5,
+        )
+        dsize = 2
+        if rank == 0:
+            batches = [create_sample_batch(value=i + 10, start_v=i + 1) for i in range(dsize)]
+            shm.add_batch(batches)
+            shm.add_batch(None)
+        else:
+            for _ in range(dsize):
+                batch = shm.get_data(0)
+                assert batch is not None
+            batch = shm.get_data(0)
+            assert batch is None
+
+    shm.tear_down(master_wait_for_worker=True, wait_timeout=15)
+    atorch.reset_distributed()
+
+
+def api_run_func():
+    res = atorch.init_distributed("gloo", coworker_num_per_node=1)
+    assert res
+
+    dataset = ToyDataset(50)
+    dataloader_args = {"batch_size": 4}
+
+    io_timeout = 5
+    initialize_timeout = 15
+
+    shm_context = create_coworker_shm_context(
+        dataset=dataset, dataloader_args=dataloader_args, io_timeout=io_timeout, initialize_timeout=initialize_timeout
+    )
+
+    dsize = 2
+    if atorch.distributed.is_coworker():
+        batches = get_sample_batch(dataset, dataloader_args, num=dsize)
+        shm_context.add_batch(batches)
+        shm_context.add_batch(None)
+    else:
+        for _ in range(dsize):
+            batch = shm_context.get_data(0)
+            assert batch is not None
+        batch = shm_context.get_data(0)
+        assert batch is None
+
+    shm_context.tear_down(master_wait_for_worker=True)
+    atorch.reset_distributed()
+
+
+def shm_data_func():
+    res = atorch.init_distributed("gloo", coworker_num_per_node=1)
+    assert res
+    size = 20
+    dtype = np.int64
+
+    def check_value(shm, offset, size, values, local_rank=None):
+        for i in range(size):
+            shm_value = shm.get(offset + i, local_rank=local_rank)
+            if shm_value != values[i]:
+                return False
+        return True
+
+    shm_data = ShmData("test_shm_d", size=size, dtype=dtype, per_rank_data=False, initialize_timeout=30)
+    values = [0 for i in range(size)]
+    values[0] = 10
+    values[1] = -1
+    values[2] = -2
+    values[5] = 20
+    values[6] = -10
+    values[7] = -20
+    if atorch.local_rank() == 0:
+        shm_data.put(0, 10)  # set [0] = 10
+        shm_data.put([1, 3], [-1, -2])  # set[1,2] = [-1, -2]
+    else:
+        shm_data.put(5, 20)  # set [5] = 20
+        shm_data.put([6, 8], [-10, -20])  # set[6,7] = [-10, -20]
+    need_check = True
+    sleep_count = 10
+    while need_check and sleep_count > 0:
+        if check_value(shm_data, 0, size, values):
+            need_check = False
+            break
+        time.sleep(1)
+        sleep_count -= 0
+    assert not need_check
+    shm_data.tear_down()
+
+    shm_data = ShmData("test_shm_per_rank", size=size, dtype=dtype, per_rank_data=True, initialize_timeout=30)
+    if atorch.local_rank() == 0:
+        shm_data.put(0, 10)  # set [0] = 10
+        shm_data.put([1, 3], [-1, -2])  # set[1,2] = [-1, -2]
+    else:
+        shm_data.put(5, 20)  # set [5] = 20
+        shm_data.put([6, 8], [-10, -20])  # set[6,7] = [-10, -20]
+
+    values0 = [0 for i in range(size)]
+    values0[0] = 10
+    values0[1] = -1
+    values0[2] = -2
+    values1 = [0 for i in range(size)]
+    values1[5] = 20
+    values1[6] = -10
+    values1[7] = -20
+
+    need_check = True
+    sleep_count = 10
+    while need_check and sleep_count > 0:
+        if check_value(shm_data, 0, size, values0, local_rank=0) and check_value(
+            shm_data, 0, size, values1, local_rank=1
+        ):
+            need_check = False
+            break
+        time.sleep(1)
+        sleep_count -= 0
+    assert not need_check
+    shm_data.tear_down()
+
+
+def check_equal(x, y):
+    if type(x) != type(y):
+        return False
+    if isinstance(x, collections.abc.Sequence):
+        if len(x) != len(y):
+            return False
+        for idx in range(len(x)):
+            if not check_equal(x[idx], y[idx]):
+                return False
+    elif isinstance(x, collections.abc.Mapping):
+        for key in x:
+            if key not in y:
+                return False
+            if not check_equal(x[key], y[key]):
+                return False
+    else:
+        return torch.equal(x, y)
+    return True
+
+
+class ShmDataContextTest(unittest.TestCase):
+    def test_coworker_case(self):
+        num_read_per_batch = 1
+        num_batch_per_step = 2
+        num_coworker_per_node = 2
+        shm_name_prefix = "atorch_test_O1_"
+
+        sample_batch = create_sample_batch()
+
+        master_shms = [
+            ShmDataContext(
+                is_master=True,
+                sample_batch=sample_batch,
+                rank=r,
+                num_read_per_batch=num_read_per_batch,
+                num_batch_per_step=num_batch_per_step,
+                num_coworker_per_node=num_coworker_per_node,
+                shm_name_prefix=shm_name_prefix,
+            )
+            for r in range(num_coworker_per_node)
+        ]
+
+        worker_shms = [
+            ShmDataContext(
+                is_master=False,
+                sample_batch=sample_batch,
+                rank=r,
+                num_read_per_batch=num_read_per_batch,
+                num_batch_per_step=num_batch_per_step,
+                num_coworker_per_node=num_coworker_per_node,
+                shm_name_prefix=shm_name_prefix,
+            )
+            for r in range(num_batch_per_step)
+        ]
+
+        batches = [create_sample_batch(value=i + 10, start_v=i + 1) for i in range(num_batch_per_step)]
+        for shm in master_shms:
+            shm.add_batch(batches)
+            shm.add_batch(None)
+
+        for d_idx, shm in enumerate(worker_shms):
+            for idx in range(num_coworker_per_node):
+                batch = shm.get_data(idx)
+                self.assertTrue(check_equal(batch, batches[d_idx]))
+                batch = shm.get_data(idx)
+                self.assertTrue(batch is None)
+
+        m_write_count = master_shms[0].get_write_count()
+        m_read_count = master_shms[0].get_read_count()
+
+        for shm in worker_shms:
+            w_write_count = master_shms[0].get_write_count(0)
+            w_read_count = master_shms[0].get_read_count(0)
+            self.assertEqual(m_write_count, w_write_count)
+            self.assertEqual(m_read_count, w_read_count)
+            self.assertEqual(m_write_count, m_read_count)
+
+        # reset
+        for shm in worker_shms:
+            shm.reset()
+
+        for shm in master_shms:
+            shm.reset()
+
+        for shm in master_shms:
+            shm.add_batch(batches)
+            shm.add_batch(None)
+
+        for d_idx, shm in enumerate(worker_shms):
+            for idx in range(num_coworker_per_node):
+                batch = shm.get_data(idx)
+                self.assertTrue(check_equal(batch, batches[d_idx]))
+                batch = shm.get_data(idx)
+                self.assertTrue(batch is None)
+
+        for shm in worker_shms:
+            shm.tear_down()
+
+        for shm in master_shms:
+            shm.tear_down(master_wait_for_worker=True)
+
+    def test_model_parallel_case(self):
+        num_read_per_batch = 3
+        num_batch_per_step = 1
+        shm_name_prefix = "atorch_test_O2_"
+
+        sample_batch = create_sample_batch()
+
+        master_shm = ShmDataContext(
+            is_master=True,
+            sample_batch=sample_batch,
+            rank=0,
+            num_read_per_batch=num_read_per_batch,
+            num_batch_per_step=num_batch_per_step,
+            shm_name_prefix=shm_name_prefix,
+        )
+
+        worker_shms = [
+            ShmDataContext(
+                is_master=False,
+                sample_batch=sample_batch,
+                rank=r + 1,
+                num_read_per_batch=num_read_per_batch,
+                num_batch_per_step=num_batch_per_step,
+                shm_name_prefix=shm_name_prefix,
+            )
+            for r in range(num_read_per_batch)
+        ]
+
+        bs = 4
+        batches = [create_sample_batch(value=i + 10, start_v=i + 1) for i in range(bs)]
+        master_shm.add_batch(batches)
+        state_shm = master_shm.shms[0]["state"][1]
+        self.assertEqual(state_shm[1], bs)
+        self.assertEqual(state_shm[0], 0)
+        master_shm.add_batch(None)
+        self.assertEqual(state_shm[0], 1)
+
+        for i in range(bs + 1):
+            for shm in worker_shms:
+                batch = shm.get_data()
+                if i < bs:
+                    self.assertTrue(check_equal(batch, batches[i]))
+                else:
+                    self.assertTrue(batch is None)
+
+        for shm in worker_shms:
+            shm.tear_down()
+
+        master_shm.tear_down()
+
+    def test_timeout(self):
+        num_read_per_batch = 3
+        num_batch_per_step = 1
+        shm_name_prefix = "atorch_timeout_"
+
+        sample_batch = create_sample_batch()
+
+        master_shm = ShmDataContext(
+            is_master=True,
+            sample_batch=sample_batch,
+            rank=0,
+            num_read_per_batch=num_read_per_batch,
+            num_batch_per_step=num_batch_per_step,
+            shm_name_prefix=shm_name_prefix,
+        )
+
+        worker_shm = ShmDataContext(
+            is_master=False,
+            sample_batch=sample_batch,
+            rank=1,
+            num_read_per_batch=num_read_per_batch,
+            num_batch_per_step=num_batch_per_step,
+            shm_name_prefix=shm_name_prefix,
+            io_timeout=2,
+        )
+
+        self.assertRaises(TimeoutError, worker_shm.get_data)
+        master_shm.tear_down()
+        worker_shm.tear_down()
+
+        def create_worker_shm():
+            return ShmDataContext(
+                is_master=False,
+                sample_batch=sample_batch,
+                rank=1,
+                num_read_per_batch=num_read_per_batch,
+                num_batch_per_step=num_batch_per_step,
+                shm_name_prefix=shm_name_prefix,
+                initialize_timeout=2,
+            )
+
+        self.assertRaises(TimeoutError, create_worker_shm)
+
+    def test_coworker_run(self):
+        run_dist_code("coworker_test")
+
+    def test_mp_run(self):
+        run_dist_code("mp_test")
+
+    @unittest.skipIf(torch.cuda.is_available(), "Skip on gpu as cpu test covers it.")
+    def test_api_run(self):
+        run_dist_code("api_test")
+
+    @unittest.skipIf(torch.cuda.is_available(), "Skip on gpu as cpu test covers it.")
+    def test_shm_data_run(self):
+        run_dist_code("shm_data")
+
+
+def run_dist_code(name, nproc=2):
+    code_path = os.path.abspath(__file__)
+    run_multi_process_init_distributed(nproc=nproc, training_script=code_path, training_script_args=(name,))
+
+
+if __name__ == "__main__":
+    cov_status = start_coverage()
+    if sys.argv[1] == "coworker_test":
+        context_run_func("coworker")
+    elif sys.argv[1] == "mp_test":
+        context_run_func("mp")
+    elif sys.argv[1] == "api_test":
+        api_run_func()
+    elif sys.argv[1] == "shm_data":
+        shm_data_func()
+    if cov_status:
+        stop_coverage()

--- a/atorch/atorch/tests/common_tests/shm_dataloader_test.py
+++ b/atorch/atorch/tests/common_tests/shm_dataloader_test.py
@@ -1,0 +1,240 @@
+import os
+import sys
+import unittest
+
+import torch
+from torch.utils.data import DataLoader
+
+import atorch
+from atorch.data import ShmDataloader, create_coworker_shm_context, create_shm_dataloader
+from atorch.tests.toy_modules.toy_module import ToyDataset
+from atorch.tests.utils.test_utils import run_multi_process_init_distributed, start_coverage, stop_coverage
+
+
+def api_run_func():
+    if torch.cuda.is_available():
+        backend = "nccl"
+    else:
+        backend = "gloo"
+    res = atorch.init_distributed(backend, coworker_num_per_node=1)
+    assert res
+
+    data_size = 48
+    batch_size = 4
+    dataset = ToyDataset(data_size)
+    dataloader_args = {"batch_size": batch_size, "drop_last": True}
+
+    io_timeout = 5
+    initialize_timeout = 15
+
+    if atorch.distributed.is_coworker():
+        shm_context = create_coworker_shm_context(
+            dataset=dataset,
+            dataloader_args=dataloader_args,
+            io_timeout=io_timeout,
+            initialize_timeout=initialize_timeout,
+        )
+        dataloader = DataLoader(dataset, **dataloader_args)
+        for n in range(2):
+            if n > 0:
+                shm_context.reset()
+            for batch in dataloader:
+                shm_context.add_batch([batch])
+            shm_context.add_batch(None)
+        shm_context.tear_down(master_wait_for_worker=True)
+    else:
+        dataloader = ShmDataloader(
+            dataset, dataloader_args, io_timeout=io_timeout, initialize_timeout=initialize_timeout
+        )
+        for n in range(2):
+            count = 0
+            for data in dataloader:
+                count += 1
+            assert count == data_size // batch_size
+
+    atorch.reset_distributed()
+
+
+def advance_api_run_func():
+    res = atorch.init_distributed("gloo", coworker_num_per_node=1)
+    assert res
+
+    data_size = 48
+    batch_size = 4
+    dataset = ToyDataset(data_size)
+    dataloader_args = {"batch_size": batch_size, "drop_last": True}
+    sampler = torch.utils.data.distributed.DistributedSampler(dataset, shuffle=True)
+    coworker_dataloader_args = {"sampler": sampler, "batch_size": batch_size * 2, "drop_last": True}
+
+    io_timeout = 5
+    initialize_timeout = 15
+    epoch_num = 2
+
+    def split_batch(data, batch_size, index):
+        if isinstance(data, torch.Tensor):
+            res = torch.split(data, batch_size)
+            res = res[index]
+        elif isinstance(data, dict):
+            res = {}
+            for key in data:
+                res[key] = split_batch(data[key], batch_size, index)
+        elif isinstance(data, tuple) or isinstance(data, list):
+            res = []
+            for d in data:
+                res.append(split_batch(d, batch_size, index))
+            if isinstance(data, tuple):
+                res = tuple(res)
+        else:
+            return None
+        return res
+
+    class MyProcess:
+        def __init__(
+            self,
+            dataset,
+            dataloader_args,
+            training_batch_size=4,
+            epoch_num=2,
+        ):
+            self.dataset = dataset
+            self.dataloader_args = dataloader_args
+            self.epoch_num = epoch_num
+            self.training_batch_size = training_batch_size
+
+        def process_data(self, shm_context):
+            dataloader = DataLoader(self.dataset, **self.dataloader_args)
+            num_shms = len(shm_context) if type(shm_context) == list else 1
+            if num_shms == 1:
+                shm_context = [shm_context]
+            should_stop = [False for _ in range(num_shms)]
+            for _ in range(self.epoch_num):
+                if all(should_stop):
+                    break
+                for batch in dataloader:
+                    # split batch into training batch_size
+                    if all(should_stop):
+                        break
+                    batches = [
+                        split_batch(batch, self.training_batch_size, i)
+                        for i in range(dataloader.batch_size // self.training_batch_size)
+                    ]
+                    for i in range(num_shms):
+                        if should_stop[i]:
+                            continue
+                        shm_context[i].add_batch(batches)
+                        stop_status = shm_context[i].get_stop_status()
+                        if any(stop_status):
+                            should_stop[i] = True
+                            shm_context[i].add_batch(None)
+            for i in range(num_shms):
+                if not should_stop[i]:
+                    shm_context[i].add_batch(None)
+
+    my_process = MyProcess(dataset, coworker_dataloader_args, epoch_num=epoch_num, training_batch_size=4)
+    num_s = 2
+    dataset = [dataset] * num_s
+    dataloader_args = [dataloader_args] * num_s
+    shm_data_size = [4] * num_s
+    shm_name_prefix = [f"p_{x}" for x in range(num_s)]
+
+    dataloader = create_shm_dataloader(
+        dataset,
+        dataloader_args,
+        coworker_data_process_func=my_process.process_data,
+        io_timeout=io_timeout,
+        initialize_timeout=initialize_timeout,
+        shm_data_size=shm_data_size,
+        shm_name_prefix=shm_name_prefix,
+        coworker_wait_worker_read=True,
+        coworker_wait_worker_read_timeout=10,
+    )
+    if type(dataloader) != list:
+        dataloader = [dataloader]
+    itt = [iter(dataloader[idx]) for idx in range(num_s)]
+    count = [0] * num_s
+    total_0 = [0] * num_s
+    total_1 = [0] * num_s
+    doing = True
+    bb = [False] * num_s
+
+    while doing and not all(bb):
+        for idx in range(num_s):
+            if bb[idx]:
+                continue
+            try:
+                data = next(itt[idx])
+                count[idx] += 1
+                for i in range(batch_size):
+                    total_0[idx] += data[0][i][0].item()
+                    total_1[idx] += data[1][i][0].item()
+                if count[idx] == data_size // batch_size:
+                    dataloader[idx].stop()
+                    bb[idx] = True
+            except StopIteration:
+                doing = False
+    for idx in range(num_s):
+        assert count[idx] == data_size // batch_size
+        assert total_0[idx] == data_size * (data_size - 1) // 2
+        assert total_1[idx] == data_size
+    atorch.reset_distributed()
+
+
+def mp_run_func():
+    res = atorch.init_distributed("gloo")
+    assert res
+    data_size = 48
+    batch_size = 4
+    dataset = ToyDataset(data_size)
+    dataloader_args = {"batch_size": batch_size, "num_workers": 1, "drop_last": True}
+    io_timeout = 5
+    initialize_timeout = 15
+    dataloader = ShmDataloader(
+        dataset,
+        dataloader_args,
+        rank=atorch.distributed.rank(),
+        group_size=atorch.distributed.world_size(),
+        io_timeout=io_timeout,
+        initialize_timeout=initialize_timeout,
+        need_sync_write=False,
+        shm_data_size=2,
+    )
+    for _ in range(2):
+        count = 0
+        for data in dataloader:
+            count += 1
+            assert len(data) == 2
+            assert isinstance(data[0], torch.Tensor)
+            assert isinstance(data[1], torch.Tensor)
+        assert count == data_size // batch_size
+    assert dataloader.executor is not None or atorch.distributed.rank() > 0
+    atorch.reset_distributed()
+
+
+def run_dist_code(name, nproc=2):
+    code_path = os.path.abspath(__file__)
+    run_multi_process_init_distributed(nproc=nproc, training_script=code_path, training_script_args=(name,))
+
+
+class ShmDataLoaderTest(unittest.TestCase):
+    def test_multiprocess_api_run(self):
+        run_dist_code("api_run")
+
+    @unittest.skipIf(torch.cuda.is_available(), "Skip on gpu as cpu test covers it.")
+    def test_multiprocess_advance_api_run(self):
+        run_dist_code("advance_api_run")
+
+    @unittest.skipIf(torch.cuda.is_available(), "Skip on gpu as cpu test covers it.")
+    def test_mp_multiprocess_api_run(self):
+        run_dist_code("mp_run")
+
+
+if __name__ == "__main__":
+    cov_status = start_coverage()
+    if sys.argv[1] == "api_run":
+        api_run_func()
+    elif sys.argv[1] == "advance_api_run":
+        advance_api_run_func()
+    elif sys.argv[1] == "mp_run":
+        mp_run_func()
+    if cov_status:
+        stop_coverage()

--- a/atorch/atorch/tests/common_tests/sparse_tensor_test.py
+++ b/atorch/atorch/tests/common_tests/sparse_tensor_test.py
@@ -1,0 +1,40 @@
+import os
+import unittest
+
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+from atorch.common.util_func import find_free_port
+from atorch.utils.sparse import all_reduce_sparse
+
+
+def run_all_reduce_sparse(rank, size, backend="gloo"):
+    """Distributed function to be implemented later."""
+    dist.init_process_group(backend, rank=rank, world_size=size)
+    if rank == 0:
+        data = torch.tensor([[0.0, 0.0, 0.0], [0.0, 1.1, 1.2]]).to_sparse(2)
+        result = all_reduce_sparse(data)
+    else:
+        data = torch.tensor([[0.0, 0.0, 0.0], [0.0, 0.0, 2.0]]).to_sparse(2)
+        result = all_reduce_sparse(data)
+
+    indices = torch.tensor([[1, 1], [1, 2]])
+    values = torch.tensor([1.1000, 3.2000])
+    tensor_size = torch.tensor([2, 3])
+    assert torch.equal(result.indices(), indices)
+    assert torch.equal(result.values(), values)
+    assert torch.equal(torch.tensor(result.size()), tensor_size)
+
+
+class SparseTensorCommunicationTest(unittest.TestCase):
+    @unittest.skipIf(True, "Failed on gpu")
+    def test_all_reduce_sparse(self):
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = str(find_free_port())
+        world_size = 2
+        mp.spawn(run_all_reduce_sparse, args=(world_size,), nprocs=world_size, join=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/atorch/atorch/tests/common_tests/sync_batch_norm_process_group_test.py
+++ b/atorch/atorch/tests/common_tests/sync_batch_norm_process_group_test.py
@@ -1,0 +1,70 @@
+import os
+import unittest
+
+import torch
+import torch.multiprocessing as mp
+from torch.distributed.distributed_c10d import _get_default_group
+
+import atorch
+from atorch.common.util_func import set_sync_bn_pg
+from atorch.distributed.distributed import create_parallel_group, parallel_group
+
+
+def init_dist(rank, world_size):
+    os.environ["LOCAL_RANK"] = str(rank)
+    os.environ["RANK"] = str(rank)
+    os.environ["WORLD_SIZE"] = str(world_size)
+    if torch.cuda.is_available():
+        atorch.init_distributed("nccl")
+    else:
+        atorch.init_distributed("gloo")
+
+
+def _test_set_sync_batch_norm_process_group(rank, world_size):
+    init_dist(rank, world_size)
+    model_parallel_size = 2
+    data_parallel_size = 1
+    parallel_config = ([("model", model_parallel_size), ("data", data_parallel_size)], None)
+    create_parallel_group(parallel_config)
+    if torch.cuda.is_available():
+        device = torch.device(f"cuda:{atorch.local_rank()}")
+    else:
+        device = torch.device("cpu")
+
+    # Network with nn.BatchNorm layer
+    module = torch.nn.Sequential(
+        torch.nn.Linear(2, 4),
+        torch.nn.BatchNorm1d(4),
+    ).to(device)
+    sync_bn_module = torch.nn.SyncBatchNorm.convert_sync_batchnorm(module, _get_default_group())
+
+    for _, child in sync_bn_module.named_modules():
+        if isinstance(child, torch.nn.SyncBatchNorm):
+            assert child.process_group.size() == world_size
+
+    set_sync_bn_pg(sync_bn_module, parallel_group("data"))
+
+    for _, child in sync_bn_module.named_modules():
+        if isinstance(child, torch.nn.SyncBatchNorm):
+            assert child.process_group.size() == data_parallel_size
+
+    atorch.reset_distributed()
+
+
+class TestReshardingOperator(unittest.TestCase):
+    @unittest.skipIf(
+        not torch.cuda.is_available() or torch.cuda.device_count() < 2,
+        "No gpu available for cuda tests",
+    )
+    def test_syncbatchnorm_process_group(self):
+        world_size = 2
+        mp.spawn(
+            _test_set_sync_batch_norm_process_group,
+            args=(world_size,),
+            nprocs=world_size,
+            join=True,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/atorch/atorch/tests/common_tests/tensor_parallel_operators_test.py
+++ b/atorch/atorch/tests/common_tests/tensor_parallel_operators_test.py
@@ -1,0 +1,135 @@
+"""This test is used to verify the basic tp operators has the expected forward/backward behavior
+"""
+import os
+import unittest
+
+import torch
+import torch.multiprocessing as mp
+import torch.optim as optim
+from torch.nn import MSELoss
+from transformers import set_seed
+
+import atorch
+from atorch.common.util_func import find_free_port
+from atorch.distributed.distributed import destroy_parallel_group, local_rank, world_size
+from atorch.tests.tp_modules.model_args import ModelArgs
+
+
+def init_atorch(model_args):
+    set_seed(42)
+
+    from atorch.distributed.distributed import create_parallel_group
+    from atorch.tests.tp_modules.atorch_mlp import MLP
+
+    tensor_world_size = world_size()
+
+    gpu_partition = ([("tensor", tensor_world_size)], None)
+    create_parallel_group(gpu_partition)
+    device = f"cuda:{local_rank()}" if torch.cuda.is_available() else "cpu"
+    mlp = MLP(model_args).to(device)
+    return mlp
+
+
+def init_fairscale(model_args):
+    set_seed(42)
+    from fairscale.nn.model_parallel.initialize import initialize_model_parallel
+
+    from atorch.tests.tp_modules.fairscale_mlp import MLP
+
+    world_size = int(os.environ.get("WORLD_SIZE", -1))
+    initialize_model_parallel(world_size)
+
+    if torch.cuda.is_available():
+        device = f"cuda:{torch.distributed.get_rank()}"
+    else:
+        device = "cpu"
+
+    mlp = MLP(model_args).to(device)
+    return mlp
+
+
+def run_test(rank, world_size):
+    set_seed(42)
+    os.environ["LOCAL_RANK"] = str(rank)
+    os.environ["RANK"] = str(rank)
+    os.environ["WORLD_SIZE"] = str(world_size)
+    os.environ["NPROC_PER_NODE"] = str(world_size)
+    if torch.cuda.is_available():
+        atorch.init_distributed("nccl")
+        torch.cuda.set_device(rank)
+        device = torch.device(f"cuda:{rank}")
+    else:
+        atorch.init_distributed("gloo")
+        device = "cpu"
+
+    model_params = ModelArgs(
+        dim=64,
+        n_layers=4,
+        n_heads=8,
+        vocab_size=512,
+        norm_eps=1e-5,
+        max_batch_size=8,
+        max_seq_len=8,
+    )
+
+    atorch_mlp = init_atorch(model_params)
+    fairscale_mlp = init_fairscale(model_params)
+
+    input_ids = torch.randint(
+        low=0,
+        high=model_params.vocab_size,
+        size=(model_params.max_batch_size, model_params.max_seq_len),
+        dtype=torch.long,
+        device=device,
+    )
+    labels = torch.rand(model_params.max_batch_size, model_params.max_seq_len, model_params.dim, device=device)
+
+    atorch_loss_fct = MSELoss()
+    fairscale_loss_fct = MSELoss()
+
+    atorch_mlp.train()
+    fairscale_mlp.train()
+
+    atorch_optimizer = optim.SGD(atorch_mlp.parameters(), lr=0.1)
+    fairscale_optimizer = optim.SGD(fairscale_mlp.parameters(), lr=0.1)
+
+    # step: 0, atorch loss: 0.32881444692611694
+    # step: 0, fairscale loss: 0.32881444692611694
+    # step: 1, atorch loss: 0.373551607131958
+    # step: 1, fairscale loss: 0.373551607131958
+    for _ in range(2):
+        atorch_logits = atorch_mlp(input_ids)
+        fairscale_logits = fairscale_mlp(input_ids)
+        atorch_optimizer.zero_grad()
+        fairscale_optimizer.zero_grad()
+
+        atorch_loss = atorch_loss_fct(atorch_logits.view(-1), labels.view(-1))
+        fairscale_loss = fairscale_loss_fct(fairscale_logits.view(-1), labels.view(-1))
+        assert torch.allclose(atorch_loss, fairscale_loss), "torch and fairscale should return the same loss"
+
+        atorch_loss.backward(retain_graph=True)
+        fairscale_loss.backward(retain_graph=True)
+        atorch_optimizer.step()
+        fairscale_optimizer.step()
+
+    atorch.reset_distributed()
+
+
+class TestTPMLP(unittest.TestCase):
+    def tearDown(self):
+        destroy_parallel_group()
+        return super().tearDown()
+
+    @unittest.skipIf(torch.cuda.is_available() and torch.cuda.device_count() != 2, "run with cpu or gpu_num >=2")
+    def test_tp_mlp(self):
+        world_size = torch.cuda.device_count()
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = str(find_free_port())
+        mp.spawn(
+            run_test,
+            args=(world_size,),
+            nprocs=world_size,
+            join=True,
+        )
+        os.environ["MASTER_ADDR"] = ""
+        os.environ["MASTER_PORT"] = ""

--- a/atorch/atorch/tests/common_tests/tensor_parallel_optimization_test.py
+++ b/atorch/atorch/tests/common_tests/tensor_parallel_optimization_test.py
@@ -1,0 +1,81 @@
+import unittest
+
+import torch
+from torch.utils.data import Dataset
+
+from atorch.auto.model_context import ModelContext
+from atorch.auto.opt_lib.tensor_parallel_optimization import TensorParallelOptimization
+from atorch.distributed.distributed import destroy_parallel_group
+
+
+class MyModule(torch.nn.Module):
+    def __init__(self, in_features, out_features, bias=True):
+        super().__init__()
+        self.layer = torch.nn.Linear(in_features, out_features, bias=bias)
+        self.layers = torch.nn.ModuleList([torch.nn.Linear(out_features, out_features, bias=bias) for _ in range(16)])
+
+    def forward(self, input_):
+        data = torch.nn.functional.softmax(self.layer(input_[0]), dim=-1)
+        for op in self.layers:
+            data = op(data)
+            data = torch.nn.functional.softmax(data, dim=-1)
+        return data
+
+
+class ToyDataset(Dataset):
+    def __init__(self, size):
+        self.size = size
+
+    def __len__(self):
+        return self.size
+
+    def __getitem__(self, idx):
+        return torch.rand((7, 32)), torch.randn(16)
+
+
+def prepare_input(data, device):
+    return data[0].to(device), data[1].to(device)
+
+
+def create_model_context(data_size=16, batch_size=3):
+    model = MyModule(32, 16, True)
+    dataset = ToyDataset(data_size)
+    model_context = ModelContext(
+        model=model,
+        dataset=dataset,
+        prepare_input=prepare_input,
+        dataloader_args={"batch_size": batch_size, "drop_last": True},
+    )
+    return model_context
+
+
+def _run_tensor_parallel_optimization(num_nodes=1, num_devices_per_node=2):
+    # This is mock test for TensorParallelOptimization
+    # Test to make sure TP can generate a replacement_map
+    torch.manual_seed(42)
+
+    model_context = create_model_context()
+
+    parallel_optimization = TensorParallelOptimization(
+        shard_planner="base",
+        num_nodes=num_nodes,
+        num_devices_per_node=num_devices_per_node,
+        tracer_backend="meta_fx",
+        prop_mode="meta_tracer",
+    )
+
+    status, best_config, model_context = parallel_optimization.tune(model_context, {"tp_ranks": [0, 1]}, [])
+    assert "replacement_map" in best_config and status
+
+
+class TestTensorParallelOptimization(unittest.TestCase):
+    def tearDown(self):
+        destroy_parallel_group()
+        return super().tearDown()
+
+    def test_tensor_parallel_optimization(self):
+        _run_tensor_parallel_optimization()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/atorch/atorch/tests/common_tests/test_dataset.py
+++ b/atorch/atorch/tests/common_tests/test_dataset.py
@@ -1,0 +1,58 @@
+import json
+import os.path
+import unittest
+from io import BytesIO
+
+import torch
+import torchvision.transforms as transforms
+from PIL import Image
+
+import atorch
+from atorch.common.constants import DataConstants
+from atorch.data.dataloader import AtorchDataloader
+
+
+def transform_item_func(image_bytes, meta_bytes):
+    with Image.open(BytesIO(image_bytes)) as img:
+        img = transforms.ToTensor()(img)
+    return (img, json.load(BytesIO(meta_bytes)))
+
+
+@unittest.skipIf(not torch.cuda.is_available(), "can not import zdfs in aci image, works in gpu image")
+class ChunkDatasetTest(unittest.TestCase):
+    def setUp(self) -> None:
+        import zdfs
+
+        atorch.reset_distributed()
+        atorch.init_distributed()
+        self.index_file = os.path.join(
+            "dfs://unifile_sdk/test-0625",
+            "antsys-max-rs_multimodal_TrainJsonl_laion5B_zh_simple_total_pcache_filter_1000000/index.jsonl",
+        )
+        self.dfs_kwargs = {
+            "cluster": "dfs://f-c1f77171wai77.cn-heyuan.dfs.aliyuncs.com:10290",
+            "options": zdfs.FileSystemOptions(),
+        }
+
+    def test_chunk_dataset(self):
+        dataset_options = {
+            DataConstants.IS_CHUNK: True,
+            DataConstants.JSONL_VERSION: 1,
+            DataConstants.DFS_KWARGS: self.dfs_kwargs,
+            "buf_size": 10,
+            "transform_item_func": transform_item_func,
+        }
+        dataloader = AtorchDataloader(self.index_file, dataset_options)
+        dataloader.dataset._epoch = 0
+        num = 0
+        for _ in iter(dataloader):
+            if num > 10:
+                break
+            num += 1
+
+    def tearDown(self) -> None:
+        atorch.reset_distributed()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/atorch/atorch/tests/common_tests/test_quantize.py
+++ b/atorch/atorch/tests/common_tests/test_quantize.py
@@ -1,0 +1,210 @@
+# Modifications Copyright 2023 AntGroups, Inc.
+# ATorch Team
+
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+# DeepSpeed Team
+
+import unittest
+
+import torch
+
+from atorch.ops.accelerator import get_accelerator
+
+# if not atorch.ops.__compatible_ops__[QuantizerBuilder.NAME]:
+#     pytest.skip("Inference ops are not available on this system", allow_module_level=True)
+
+inference_module = None
+
+
+def run_quantize(activations, num_groups, q_bits, is_symmetric_quant):
+    global inference_module
+    if inference_module is None:
+        from atorch.ops.op_builder import QuantizerBuilder
+
+        inference_module = QuantizerBuilder().load()
+
+    return inference_module.quantize(
+        activations,
+        num_groups,
+        q_bits,
+        inference_module.Symmetric if is_symmetric_quant else inference_module.Asymmetric,
+    )
+
+
+def run_dequantize(activations, params, num_groups, q_bits, is_symmetric_quant):
+    global inference_module
+    if inference_module is None:
+        from atorch.ops.op_builder import QuantizerBuilder
+
+        inference_module = QuantizerBuilder().load()
+    return inference_module.dequantize(
+        activations,
+        params,
+        num_groups,
+        q_bits,
+        inference_module.Symmetric if is_symmetric_quant else inference_module.Asymmetric,
+    )
+
+
+def get_q_props(q_bits):
+    q_range = 2**q_bits
+    q_min = -(2 ** (q_bits - 1))
+    q_max = 2 ** (q_bits - 1) - 1
+
+    q_min = torch.IntTensor([q_min]).to(device=get_accelerator().device_name())
+    q_max = torch.IntTensor([q_max]).to(device=get_accelerator().device_name())
+    return q_range, q_max, q_min
+
+
+def get_scale_zero_point(q_bits, is_symmetric_quant, max, min, absmax, scales=None, zero_points=None):
+
+    q_range, q_max, q_min = get_q_props(q_bits)
+
+    if is_symmetric_quant:
+        scale = torch.empty_like(absmax)
+        for i, x in enumerate(absmax):
+            scale[i] = torch.ones_like(x) if x == 0 else q_range / (2 * x)
+        zero_point = torch.zeros(scale.shape, dtype=torch.float32, device=get_accelerator().device_name())
+    else:
+        scale = torch.empty_like(max)
+        for i, x in enumerate(max):
+            scale[i] = torch.ones_like(x) if max[i] == min[i] else q_range / (max[i] - min[i])
+        zero_point = q_min - (min * scale)
+
+    return scale, zero_point
+
+
+def int4x2to2xint4(int4X2tensor):
+    high = int4X2tensor >> 4
+    low = (int4X2tensor << 4) >> 4
+    return torch.stack((high, low), dim=-1).flatten()
+
+
+def run_float_quantize(q_bits, is_symmetric_quant, activations_ref, num_groups):
+
+    # Reference implementation
+    # https://pytorch.org/docs/stable/quantization-support.html
+
+    activations_ref = activations_ref.reshape(num_groups, -1).to(dtype=torch.float32)
+
+    max_abs_activations_ref = torch.amax(torch.abs(activations_ref), dim=-1).view(num_groups, -1)
+    max_activations_ref = torch.amax(activations_ref, dim=-1).view(num_groups, -1)
+    min_activations_ref = torch.amin(activations_ref, dim=-1).view(num_groups, -1)
+
+    _, q_max, q_min = get_q_props(q_bits)
+
+    scale, zero_point = get_scale_zero_point(
+        q_bits, is_symmetric_quant, max_activations_ref, min_activations_ref, max_abs_activations_ref
+    )
+
+    data_f = activations_ref * scale
+
+    if not is_symmetric_quant:
+        data_f = data_f + zero_point
+
+    data_i32 = torch.round(data_f).to(dtype=torch.int32)
+
+    data_i32 = torch.minimum(torch.maximum(data_i32, q_min.expand_as(data_i32)), q_max.expand_as(data_i32))
+    data_i8 = data_i32.to(dtype=torch.int8)
+
+    scales = (1.0 / scale).reshape(-1, 1)
+    offsets = zero_point.reshape(-1, 1)
+    params = torch.cat((scales, offsets), dim=-1)
+
+    return data_i8, params
+
+
+def run_float_dequantize(q_bits, is_symmetric_quant, data_i8, params, num_groups):
+    data_f = data_i8.reshape(num_groups, -1).to(dtype=torch.float32)
+
+    scales = params[:, 0].reshape(-1, 1)
+    offsets = params[:, 1].reshape(-1, 1)
+
+    if not is_symmetric_quant:
+        data_f = data_f - offsets
+    else:
+        assert offsets.allclose(torch.zeros_like(offsets))
+
+    data_f = data_f * scales
+
+    return data_f
+
+
+class QuantizeTest(unittest.TestCase):
+    @unittest.skipIf(
+        not torch.cuda.is_available(),
+        "No gpu available for cuda tests",
+    )
+    def test_quantize(self):
+        def callback(num_elems, num_groups, is_symmetric_quant, q_bits, directed_case):
+            # fix seed
+            torch.manual_seed(num_elems)
+
+            if directed_case == "all_zeros":
+                activations = torch.zeros(
+                    (num_groups, num_elems), dtype=torch.float16, device=get_accelerator().device_name()
+                )
+            else:
+                activations = torch.randn(
+                    (num_groups, num_elems), dtype=torch.float16, device=get_accelerator().device_name()
+                )
+            activations_ref = activations.clone().detach()
+
+            ref_out_tensor, ref_params = run_float_quantize(q_bits, is_symmetric_quant, activations_ref, num_groups)
+            ref_dequantized_tensor = run_float_dequantize(
+                q_bits, is_symmetric_quant, ref_out_tensor, ref_params, num_groups
+            )
+            # we need to convert the tensor to float64 to avoid overflow
+            ref_quantization_error = torch.sum(torch.abs((activations_ref - ref_dequantized_tensor).to(torch.float64)))
+
+            out_tensor, out_params = run_quantize(activations, num_groups, q_bits, is_symmetric_quant)
+            dequantized_tensor = run_dequantize(out_tensor, out_params, num_groups, q_bits, is_symmetric_quant)
+            assert torch.all(torch.isfinite(dequantized_tensor))
+
+            quantization_error = torch.sum(torch.abs((activations - dequantized_tensor).to(torch.float64)))
+
+            assert quantization_error <= ref_quantization_error * 1.05
+
+        for _num_groups in [1, 13, 512]:
+            for _num_elems in [8, 16, 32, 64, 128, 256, 4096, 8192, 12288, 16384]:
+                for _is_symmetric_quant in True, False:
+                    for _q_bits in [4, 8]:
+                        for _directed_case in ["all_zeros", None]:
+                            callback(_num_elems, _num_groups, _is_symmetric_quant, _q_bits, _directed_case)
+
+
+class CUDAQuantizeTest(unittest.TestCase):
+    @unittest.skipIf(
+        not torch.cuda.is_available(),
+        "No gpu available for cuda tests",
+    )
+    def test_cuda_quantizer(self):
+        num_elems = 4096
+        num_groups = 512
+        from atorch.ops.quantizer import CUDAQuantizer
+
+        cuda_quantizer = CUDAQuantizer()
+
+        torch.manual_seed(num_elems)
+
+        activations = torch.randn((num_groups, num_elems), dtype=torch.float16, device=get_accelerator().device_name())
+
+        activations_ref = activations.clone().detach()
+
+        ref_out_tensor_1, ref_params_1 = cuda_quantizer.quantize(activations)
+        ref_dequantized_tensor_1 = cuda_quantizer.dequantize(ref_out_tensor_1, ref_params_1)
+
+        # we need to convert the tensor to float64 to avoid overflow
+        ref_quantization_error_1 = torch.sum(torch.abs((activations_ref - ref_dequantized_tensor_1).to(torch.float64)))
+
+        ref_out_tensor_2, ref_params_2 = run_float_quantize(8, True, activations_ref, num_groups)
+        ref_dequantized_tensor_2 = run_float_dequantize(8, True, ref_out_tensor_2, ref_params_2, num_groups)
+        ref_quantization_error_2 = torch.sum(torch.abs((activations_ref - ref_dequantized_tensor_2).to(torch.float64)))
+
+        assert ref_quantization_error_1 <= ref_quantization_error_2 * 1.05
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/atorch/atorch/tests/common_tests/tp_activation_checkpoint_test.py
+++ b/atorch/atorch/tests/common_tests/tp_activation_checkpoint_test.py
@@ -1,0 +1,139 @@
+import os
+import tempfile
+import unittest
+
+import torch
+import torch.multiprocessing as mp
+import torch.optim as optim
+from torch.nn import MSELoss
+from transformers import set_seed
+
+import atorch
+from atorch.distributed.distributed import local_rank, world_size
+from atorch.modules.distributed_modules.activation_checkpointing import tp_wrap_fn
+from atorch.tests.tp_modules.model_args import ModelArgs
+
+
+def init_atorch(model_args):
+    set_seed(42)
+
+    from atorch.distributed.distributed import create_parallel_group
+    from atorch.tests.tp_modules.atorch_mlp import MLP, FeedForward
+
+    tensor_world_size = world_size()
+
+    gpu_partition = ([("tensor", tensor_world_size)], None)
+    create_parallel_group(gpu_partition)
+    device = f"cuda:{local_rank()}"
+    mlp = MLP(model_args).to(device)
+
+    from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import apply_activation_checkpointing
+
+    wrap_modules = (FeedForward,)
+
+    def check_fn(module):
+        return isinstance(module, wrap_modules)
+
+    apply_activation_checkpointing(
+        mlp,
+        checkpoint_wrapper_fn=tp_wrap_fn,
+        check_fn=check_fn,
+    )
+    return mlp
+
+
+def init_fairscale(model_args):
+    set_seed(42)
+    from fairscale.nn.model_parallel.initialize import initialize_model_parallel
+
+    from atorch.tests.tp_modules.fairscale_mlp import MLP
+
+    world_size = int(os.environ.get("WORLD_SIZE", -1))
+    initialize_model_parallel(world_size)
+    device = f"cuda:{torch.distributed.get_rank()}"
+
+    mlp = MLP(model_args).to(device)
+    return mlp
+
+
+def run_test(rank, world_size, tmp_file):
+    set_seed(42)
+    os.environ["RANK"] = f"{rank}"
+    os.environ["WORLD_SIZE"] = f"{world_size}"
+    atorch.init_distributed("nccl")
+    torch.cuda.set_device(rank)
+    device = torch.device(f"cuda:{rank}")
+
+    model_params = ModelArgs(
+        dim=64,
+        n_layers=4,
+        n_heads=8,
+        vocab_size=512,
+        norm_eps=1e-5,
+        max_batch_size=8,
+        max_seq_len=8,
+    )
+
+    atorch_mlp = init_atorch(model_params)
+
+    fairscale_mlp = init_fairscale(model_params)
+
+    input_ids = torch.randint(
+        low=0,
+        high=model_params.vocab_size,
+        size=(model_params.max_batch_size, model_params.max_seq_len),
+        dtype=torch.long,
+        device=device,
+    )
+    labels = torch.rand(model_params.max_batch_size, model_params.max_seq_len, model_params.dim, device=device)
+
+    atorch_loss_fct = MSELoss()
+    fairscale_loss_fct = MSELoss()
+
+    atorch_mlp.train()
+    fairscale_mlp.train()
+
+    atorch_optimizer = optim.SGD(atorch_mlp.parameters(), lr=0.1)
+    fairscale_optimizer = optim.SGD(fairscale_mlp.parameters(), lr=0.1)
+
+    # step: 0, atorch loss: 0.32881444692611694
+    # step: 0, fairscale loss: 0.32881444692611694
+    # step: 1, atorch loss: 0.373551607131958
+    # step: 1, fairscale loss: 0.373551607131958
+    for _ in range(2):
+        atorch_logits = atorch_mlp(input_ids)
+        fairscale_logits = fairscale_mlp(input_ids)
+        atorch_optimizer.zero_grad()
+        fairscale_optimizer.zero_grad()
+
+        atorch_loss = atorch_loss_fct(atorch_logits.view(-1), labels.view(-1))
+        fairscale_loss = fairscale_loss_fct(fairscale_logits.view(-1), labels.view(-1))
+        assert torch.allclose(atorch_loss, fairscale_loss), "torch and fairscale should return the same loss"
+
+        atorch_loss.backward(retain_graph=True)
+        fairscale_loss.backward(retain_graph=True)
+        atorch_optimizer.step()
+        fairscale_optimizer.step()
+
+    atorch.reset_distributed()
+
+
+class TestTPMLP(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.mkstemp()[1]
+
+    def tearDown(self):
+        try:
+            os.remove(self.temp)
+        except FileNotFoundError:
+            pass
+
+    @unittest.skipIf(True, "init_process_group timeout error")
+    def test_tp_checkpointing(self):
+        world_size = 2
+        mp.spawn(
+            run_test,
+            args=(world_size, self.temp),
+            nprocs=world_size,
+            join=True,
+        )

--- a/atorch/atorch/tests/common_tests/tracer_test.py
+++ b/atorch/atorch/tests/common_tests/tracer_test.py
@@ -1,0 +1,68 @@
+import unittest
+
+import torch
+
+from atorch.utils.tracer import MetaTracer
+
+
+# create a nested module tree
+# to make sure control flow variables
+# can be correctly propogated
+# also test if leaf modules can be correctly registered
+class Level1(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.layer0 = torch.nn.Linear(4, 4)
+
+    def forward(self, x):
+        return self.layer0(x)
+
+
+class Level2(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.layer1a = Level1()
+        self.layer1b = torch.nn.Linear(4, 4)
+
+    def forward(self, x, y=None):
+        if x is not None and y is not None:
+            raise ValueError("x and y set simultaneously")
+        if x is not None:
+            return self.layer1a(x)
+        else:
+            return self.layer1b(y)
+
+
+class Level3(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.layer2 = Level2()
+
+    def forward(self, x, y=None):
+        return self.layer2(x, y)
+
+
+class Level4(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.layer3 = Level3()
+
+    def forward(self, x, y=None):
+        return torch.nn.functional.relu(self.layer3(x, y))
+
+
+class TestTracer(unittest.TestCase):
+    def test_tracer(self):
+        x = torch.rand((3, 4))
+        model = Level4()
+        tracer = MetaTracer()
+        tracer.register_leaf_modules([Level1, Level3])
+        traced_graph = tracer.trace(model, {"x": x})
+        traced = torch.fx.GraphModule(model, traced_graph)
+        # traced.device = model.device
+        normal_output = model(x)
+        test_output = traced(x)
+        self.assertEqual(normal_output.shape, test_output.shape)
+        for i in range(normal_output.shape[0]):
+            for j in range(normal_output.shape[1]):
+                self.assertEqual(float(normal_output[i][j]), float(test_output[i][j]))

--- a/atorch/atorch/tests/common_tests/trainer_test.py
+++ b/atorch/atorch/tests/common_tests/trainer_test.py
@@ -1,0 +1,109 @@
+import os
+import unittest
+
+import torch
+import torch.multiprocessing as mp
+from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+from torch.utils.data import Dataset
+from transformers import LlamaConfig
+from transformers.models.llama.modeling_llama import LlamaDecoderLayer, LlamaForCausalLM
+
+import atorch
+from atorch.common.util_func import find_free_port
+from atorch.trainer.atorch_args import AtorchArguments
+from atorch.trainer.atorch_trainer import AtorchTrainer
+from atorch.utils.version import torch_version
+
+
+class LlamaDatset(Dataset):
+    def __init__(self, size=100, max_words=30):
+        self.size = 100
+        self.max_words = max_words
+
+    def __len__(self):
+        return self.size
+
+    def __getitem__(self, idx):
+        input_ids = torch.ones([self.max_words], dtype=torch.int64)
+        labels = torch.ones([self.max_words], dtype=torch.int64)
+        attention_mask = torch.ones([self.max_words], dtype=torch.float32)
+        return {
+            "input_ids": input_ids,
+            "labels": labels,
+            "attention_mask": attention_mask,
+        }
+
+
+def run_atorch_trainer(rank, world_size):
+    os.environ["LOCAL_RANK"] = str(rank)
+    os.environ["RANK"] = str(rank)
+    os.environ["WORLD_SIZE"] = str(world_size)
+    os.environ["NPROC_PER_NODE"] = str(world_size)
+
+    train_dataset = LlamaDatset(100)
+    eval_dataset = LlamaDatset(20)
+
+    config = LlamaConfig(
+        vocab_size=10,
+        hidden_size=32,
+        intermediate_size=1,
+        num_hidden_layers=4,
+        num_attention_heads=4,
+        max_position_embeddings=1,
+    )
+    model = LlamaForCausalLM(config)
+    args = AtorchArguments(
+        output_dir="/tmp/output_atorch_trainer",
+        num_train_epochs=1,
+        per_device_train_batch_size=1,
+        per_device_eval_batch_size=1,
+        do_train=True,
+        fp16=True,
+        save_load_by_streaming=True,
+        save_strategy="steps",
+        save_steps=0.8,
+        save_total_limit=2,
+        evaluation_strategy="steps",
+        eval_steps=0.9,
+        logging_strategy="steps",
+        logging_steps=0.5,
+        logging_nan_inf_filter=False,
+        gradient_checkpointing=True,
+        atorch_opt="fsdp",
+        atorch_wrap_cls=(LlamaDecoderLayer,),
+        model_input_format="unpack_dict",
+        use_atorch_dataloader=False,
+    )
+    trainer = AtorchTrainer(
+        model=model,
+        args=args,
+        train_dataset=train_dataset,
+        eval_dataset=eval_dataset,
+        optimizers=(torch.optim.AdamW, None),
+    )
+    train_result = trainer.train()
+    metrics = train_result.metrics
+    metrics["train_samples"] = len(train_dataset)
+    trainer.log_metrics("train", metrics)
+    trainer.save_metrics("train", metrics)
+    trainer.save_state()
+    assert isinstance(trainer.model, FSDP)
+    assert isinstance(metrics, dict)
+    atorch.reset_distributed()
+
+
+@unittest.skipIf(not torch.cuda.is_available(), "Skip cpu ut, only run on gpu.")
+@unittest.skipIf(torch_version() < (2, 0, 0), "AtorchTrainer need torch2.0 .")
+class AtorchTrainerTest(unittest.TestCase):
+    def test_atorch_trainer(self):
+        world_size = 4
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = str(find_free_port())
+        mp.spawn(
+            run_atorch_trainer,
+            args=(world_size,),
+            nprocs=world_size,
+            join=True,
+        )
+        os.environ["MASTER_ADDR"] = ""
+        os.environ["MASTER_PORT"] = ""

--- a/atorch/atorch/tests/common_tests/tune_test.py
+++ b/atorch/atorch/tests/common_tests/tune_test.py
@@ -1,0 +1,75 @@
+import unittest
+
+from atorch.auto.accelerate import model_transform, run_tune_task
+from atorch.auto.opt_lib.optimization import Optimization
+from atorch.auto.opt_lib.optimization_library import OptimizationLibrary
+from atorch.auto.strategy import Strategy
+from atorch.tests.toy_modules.toy_module import create_model_context
+
+
+class DummyXOptimization(Optimization):
+    def __init__(self):
+        name = "dummyx"
+        group = "dummy"
+        is_tunable = True
+        super().__init__(name, group, is_tunable)
+
+    def tune(self, model_context, config=None, strategy=None, apply_transform=True, time_limit=None):
+        best_config = {"batch_size": 10}
+        if apply_transform:
+            model_context = self.transform(model_context, best_config, apply_wrapper=False)
+        return True, best_config, model_context
+
+    def transform(self, model_context, config=None, apply_wrapper=False):
+        if model_context.dataloader_args is None:
+            model_context.dataloader_args = config
+        else:
+            model_context.dataloader_args.update(config)
+        return model_context
+
+
+class DummyYOptimization(Optimization):
+    def __init__(self):
+        name = "dummyy"
+        group = "dummy"
+        is_tunable = True
+        super().__init__(name, group, is_tunable)
+
+    def tune(self, model_context, config=None, strategy=None, apply_transform=True, time_limit=None):
+        best_config = {"lr": 0.0002}
+        if apply_transform:
+            model_context = self.transform(model_context, best_config, apply_wrapper=False)
+        return True, best_config, model_context
+
+    def transform(self, model_context, config=None, apply_wrapper=False):
+        if model_context.optim_args is None:
+            model_context.optim_args = config
+        else:
+            model_context.optim_args.update(config)
+        return model_context
+
+
+class TuneTest(unittest.TestCase):
+    def test_tune(self):
+        model_context = create_model_context(data_size=8, batch_size=2)
+        opt_lib = OptimizationLibrary()
+        # add dummy opts
+        dummyx = DummyXOptimization()
+        dummyy = DummyYOptimization()
+        opt_lib.register_opt(dummyx)
+        opt_lib.register_opt(dummyy)
+        strategy = Strategy()
+        strategy.add_opt(("dummyx", None, True))
+        strategy.add_opt(("dummyy", None, True))
+        strategy.add_opt(("dummyy", {"weight_decay": 0.1}, False))
+        status, result = run_tune_task(model_context, strategy, opt_lib)
+        self.assertTrue(status)
+        # check result
+        self.assertTrue(len(result) == 3)
+        self.assertTrue(result[0] == ("dummyx", {"batch_size": 10}, False))
+        self.assertTrue(result[1] == ("dummyy", {"lr": 0.0002}, False))
+        self.assertTrue(result[2] == ("dummyy", {"weight_decay": 0.1}, False))
+        mc = model_transform(model_context, result, opt_lib, create_optim=False, create_dataloader=False)
+        self.assertTrue(mc.dataloader_args["batch_size"] == 10)
+        self.assertTrue(mc.optim_args["lr"] == 0.0002)
+        self.assertTrue(mc.optim_args["weight_decay"] == 0.1)

--- a/atorch/atorch/tests/common_tests/unordered_dataloader_test.py
+++ b/atorch/atorch/tests/common_tests/unordered_dataloader_test.py
@@ -1,0 +1,99 @@
+import time
+import unittest
+
+import torch
+from torch.utils.data import Dataset, IterableDataset
+
+from atorch.data import UnorderedDataLoader
+
+
+class _TestDataset(Dataset):
+    def __init__(self, data_size=32, sleep_time=0):
+        self.size = data_size
+        self.sleep_time = sleep_time
+
+    def __len__(self):
+        return self.size
+
+    def __getitem__(self, idx):
+        time.sleep(0.001)
+        info = torch.utils.data.get_worker_info()
+        if info.id == 1 and self.sleep_time > 0:
+            time.sleep(self.sleep_time * 2.5)
+        if info.id == 2 and self.sleep_time > 0:
+            time.sleep(self.sleep_time)
+        return info.id
+
+
+class _TestIterableDataset(IterableDataset):
+    def __init__(self, data_size=32, sleep_time=0):
+        self.size = data_size
+        self.sleep_time = sleep_time
+
+    def __iter__(self):
+        worker_info = torch.utils.data.get_worker_info()
+        if worker_info is None:  # single-process data loading, return the full iterator
+            worker_id = 0
+        else:  # in a worker process
+            worker_id = worker_info.id
+        if worker_id == 1:
+            time.sleep(self.sleep_time)
+        for x in range(self.size):
+            yield x + worker_id * 100
+
+
+class UnorderedDataLoaderTest(unittest.TestCase):
+    def test_outof_order(self):
+        size = 16
+        batch_size = 2
+        num_workers = 4
+        sleep_time = 0.5
+        dataset = _TestDataset(size, sleep_time)
+        dataloader = UnorderedDataLoader(dataset, batch_size=batch_size, num_workers=num_workers)
+
+        result = [data for data in dataloader]
+
+        self.assertEqual(len(dataloader), len(result))
+        # result in the order of other | 2 | 1
+        worker_len = len(result) // num_workers
+        id_2_index = len(result) - 2 * worker_len
+        total_v = 0
+        for batch in result[id_2_index:]:
+            for d in batch:
+                total_v += d
+        self.assertEqual(3 * worker_len * batch_size, total_v)
+        self.assertEqual(result[id_2_index][0], 2)
+        self.assertEqual(result[-1][-1], 1)
+
+        dataloader = UnorderedDataLoader(
+            dataset,
+            batch_size=1,
+            num_workers=num_workers,
+            prefetch_factor=1,
+        )
+
+        result = [data for data in dataloader]
+        self.assertEqual(len(dataloader), len(result))
+
+        worker_1_count = 0
+        worker_2_count = 0
+        for res in result:
+            if res[0] == 1:
+                worker_1_count += 1
+            if res[0] == 2:
+                worker_2_count += 1
+        # worker 1 would only process once as they are slow
+        self.assertEqual(worker_1_count, 1)
+        # worker 2 is also slow and may process once or twice
+        self.assertTrue(worker_2_count <= 2)
+
+    def test_iterable(self):
+        size = 16
+        batch_size = 2
+        num_workers = 2
+        sleep_time = 0.5
+        dataset = _TestIterableDataset(size, sleep_time)
+        dataloader = UnorderedDataLoader(dataset, batch_size=batch_size, num_workers=num_workers)
+
+        result = [data for data in dataloader]
+        self.assertEqual(len(result), size // batch_size * num_workers)

--- a/atorch/atorch/tests/common_tests/unshuffled_batch_dataloder_test.py
+++ b/atorch/atorch/tests/common_tests/unshuffled_batch_dataloder_test.py
@@ -1,0 +1,37 @@
+import unittest
+
+from torch.utils.data import Dataset
+
+from atorch.data.unshuffled_batch_dataloader import DistributedUnshuffledBatchSampler
+
+
+class _TestDataset(Dataset):
+    def __init__(self, data_size=32):
+        self.size = data_size
+        self.data = [i for i in range(data_size)]
+
+    def __len__(self):
+        return self.size
+
+    def __getitem__(self, idx):
+        return self.data[idx]
+
+
+class DistributedUnshuffledBatchSamplerTest(unittest.TestCase):
+    def test_unshuffled_batch_sampler(self):
+        dataset = _TestDataset(data_size=64)
+        num_replicas = 8
+        rank = 0
+        batch_size = 4
+        indices = [0, 1, 2, 3, 32, 33, 34, 35]
+        sampler = DistributedUnshuffledBatchSampler(
+            dataset, num_replicas=num_replicas, rank=rank, batch_size=batch_size
+        )
+        res = []
+        for i in sampler:
+            res.append(i)
+        self.assertListEqual(res, indices)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/atorch/atorch/tests/common_tests/util_test.py
+++ b/atorch/atorch/tests/common_tests/util_test.py
@@ -1,0 +1,41 @@
+import unittest
+
+from atorch.utils.hooks import ATorchHooks
+from atorch.utils.import_util import import_module_from_py_file
+
+
+class UtilsTest(unittest.TestCase):
+    def test_import_module_from_py_file(self):
+        file_path = "/none/exist/file/path"
+        module = import_module_from_py_file(file_path)
+        self.assertEqual(module, None)
+        file_path = "./atorch/tests/test_define_rl_models/independent_models/strategy.py"
+        module = import_module_from_py_file(file_path)
+        self.assertTrue(module is not None)
+        self.assertTrue(hasattr(module, "strategy"))
+
+    def test_atorch_hooks(self):
+        class TestData:
+            value = 0
+
+        def inc_value(data):
+            data.value += 1
+
+        def dec_value(data):
+            data.value -= 1
+
+        ATorchHooks.register_hook("data_hook", inc_value)
+        ATorchHooks.call_hooks("data_hook", TestData)
+        self.assertEqual(TestData.value, 1)
+        ATorchHooks.call_hooks("data_hook", TestData)
+        self.assertEqual(TestData.value, 2)
+        ATorchHooks.register_hook("data_hook", dec_value)
+        ATorchHooks.call_hooks("data_hook", TestData)
+        self.assertEqual(TestData.value, 2)
+        ATorchHooks.remove_hook("data_hook", inc_value)
+        ATorchHooks.call_hooks("data_hook", TestData)
+        self.assertEqual(TestData.value, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/atorch/atorch/tests/common_tests/zero_optimization_test.py
+++ b/atorch/atorch/tests/common_tests/zero_optimization_test.py
@@ -1,0 +1,200 @@
+import copy
+import unittest
+from unittest.mock import patch
+
+import torch
+from fairscale.nn.data_parallel import ShardedDataParallel as ShardedDDP
+from fairscale.nn.misc import ParamBucket
+from fairscale.optim.oss import OSS
+from torch import nn
+from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+
+import atorch
+from atorch.auto import auto_accelerate
+from atorch.auto.opt_lib.utils import to_module_class_by_name
+from atorch.auto.opt_lib.zero_optimization import FSDPOptimization, Zero1Optimization, Zero2Optimization
+from atorch.tests.toy_modules.toy_module import ToyCustomModule, create_model_context
+from atorch.utils.patch_fairscale import patch_add_param_as_view, patch_setup_flat_buffers
+from atorch.utils.version import torch_version
+
+
+class ZeroOptimizationTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.model_context = create_model_context(use_custom_module=True)
+
+    def test_zero_optimization(self):
+        backend = "nccl" if torch.cuda.is_available() else "gloo"
+        atorch.init_distributed(backend)
+        zero1_optimization = Zero1Optimization()
+        zero2_optimization = Zero2Optimization()
+        fsdp_optimization = FSDPOptimization()
+
+        # test zero1
+        zero1_model_context = copy.deepcopy(self.model_context)
+        zero1_model_context = zero1_optimization.transform(zero1_model_context, config=None)
+        self.assertIsInstance(zero1_model_context.create_optim(), OSS)
+
+        # test zero2
+        zero2_model_context = copy.deepcopy(self.model_context)
+        zero2_model_context = zero2_optimization.transform(zero2_model_context, None)
+        zero2_model_context.apply_wrappers(is_pre_wrapper=True)
+        zero2_model_context.update_optim()
+        zero2_model_context.apply_wrappers(is_pre_wrapper=False)
+        if torch_version() < (1, 12, 0) or not torch.cuda.is_available():
+            self.assertIsInstance(zero2_model_context.optim, OSS)
+            self.assertIsInstance(zero2_model_context.model, ShardedDDP)
+        else:
+            self.assertIsInstance(zero2_model_context.model, FSDP)
+
+        # test zero2 with not_use_fsdp
+        zero2_model_context = copy.deepcopy(self.model_context)
+        zero_conf = {"sync_models_at_startup": True, "not_use_fsdp": True}
+        zero2_model_context = zero2_optimization.transform(zero2_model_context, config=zero_conf)
+        zero2_model_context.update_optim()
+        zero2_model_context.apply_wrappers(is_pre_wrapper=False)
+        self.assertTrue("zero2" in zero2_model_context.post_wrappers)
+        self.assertIsInstance(zero2_model_context.model, ShardedDDP)
+
+        # test fsdp, gpu only
+        if torch.cuda.is_available():
+            fsdp_model_context = copy.deepcopy(self.model_context)
+            zero_conf = {"sync_module_states": True, "forward_prefetch": True, "atorch_wrap_cls": ("Linear",)}
+            fsdp_model_context = fsdp_optimization.transform(fsdp_model_context, config=zero_conf)
+            fsdp_model_context.apply_wrappers(is_pre_wrapper=True)
+            self.assertTrue("fsdp" in fsdp_model_context.pre_wrappers)
+            self.assertIsInstance(fsdp_model_context.model, FSDP)
+        atorch.reset_distributed()
+
+    @unittest.skipIf(not torch.cuda.is_available(), "cuda is not available")
+    def test_fsdp_wrap_trainable_outmost(self):
+        def run_wrap_trainable_outmost(config):
+            fsdp_model_context = copy.deepcopy(self.model_context)
+            fsdp_optimization = FSDPOptimization()
+            for name, param in fsdp_model_context.model.named_parameters():
+                if "bias" in name:
+                    param.requires_grad = False
+            atorch.init_distributed("nccl")
+            zero_conf = {
+                "sync_module_states": True,
+                "forward_prefetch": True,
+                "atorch_wrap_cls": ("Linear",),
+                "wrap_trainable_outmost": config,
+            }
+            fsdp_model_context = fsdp_optimization.transform(fsdp_model_context, config=zero_conf)
+            if torch_version() < (2, 1, 0):
+                with self.assertRaises(RuntimeError):
+                    fsdp_model_context.apply_wrappers(is_pre_wrapper=True)
+            else:
+                fsdp_model_context.apply_wrappers(is_pre_wrapper=True)
+                self.assertIsInstance(fsdp_model_context.model, FSDP)
+                cpu_device = torch.device("cpu")
+                for _, m in fsdp_model_context.model.named_modules():
+                    if isinstance(m, FSDP):
+                        self.assertTrue(len(m._ignored_params) == 0)
+                trainable_param_num = 0
+                for p in fsdp_model_context.model.parameters():
+                    self.assertTrue(p.device != cpu_device)
+                    if p.requires_grad:
+                        trainable_param_num += 1
+                self.assertEqual(trainable_param_num, 1)
+            atorch.reset_distributed()
+
+        configs = [True, "NO_SHARD"]
+        for config in configs:
+            run_wrap_trainable_outmost(config)
+
+    def test_to_module_class_by_name(self):
+        model = self.model_context.model
+        wrap_cls = [ToyCustomModule]
+        result = to_module_class_by_name(model, wrap_cls)
+        self.assertEqual(len(result), 1)
+        wrap_cls = ["ToyCustomModule"]
+        result = to_module_class_by_name(model, wrap_cls)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0], ToyCustomModule)
+        wrap_cls = (ToyCustomModule, "Linear", "bad_module")
+        result = to_module_class_by_name(model, wrap_cls)
+        self.assertEqual(len(result), 2)
+        self.assertTrue(isinstance(result, tuple))
+        self.assertEqual(result[0], ToyCustomModule)
+        self.assertEqual(result[1].__name__, "Linear")
+
+    @unittest.skipIf(not torch.cuda.is_available(), "cuda is not available")
+    def test_fsdp(self):
+        model_context = create_model_context(data_size=4, batch_size=1)
+        # test fsdp in cpu mode
+        from atorch.common.log_utils import default_logger as logger
+
+        old_info_fn = logger.info
+
+        def new_info_fn(*args, **kwargs):
+            old_info_fn(*args, **kwargs)
+
+        with patch.object(logger, "info", side_effect=new_info_fn) as mock_obj:
+            auto_accelerate(
+                model_context.model,
+                load_strategy=[
+                    (
+                        "fsdp",
+                        {
+                            "atorch_wrap_cls": (nn.Linear,),
+                        },
+                    )
+                ],
+            )
+        found = False
+        for call_args_kwargs in mock_obj.call_args_list:
+            args = call_args_kwargs[0]
+            if args[0] == ("These distributed optimization methods are ignored in non-distributed case: %s"):
+                found = True
+                self.assertListEqual(args[1], ["fsdp"])
+                break
+        self.assertTrue(found)
+
+    def test_deepcopy(self):
+        model_context = create_model_context(data_size=4, batch_size=1)
+        model = model_context.model
+        need_ignore_modulse = [model.linear]
+        # using deepcopy will cause ignore_modules no work
+        ignore_modules = copy.deepcopy(need_ignore_modulse)
+        found = False
+        # simulate the behavior of _recursive_wrap
+        for _, child in model.named_modules():
+            if child in ignore_modules:
+                found = True
+        self.assertFalse(found)
+
+        ignore_modules = copy.copy(need_ignore_modulse)
+        found = False
+        for _, child in model.named_modules():
+            if child in ignore_modules:
+                found = True
+        self.assertTrue(found)
+
+    @unittest.skipIf(
+        not torch.cuda.is_available() or torch_version() == (2, 0, 0),
+        "Skip when torch==2.0.0. It may be a bug of torch==2.0.0",
+    )
+    def test_cpu_offload(self):
+        backend = "nccl"
+        atorch.init_distributed(backend)
+        model_context = create_model_context(data_size=4, batch_size=1)
+        fsdp_opt = FSDPOptimization()
+        model_context = fsdp_opt.transform(model_context)
+        model_context.update_dataloader()
+        model_context.update_optim()
+        config = {"cpu_offload": True}
+        # cpu offload can be used in non-distributed mode
+        self.assertFalse(fsdp_opt.distributed_only(config=config))
+        fsdp_opt.apply_wrapper(model_context, "", wrapper_config=config)
+        for param in model_context.model.parameters():
+            self.assertEqual(param.device.type, "cpu")
+        atorch.reset_distributed()
+
+    def test_fairscale_patch(self):
+        self.assertEqual(OSS._setup_flat_buffers, patch_setup_flat_buffers)
+        self.assertEqual(ParamBucket._add_param_as_view, patch_add_param_as_view)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/atorch/atorch/tests/fsdp_speedup_init_test.py
+++ b/atorch/atorch/tests/fsdp_speedup_init_test.py
@@ -6,11 +6,10 @@ import shutil
 import unittest
 
 import pytest
-import torch
 
 torch = pytest.importorskip("torch", minversion="2.0.9")
-if torch.version.git_version != "7bcf7da3a268b435777fe87c7794c382f444e86d" or not torch.cuda.is_available():
-    pytest.skip("requires pytorch 2.1 stable release and gpu", allow_module_level=True)
+if torch.version.git_version != "7bcf7da3a268b435777fe87c7794c382f444e86d":
+    pytest.skip("requires pytorch 2.1 stable release", allow_module_level=True)
 from unittest import mock
 
 import torch.multiprocessing as mp

--- a/atorch/atorch/tests/rl_tests/rl_config_test.py
+++ b/atorch/atorch/tests/rl_tests/rl_config_test.py
@@ -1,0 +1,160 @@
+import unittest
+
+from atorch.rl.config import AtorchRLConfig, TrainableModelConfig
+from atorch.utils.import_util import import_module
+
+
+class TestAtorchRLConfig(unittest.TestCase):
+    def test_rl_config(self):
+        config_path = "./atorch/tests/test_define_rl_models/independent_models/model_def.yaml"
+        atorch_rl_config = AtorchRLConfig.load_yaml(config_path)
+        self.assertTrue(isinstance(atorch_rl_config.model.actor, TrainableModelConfig))
+        self.assertEqual(
+            atorch_rl_config.model.actor.model_path,
+            "./atorch/tests/test_define_rl_models/independent_models/model_definition.py",
+        )
+        self.assertEqual(atorch_rl_config.model.actor.optimizer.name, "torch.optim.adam")
+        self.assertEqual(
+            atorch_rl_config.model.actor.train_strategy,
+            "./atorch/tests/test_define_rl_models/independent_models/strategy.py",
+        )
+        self.assertDictEqual(atorch_rl_config.model.actor.model_params, {"features_in": 10, "features_out": 10})
+        self.assertEqual(atorch_rl_config.model.actor.model_cls, "FakeActor")
+        self.assertEqual(atorch_rl_config.model.critic.model_cls, "FakeCritic")
+        self.assertEqual(atorch_rl_config.train.batch_size, 4)
+        self.assertEqual(atorch_rl_config.train.num_rollouts, 10)
+        self.assertTrue(isinstance(atorch_rl_config.model.actor.peft_config, dict))
+
+    def test_rl_hg_config(self):
+        config_path = "./atorch/tests/test_define_rl_models/independent_models/hg_model_def.yaml"
+        atorch_rl_config = AtorchRLConfig.load_yaml(config_path)
+        self.assertTrue(isinstance(atorch_rl_config.model.actor, TrainableModelConfig))
+        self.assertEqual(atorch_rl_config.model.actor.model_path, "/home/glm-large-chinese")
+        self.assertEqual(atorch_rl_config.model.actor.optimizer.name, "torch.optim.adam")
+        self.assertDictEqual(atorch_rl_config.model.actor.model_params, {"features_in": 10, "features_out": 10})
+        self.assertEqual(atorch_rl_config.model.actor.model_cls, "transformers.AutoModelForSeq2SeqLM")
+        self.assertEqual(atorch_rl_config.model.actor.peft_config, None)
+        self.assertEqual(atorch_rl_config.model.critic.model_cls, "transformers.AutoModelForSeq2SeqLM")
+        self.assertEqual(atorch_rl_config.train.batch_size, 4)
+        self.assertEqual(atorch_rl_config.train.num_rollouts, 4)
+        self.assertEqual(atorch_rl_config.train.logdir, "./tensorboard")
+        self.assertEqual(atorch_rl_config.train.num_rollouts, 4)
+        self.assertDictEqual(
+            atorch_rl_config.generation.gen_kwargs,
+            {"max_new_tokens": 512, "top_k": 0, "top_p": 1.0, "do_sample": False},
+        )
+        self.assertDictEqual(
+            atorch_rl_config.to_dict(),
+            {
+                "model": {
+                    "model": {
+                        "actor": {
+                            "optimizer": {"name": "torch.optim.adam", "kwargs": {"betas": (0.9, 0.999)}},
+                            "model_path": "/home/glm-large-chinese",
+                            "model_cls": "transformers.AutoModelForSeq2SeqLM",
+                            "model_params": {"features_in": 10, "features_out": 10},
+                            "peft_config": None,
+                            "train_strategy": "torch_native",
+                            "inference_strategy": "torch_native",
+                            "lazy_load": False,
+                            "loss": "",
+                        },
+                        "critic": {
+                            "optimizer": {"name": "torch.optim.adam", "kwargs": {"betas": (0.9, 0.999)}},
+                            "model_path": "/home/glm-large-chinese",
+                            "model_cls": "transformers.AutoModelForSeq2SeqLM",
+                            "model_params": {"dims_in": 2, "dims_out": 2},
+                            "peft_config": None,
+                            "train_strategy": "torch_native",
+                            "inference_strategy": "torch_native",
+                            "lazy_load": False,
+                            "loss": "",
+                        },
+                        "ref_model": {
+                            "model_path": "/home/glm-large-chinese",
+                            "model_cls": "transformers.AutoModelForSeq2SeqLM",
+                            "model_params": {"dims_in": 2, "dims_out": 2},
+                            "train_strategy": "torch_native",
+                            "inference_strategy": "torch_native",
+                            "lazy_load": False,
+                            "peft_config": None,
+                        },
+                        "reward_model": {
+                            "model_path": "/home/glm-large-chinese",
+                            "model_cls": "transformers.AutoModelForSeq2SeqLM",
+                            "model_params": {"dims_in": 2, "dims_out": 2},
+                            "train_strategy": "torch_native",
+                            "inference_strategy": "torch_native",
+                            "lazy_load": False,
+                            "peft_config": None,
+                        },
+                    }
+                },
+                "ppo_config": {
+                    "ppo_epoch": 2,
+                    "init_kl_coef": 0.02,
+                    "gamma": 1,
+                    "lam": 0.95,
+                    "cliprange": 0.2,
+                    "cliprange_value": 0.2,
+                    "vf_coef": 0.1,
+                    "cliprange_reward": 50,
+                    "ent_coef": 0.01,
+                    "horizon": 10000.0,
+                    "clip_ratio": True,
+                    "scale_reward": "running",
+                    "ref_mean": None,
+                    "ref_std": None,
+                },
+                "train": {
+                    "seq_length": 1024,
+                    "batch_size": 4,
+                    "epoch": 1,
+                    "num_rollouts": 4,
+                    "mode": "Concurrent",
+                    "trainer": "PPOTrainer",
+                    "logdir": "./tensorboard",
+                    "scheduler": {
+                        "name": "cosine_warmup",
+                        "kwargs": {"num_warmup_steps": 640, "num_training_steps": 6400},
+                    },
+                    "eval_interval": 100,
+                    "checkpoint_interval": 100,
+                    "checkpoint_dir": "./checkpoint",
+                    "gradient_accumulation_steps": 1,
+                    "max_grad_norm": None,
+                },
+                "generation": {
+                    "batch_size": 4,
+                    "gen_kwargs": {"max_new_tokens": 512, "top_k": 0, "top_p": 1.0, "do_sample": False},
+                    "gen_experience_kwargs": {
+                        "max_new_tokens": 512,
+                        "do_sample": False,
+                        "temperature": 1.0,
+                        "top_k": 50,
+                        "top_p": 0.95,
+                    },
+                },
+                "model_keys": ["actor", "critic", "ref_model", "reward_model"],
+                "tokenizer": {"params": {"truncation_side": "right"}, "tokenizer_path": "/home/glm-large-chinese"},
+            },
+        )
+        self.assertEqual(atorch_rl_config.generation.batch_size, 4)
+
+    def test_share_wights_model_config(self):
+        config_path = "./atorch/tests/test_define_rl_models/share_weights_models/config.yaml"
+        atorch_rl_config = AtorchRLConfig.load_yaml(config_path)
+        self.assertTrue(isinstance(atorch_rl_config.model.actor_critic_ref, TrainableModelConfig))
+        self.assertEqual(atorch_rl_config.model.actor_critic_ref.loss, "atorch.rl.ppo_utils.ppo_util.loss")
+        import_module(atorch_rl_config.model.actor_critic_ref.loss)
+        self.assertEqual(atorch_rl_config.model.actor_critic_ref.model_path, "/home/glm-large-chinese")
+        self.assertEqual(atorch_rl_config.model.actor_critic_ref.optimizer.name, "torch.optim.adam")
+        self.assertEqual(
+            atorch_rl_config.model.actor_critic_ref.model_cls,
+            "atorch.tests.test_define_rl_models.independent_models.actor_critic_ref.ActorCriticRef",
+        )
+        self.assertListEqual(atorch_rl_config.model_keys, ["actor_critic_ref", "reward_model"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/atorch/atorch/tests/rl_tests/rl_deepspeed_llama2_test.py
+++ b/atorch/atorch/tests/rl_tests/rl_deepspeed_llama2_test.py
@@ -1,0 +1,283 @@
+import os
+import unittest
+
+import deepspeed
+import torch
+import torch.multiprocessing as mp
+from deepspeed import comm as dist
+from deepspeed.inference.config import DeepSpeedInferenceConfig
+from deepspeed.module_inject import ReplaceWithTensorSlicing
+from deepspeed.ops.op_builder import InferenceBuilder
+from transformers.models.llama.modeling_llama import LlamaConfig, LlamaDecoderLayer, LlamaForCausalLM
+
+from atorch.rl.ds_hybrid_engine.ds_hook import *  # NOQA
+from atorch.rl.ds_hybrid_engine.module_inject.containers import LLAMALayerPolicy
+from atorch.rl.ds_hybrid_engine.module_inject.utils import policy_to_ds_container
+from atorch.tests.utils.test_utils import init_dist
+
+
+def _test_llama2_tp(rank, world_size):
+    inference_module = InferenceBuilder().load()
+    inference_module.allocate_workspace_fp32(1, 1, 1, 2, 30, 30, False, 1, 1, 1)
+
+    init_dist(rank, world_size)
+    deepspeed.init_distributed("nccl")
+    global_rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    mp_group_id = global_rank // world_size
+    num_mp_groups = world_size // world_size
+    for mp_group_id in range(num_mp_groups):
+        ranks = list(range(mp_group_id * world_size, (mp_group_id + 1) * world_size, 1))
+        mp_group = dist.new_group(ranks)
+
+    torch.manual_seed(1)
+
+    rank = int(os.environ.get("RANK", 0))
+
+    mp_replace = ReplaceWithTensorSlicing(
+        mp_group=mp_group, mp_size=world_size, out_dim=0, in_dim=1  # process group for tp inferencing
+    )
+
+    # create inference config for Hybrid Engine
+    inference_config = DeepSpeedInferenceConfig(
+        set_empty_params=True,
+        dtype=torch.bfloat16,
+        max_out_tokens=40,
+        min_out_tokens=60,
+        transposed_mode=True,
+    )
+
+    model_config = LlamaConfig()
+
+    model_config.num_hidden_layers = 1
+    model_config.num_key_value_heads = 64
+    model_config.num_attention_heads = 64
+    module = LlamaDecoderLayer(model_config)
+
+    module.bfloat16().to(rank)
+
+    # create inference config for Hybrid Engine
+    inference_config = DeepSpeedInferenceConfig(
+        set_empty_params=True,
+        dtype=torch.bfloat16,
+        max_out_tokens=40,
+        min_out_tokens=60,
+        transposed_mode=True,
+    )
+
+    # mock tp size = 1
+    mp_replace = ReplaceWithTensorSlicing(mp_group=mp_group, mp_size=world_size, out_dim=0, in_dim=1)
+
+    layer_id = 0
+
+    policy_cls = LLAMALayerPolicy
+
+    policy = policy_cls(module, inference=True)
+
+    _container = policy_to_ds_container(
+        policy=policy, config=inference_config, model_config=model_config, layer_id=layer_id, child=module
+    )
+
+    # mock create inference module in hybrid engine
+    _container.set_tensor_parallel_config(world_size, mp_group)
+    _container.initialize_tensors(enable_training=True)
+    _container.create_ds_model_config()
+    _container.create_module()
+    _container.set_params_wo_copy(Z3_enabled=True)
+
+    _container.apply_tensor_parallelism(mp_replace, reversed_dim=True)
+    _container.module.dtype = torch.bfloat16
+
+    policy.client_module.mlp.up_proj.weighthape_weight_start = (
+        policy.client_module.mlp.up_proj.weight.shape[0] // mp_replace.mp_size * (rank + 0)
+    )
+    shape_weight_end = policy.client_module.mlp.up_proj.weight.shape[0] // mp_replace.mp_size * (rank + 1)
+
+    shape_weight_start = policy.client_module.mlp.up_proj.weight.shape[0] // mp_replace.mp_size * (rank + 0)
+    shape_weight_end = policy.client_module.mlp.up_proj.weight.shape[0] // mp_replace.mp_size * (rank + 1)
+
+    assert torch.allclose(
+        _container.module.mlp.inter_up_w,
+        policy.client_module.mlp.up_proj.weight[shape_weight_start:shape_weight_end, :],
+        rtol=1e-05,
+        atol=1e-08,
+    )
+
+    shape_weight_start = policy.client_module.mlp.gate_proj.weight.shape[0] // mp_replace.mp_size * (rank + 0)
+    shape_weight_end = policy.client_module.mlp.gate_proj.weight.shape[0] // mp_replace.mp_size * (rank + 1)
+
+    assert torch.allclose(
+        _container.module.mlp.inter_gate_w,
+        policy.client_module.mlp.gate_proj.weight[shape_weight_start:shape_weight_end, :],
+        rtol=1e-05,
+        atol=1e-08,
+    )
+
+    shape_weight_start = policy.client_module.mlp.down_proj.weight.shape[1] // mp_replace.mp_size * (rank + 0)
+    shape_weight_end = policy.client_module.mlp.down_proj.weight.shape[1] // mp_replace.mp_size * (rank + 1)
+
+    assert torch.allclose(
+        _container.module.mlp.output_w,
+        policy.client_module.mlp.down_proj.weight[:, shape_weight_start:shape_weight_end],
+        rtol=1e-05,
+        atol=1e-08,
+    )
+    assert torch.allclose(_container._4hh_w, policy.client_module.mlp.down_proj.weight, rtol=1e-05, atol=1e-08)
+
+    shape_weight_start = policy.client_module.self_attn.q_proj.weight.shape[0] // mp_replace.mp_size * (rank + 0)
+    shape_weight_end = policy.client_module.self_attn.q_proj.weight.shape[0] // mp_replace.mp_size * (rank + 1)
+
+    assert torch.allclose(
+        _container.module.attention.attn_qw,
+        policy.client_module.self_attn.q_proj.weight[shape_weight_start:shape_weight_end, :],
+        rtol=1e-05,
+        atol=1e-08,
+    )
+
+    shape_weight_start = policy.client_module.self_attn.k_proj.weight.shape[0] // mp_replace.mp_size * (rank + 0)
+    shape_weight_end = policy.client_module.self_attn.k_proj.weight.shape[0] // mp_replace.mp_size * (rank + 1)
+
+    assert torch.allclose(
+        _container.module.attention.attn_kw,
+        policy.client_module.self_attn.k_proj.weight[shape_weight_start:shape_weight_end, :],
+        rtol=1e-05,
+        atol=1e-08,
+    )
+    assert torch.allclose(
+        _container.module.attention.attn_vw,
+        policy.client_module.self_attn.v_proj.weight[shape_weight_start:shape_weight_end, :],
+        rtol=1e-05,
+        atol=1e-08,
+    )
+
+    shape_weight_start = policy.client_module.self_attn.o_proj.weight.shape[1] // mp_replace.mp_size * (rank + 0)
+    shape_weight_end = policy.client_module.self_attn.o_proj.weight.shape[1] // mp_replace.mp_size * (rank + 1)
+
+    assert torch.allclose(
+        _container.module.attention.attn_ow,
+        policy.client_module.self_attn.o_proj.weight[:, shape_weight_start:shape_weight_end],
+        rtol=1e-05,
+        atol=1e-08,
+    )
+
+    assert torch.allclose(
+        _container.module.mlp.attn_nw, policy.client_module.input_layernorm.weight, rtol=1e-05, atol=1e-08
+    )
+    assert torch.allclose(
+        _container.module.norm_w, policy.client_module.post_attention_layernorm.weight, rtol=1e-05, atol=1e-08
+    )
+
+    batch_size = 4
+    seq_len = 16
+    hidden_states = 4096
+
+    inputs = torch.ones((batch_size, seq_len, hidden_states)).cuda().bfloat16()
+    attention_mask = torch.ones((4, 1, 16, 16)).to(rank)
+    """
+    hidden_states: torch.Tensor,
+            attention_mask: Optional[torch.Tensor] = None,
+            position_ids: Optional[torch.LongTensor] = None,
+            past_key_value: Optional[Tuple[torch.Tensor]] = None,
+            output_attentions: Optional[bool] = False,
+            use_cache: Optional[bool] = False,
+
+
+            hidden_states: torch.Tensor,
+            attention_mask: Optional[torch.Tensor] = None,
+            position_ids: Optional[torch.LongTensor] = None,
+            past_key_value: Optional[Tuple[torch.Tensor]] = None,
+            output_attentions: bool = False,
+            use_cache: bool = False,
+
+    """
+
+    _ = policy.client_module.mlp(inputs.bfloat16().to(rank))
+
+    _container.module.attention(inputs.bfloat16().to(rank), attention_mask)
+    _ = _container.module.mlp(inputs.bfloat16().to(rank), None, None, None)
+
+    _ = policy.client_module.self_attn(
+        inputs.bfloat16().to(rank),
+        attention_mask=attention_mask.to(rank),
+        position_ids=None,
+        past_key_value=None,
+        output_attentions=False,
+        use_cache=False,
+    )
+    _, _, _, _, _ = _container.module.attention(inputs.bfloat16().to(rank), attention_mask)
+
+    _ = policy.client_module(
+        inputs.bfloat16().to(rank),
+        attention_mask=attention_mask.to(rank),
+        position_ids=None,
+        past_key_value=None,
+        output_attentions=False,
+        use_cache=False,
+    )
+    hidden_states, _, _ = _container.module(
+        inputs.bfloat16().to(rank),
+        attention_mask=attention_mask.to(rank),
+        position_ids=None,
+        past_key_value=None,
+        output_attentions=False,
+        use_cache=False,
+    )
+
+    model = LlamaForCausalLM(model_config)
+    model.bfloat16().to(rank)
+    """
+    tokenizer = AutoTokenizer.from_pretrained("/mnt1/xuantai.hxd/test/Llama-2-7b-hf")
+    inputs = tokenizer("介绍下支付宝?", return_tensors="pt")
+    _ = model.generate(inputs.input_ids.to(rank), use_cache=True, max_new_tokens=50)
+    """
+    decoder_layers = model.model.layers
+    layers_length = len(decoder_layers)
+
+    ds_layers = []
+    containers = []
+    layer_id = 0
+
+    for i in range(layers_length):
+        module = decoder_layers[i]
+        layer_id += 1
+        policy_cls = LLAMALayerPolicy
+        policy = policy_cls(module, inference=True)
+        _container = policy_to_ds_container(
+            policy=policy, config=inference_config, model_config=model_config, layer_id=layer_id, child=module
+        )
+        # mocker create inference module in hybrid engine
+        _container.set_tensor_parallel_config(world_size, mp_group)
+        _container.initialize_tensors(enable_training=True)
+        _container.create_ds_model_config()
+        _container.create_module()
+        _container.set_params_wo_copy(Z3_enabled=True)
+        _container.apply_tensor_parallelism(mp_replace, reversed_dim=True)
+        _container.module.eval()
+        _container.module.dtype = torch.bfloat16
+        containers.append(_container)
+        ds_layers.append(_container.module)
+
+    ds_decoder_layers = torch.nn.ModuleList(ds_layers)
+
+    model.model.layers = ds_decoder_layers
+    """
+    _ = model.generate(inputs.input_ids.to(rank), use_cache=True, max_new_tokens=50)
+    """
+
+
+@unittest.skipIf(torch.cuda.device_count() < 2, "run with gpu_num >=2")
+class TestLoadDSModel(unittest.TestCase):
+    def test_load_ds_model_with_zero3_partition(self):
+        world_size = 2
+        os.environ["MASTER_ADDR"] = "localhost"  #
+        os.environ["MASTER_PORT"] = "5000"
+        mp.spawn(
+            _test_llama2_tp,
+            args=(world_size,),
+            nprocs=world_size,
+            join=True,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/atorch/atorch/tests/rl_tests/rl_ds_llama2_inference_test.py
+++ b/atorch/atorch/tests/rl_tests/rl_ds_llama2_inference_test.py
@@ -1,0 +1,236 @@
+import glob
+import os
+import unittest
+
+import deepspeed
+import torch
+import torch.multiprocessing as mp
+from torch import nn
+from transformers import AutoTokenizer
+from transformers.models.llama.modeling_llama import LlamaConfig, LlamaForCausalLM
+
+from atorch.common.util_func import find_free_port
+from atorch.rl.ds_hybrid_engine.ds_hook import *  # NOQA
+from atorch.rl.ds_hybrid_engine.initialize import initialize
+from atorch.tests.utils.test_utils import init_dist
+
+
+def _run_llama2_deepspeed_vllm_test(
+    rank,
+    world_size,
+    model_path,
+    max_new_tokens,
+    print_output,
+    use_zero_init,
+    batch_size_per_gpu,
+    inference_tp_size,
+    use_deepspeed,
+):
+    init_dist(rank, world_size)
+
+    model_path = model_path
+    max_new_tokens = max_new_tokens
+    inference_tp_size = inference_tp_size
+    batch_size_per_gpu = batch_size_per_gpu
+
+    config = {
+        "train_batch_size": batch_size_per_gpu * world_size,
+        "train_micro_batch_size_per_gpu": batch_size_per_gpu,
+        "steps_per_print": 10,
+        "zero_optimization": {"stage": 3, "stage3_param_persistence_threshold": 0},
+        "bf16": {
+            "enabled": True,
+        },
+        "hybrid_engine": {"enabled": True, "inference_tp_size": inference_tp_size, "max_out_tokens": 500},
+        "gradient_clipping": 1.0,
+    }
+    kwargs = {}
+    kwargs["config"] = config
+    device = int(os.environ.get("LOCAL_RANK", 0))
+
+    if use_zero_init:
+        with deepspeed.zero.Init(config_dict_or_path=config):
+            configuration = LlamaConfig.from_pretrained(model_path, trust_remote_code=True)
+            model = LlamaForCausalLM(configuration)
+
+            for p in model.parameters():
+                p.requires_grad = False
+
+            trainable_module = model.model.layers[-2:]
+            for p in trainable_module.parameters():
+                p.requires_grad = True
+
+        # to do check keys values
+        new_state_dict = {}
+        if deepspeed.comm.get_rank() == 0:
+            state_dict = {}
+            bin_files = glob.glob(os.path.join(model_path, "pytorch_model*.bin"))
+            for f in bin_files:
+                s = torch.load(f, map_location="cpu")
+                state_dict.update(s)
+            new_state_dict = state_dict
+        else:
+            state_dict = None
+
+        state_dict = new_state_dict
+
+        def load(module: nn.Module, prefix=""):
+            # because zero3 puts placeholders in model params, this context
+            # manager gathers (unpartitions) the params of the current layer, then loads from
+            # the state dict and then re-partitions them again
+
+            with deepspeed.zero.GatheredParameters(list(module.parameters(recurse=False)), modifier_rank=0):
+                if deepspeed.comm.get_rank() == 0:
+                    module._load_from_state_dict(state_dict, prefix, {}, True, [], [], [])
+
+            for name, child in module._modules.items():
+                if child is not None:
+                    load(child, prefix + name + ".")
+
+        load(model, prefix="")
+
+    else:
+        model = LlamaForCausalLM.from_pretrained(model_path, trust_remote_code=True)
+    kwargs["model"] = model
+
+    if use_deepspeed:
+        m, _, _, _ = initialize(**kwargs)  # type: ignore
+        print("model is {}".format(m))
+    else:
+        m = model.bfloat16().to(device)
+
+    tokenizer = AutoTokenizer.from_pretrained(model_path)
+    m.eval()
+
+    prompt = "介绍下支付宝?"
+    inputs = tokenizer(prompt, return_tensors="pt")
+    generate_ids = m.generate(inputs.input_ids.to(device), max_length=max_new_tokens)
+    print(tokenizer.batch_decode(generate_ids, skip_special_tokens=False, clean_up_tokenization_spaces=False)[0])
+
+    prompt = "Hey, are you conscious? Can you talk to me?"
+    inputs = tokenizer(prompt, return_tensors="pt")
+    generate_ids = m.generate(inputs.input_ids.to(device), max_length=max_new_tokens)
+
+    # params_list = [p for p in m.parameters() if p.requires_grad is True]
+    # params_name_list = [p for p, q in m.named_parameters() if q.requires_grad is True]
+
+    from atorch.rl.inference_backend.vllm_backend import VLLMBackend, VLLMComm
+
+    m.vllm_backend = "s"
+
+    # m.sync_weight()
+
+    vllm_inference_backend = VLLMBackend(checkpoint_path=model_path, gen_kwargs={"max_new_tokens": 500})
+
+    vllm_config = {
+        "unfrozen_layers": [31, 30],
+        "redis_address": {"ip": "0.0.0.0", "port": 6379},
+        "vllm_server_address": {"ip": "0.0.0.0", "port": 5005},
+    }
+    vllm_comm = VLLMComm(
+        vllm_config["vllm_server_address"]["ip"], vllm_config["vllm_server_address"]["port"]
+    )  # noqa: F841
+    assert vllm_comm is not None
+    # except Exception as e:
+    with deepspeed.zero.GatheredParameters(list(m.module.parameters(recurse=True))):
+        vllm_inference_backend.set_train_model_weights(m.module)
+        res = vllm_inference_backend.generate(["介绍下支付宝?"])
+        print(res)
+
+
+@unittest.skipIf(torch.cuda.device_count() < 2, "run with gpu_num >=2")
+class TestLoadDSModel(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        deepspeed.runtime.utils.see_memory_usage("pre test", force=True)
+
+    def test_load_ds_model_use_zero_init_tp_size_1(self):
+        world_size = 2
+        model_path = "/mnt1/xuantai.hxd/test/llama2_small"
+        max_new_tokens = 500
+        print_output = True
+        use_zero_init = True
+        batch_size_per_gpu = 1
+        inference_tp_size = 1
+        use_deepspeed = True
+        use_zero_init = True
+
+        os.environ["MASTER_ADDR"] = "localhost"  #
+        os.environ["MASTER_PORT"] = str(find_free_port())
+        mp.spawn(
+            _run_llama2_deepspeed_vllm_test,
+            args=(
+                world_size,
+                model_path,
+                max_new_tokens,
+                print_output,
+                use_zero_init,
+                batch_size_per_gpu,
+                inference_tp_size,
+                use_deepspeed,
+            ),
+            nprocs=world_size,
+            join=True,
+        )
+
+    def test_load_ds_model_tp_size_2(self):
+        world_size = 2
+
+        model_path = "/mnt1/xuantai.hxd/test/llama2_small"
+        max_new_tokens = 500
+        print_output = True
+        use_zero_init = True
+        batch_size_per_gpu = 1
+        inference_tp_size = 2
+        use_deepspeed = True
+        use_zero_init = False
+        os.environ["MASTER_ADDR"] = "localhost"  #
+        os.environ["MASTER_PORT"] = str(find_free_port())
+        mp.spawn(
+            _run_llama2_deepspeed_vllm_test,
+            args=(
+                world_size,
+                model_path,
+                max_new_tokens,
+                print_output,
+                use_zero_init,
+                batch_size_per_gpu,
+                inference_tp_size,
+                use_deepspeed,
+            ),
+            nprocs=world_size,
+            join=True,
+        )
+
+    def test_load_ds_model_use_zero_init_tp_size_2(self):
+        world_size = 2
+
+        model_path = "/mnt1/xuantai.hxd/test/llama2_small"
+        max_new_tokens = 500
+        print_output = True
+        use_zero_init = True
+        batch_size_per_gpu = 1
+        inference_tp_size = 2
+        use_deepspeed = True
+        use_zero_init = True
+        os.environ["MASTER_ADDR"] = "localhost"  #
+        os.environ["MASTER_PORT"] = str(find_free_port())
+        mp.spawn(
+            _run_llama2_deepspeed_vllm_test,
+            args=(
+                world_size,
+                model_path,
+                max_new_tokens,
+                print_output,
+                use_zero_init,
+                batch_size_per_gpu,
+                inference_tp_size,
+                use_deepspeed,
+            ),
+            nprocs=world_size,
+            join=True,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/atorch/atorch/tests/rl_tests/rl_ds_llama2_module_replace_test.py
+++ b/atorch/atorch/tests/rl_tests/rl_ds_llama2_module_replace_test.py
@@ -1,0 +1,192 @@
+import unittest
+
+import torch
+from deepspeed.inference.config import DeepSpeedInferenceConfig
+from deepspeed.module_inject import ReplaceWithTensorSlicing
+from deepspeed.ops.op_builder import InferenceBuilder
+from transformers.models.llama.modeling_llama import LlamaConfig, LlamaDecoderLayer, LlamaForCausalLM
+
+from atorch.rl.ds_hybrid_engine.ds_hook import *  # NOQA
+from atorch.rl.ds_hybrid_engine.module_inject.containers import LLAMALayerPolicy
+from atorch.rl.ds_hybrid_engine.module_inject.utils import policy_to_ds_container
+
+
+@unittest.skipIf(torch.cuda.device_count() < 2, "run with gpu_num >=2")
+class TestDsLlama2Container(unittest.TestCase):
+    def test_ds_llama2_hybrid_engine(self):
+        torch.manual_seed(1)
+        inference_module = InferenceBuilder().load()
+        inference_module.allocate_workspace_fp32(1, 1, 1, 2, 30, 30, False, 1, 1, 1)
+        model_config = LlamaConfig()
+        model_config.num_hidden_layers = 2
+        model_config.num_key_value_heads = 8
+        model_config.num_attention_heads = 64
+        module = LlamaDecoderLayer(model_config)
+        module.bfloat16().to(0)
+
+        mp_group = None
+
+        inference_config = DeepSpeedInferenceConfig(
+            set_empty_params=True,
+            dtype=torch.bfloat16,
+            max_out_tokens=40,
+            min_out_tokens=60,
+            transposed_mode=True,
+        )
+
+        mp_replace = ReplaceWithTensorSlicing(mp_group=mp_group, mp_size=1, out_dim=0, in_dim=1)
+
+        #
+        layer_id = 0
+
+        policy_cls = LLAMALayerPolicy
+
+        policy = policy_cls(module, inference=True)
+
+        _container = policy_to_ds_container(
+            policy=policy, config=inference_config, model_config=model_config, layer_id=layer_id, child=module
+        )
+
+        # mocker create inference module in hybrid engine
+        _container.set_tensor_parallel_config(1, None)
+        _container.initialize_tensors(enable_training=True)
+        _container.create_ds_model_config()
+        _container.create_module()
+        _container.set_params_wo_copy(Z3_enabled=True)
+        _container.apply_tensor_parallelism(mp_replace, reversed_dim=True)
+        _container.module.dtype = torch.bfloat16
+
+        assert torch.allclose(
+            torch.cat([policy.client_module.mlp.up_proj.weight, policy.client_module.mlp.gate_proj.weight]),
+            _container._h4h_w,
+        )
+
+        assert torch.allclose(_container._4hh_w, policy.client_module.mlp.down_proj.weight, rtol=1e-05, atol=1e-08)
+
+        assert torch.allclose(
+            _container.module.attention.attn_qw, policy.client_module.self_attn.q_proj.weight, rtol=1e-05, atol=1e-08
+        )
+        assert torch.allclose(
+            _container.module.attention.attn_kw, policy.client_module.self_attn.k_proj.weight, rtol=1e-05, atol=1e-08
+        )
+
+        assert torch.allclose(
+            _container.module.attention.attn_vw, policy.client_module.self_attn.v_proj.weight, rtol=1e-05, atol=1e-08
+        )
+
+        assert torch.allclose(
+            _container.module.attention.attn_ow, policy.client_module.self_attn.o_proj.weight, rtol=1e-05, atol=1e-08
+        )
+
+        assert torch.allclose(
+            _container.module.mlp.inter_up_w, policy.client_module.mlp.up_proj.weight, rtol=1e-05, atol=1e-08
+        )
+        assert torch.allclose(
+            _container.module.mlp.inter_gate_w, policy.client_module.mlp.gate_proj.weight, rtol=1e-05, atol=1e-08
+        )
+        assert torch.allclose(
+            _container.module.mlp.output_w, policy.client_module.mlp.down_proj.weight, rtol=1e-05, atol=1e-08
+        )
+
+        assert torch.allclose(
+            _container.module.mlp.attn_nw, policy.client_module.input_layernorm.weight, rtol=1e-05, atol=1e-08
+        )
+        assert torch.allclose(
+            _container.module.norm_w, policy.client_module.post_attention_layernorm.weight, rtol=1e-05, atol=1e-08
+        )
+
+        rank = 0
+        batch_size = 4
+        seq_len = 16
+        hidden_states = 4096
+        rank = 0
+        inputs = torch.ones((batch_size, seq_len, hidden_states)).cuda().bfloat16()
+        attention_mask = torch.ones((4, 1, 16, 16)).to(rank)
+
+        res1 = policy.client_module.mlp(inputs.bfloat16().to(rank))
+
+        _container.module.attention(inputs.bfloat16().to(rank), attention_mask)
+        res2 = _container.module.mlp(inputs.bfloat16().to(rank), None, None, None)
+
+        assert torch.allclose(res1, res2, rtol=1e-05, atol=1e-08)
+
+        res3 = policy.client_module.self_attn(
+            inputs.bfloat16().to(rank),
+            attention_mask=attention_mask.to(rank),
+            position_ids=None,
+            past_key_value=None,
+            output_attentions=False,
+            use_cache=False,
+        )
+        attention_output_container_module, _, _, _, _ = _container.module.attention(
+            inputs.bfloat16().to(rank), attention_mask
+        )
+        assert torch.allclose(res3[0], attention_output_container_module, rtol=1e-05, atol=1e-08)
+
+        res4 = policy.client_module(
+            inputs.bfloat16().to(rank),
+            attention_mask=attention_mask.to(rank),
+            position_ids=None,
+            past_key_value=None,
+            output_attentions=False,
+            use_cache=False,
+        )
+        hidden_states, past_key_value, _ = _container.module(
+            inputs.bfloat16().to(rank),
+            attention_mask=attention_mask.to(rank),
+            position_ids=None,
+            past_key_value=None,
+            output_attentions=False,
+            use_cache=False,
+        )
+        assert torch.allclose(res4[0], hidden_states, rtol=1e-05, atol=1e-08)
+
+        model = LlamaForCausalLM(model_config)
+        model.bfloat16().to(0)
+
+        decoder_layers = model.model.layers
+        layers_length = len(decoder_layers)
+
+        ds_layers = []
+        containers = []
+        layer_id = 0
+
+        for i in range(layers_length):
+            module = decoder_layers[i]
+            layer_id += 1
+
+            policy_cls = LLAMALayerPolicy
+
+            policy = policy_cls(module, inference=True)
+
+            _container = policy_to_ds_container(
+                policy=policy, config=inference_config, model_config=model_config, layer_id=layer_id, child=module
+            )
+
+            # mocker create inference module in hybrid engine
+            _container.set_tensor_parallel_config(1, None)
+            _container.initialize_tensors(enable_training=True)
+            _container.create_ds_model_config()
+            _container.create_module()
+            _container.set_params_wo_copy(Z3_enabled=True)
+            _container.apply_tensor_parallelism(mp_replace, reversed_dim=True)
+            _container.module.eval()
+            _container.module.dtype = torch.bfloat16
+            containers.append(_container)
+            ds_layers.append(_container.module)
+
+        ds_decoder_layers = torch.nn.ModuleList(ds_layers)
+
+        model.model.layers = ds_decoder_layers
+        """
+        tokenizer = AutoTokenizer.from_pretrained("/mnt1/xuantai.hxd/test/Llama-2-7b-hf")
+        inputs = tokenizer("凯旋门位于意大利米兰市古城堡旁。1807年为纪念[MASK]而建，门高25米，顶上矗立两武士青铜古兵车铸像。", return_tensors="pt")
+        rank = 0
+        o = model.generate(inputs.input_ids.to(0), use_cache=True, max_new_tokens=50)
+        outputs = model.generate(inputs.input_ids.to(0), use_cache=True, max_new_tokens=50)
+        assert torch.allclose(outputs, o, rtol=1e-05, atol=1e-08)
+        """
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/atorch/atorch/tests/rl_tests/rl_llama_model_util_test.py
+++ b/atorch/atorch/tests/rl_tests/rl_llama_model_util_test.py
@@ -1,0 +1,185 @@
+import unittest
+
+import torch
+
+# test case 70B
+from transformers import LlamaConfig, LlamaForCausalLM
+from transformers.models.llama.modeling_llama import LlamaDecoderLayer
+
+from atorch.rl.model_utils.llama2_utils import get_llama2_params_offsets, move_weight_to_continuous_buffer
+
+
+class TestLLama2Util(unittest.TestCase):
+    def test_get_param_offset(self):
+        config = LlamaConfig()
+        config.num_attention_heads = 32
+        config.num_key_value_heads = 8
+        llama_decoder_layer = LlamaDecoderLayer(config)
+        layer_parameters_num = [p.numel() for p in llama_decoder_layer.parameters()]
+        offsets_info = get_llama2_params_offsets(config)
+        offsets_parameters_num = [p[1] - p[0] for p in offsets_info.values()]
+        self.assertListEqual(layer_parameters_num, offsets_parameters_num)
+        config.num_hidden_layers = 1
+        llama2_casual_lm = LlamaForCausalLM(config)
+        state_dict = llama2_casual_lm.state_dict()
+        config = llama2_casual_lm.config
+        param_tensor = move_weight_to_continuous_buffer(state_dict, config, offsets_info)
+        assert torch.allclose(
+            llama2_casual_lm.model.layers[0].self_attn.q_proj.weight.flatten(),
+            param_tensor[offsets_info["q_proj"][0] : offsets_info["q_proj"][1]],
+        )
+        assert torch.allclose(
+            llama2_casual_lm.model.layers[0].self_attn.k_proj.weight.flatten(),
+            param_tensor[offsets_info["k_proj"][0] : offsets_info["k_proj"][1]],
+        )
+        assert torch.allclose(
+            llama2_casual_lm.model.layers[0].self_attn.v_proj.weight.flatten(),
+            param_tensor[offsets_info["v_proj"][0] : offsets_info["v_proj"][1]],
+        )
+        assert torch.allclose(
+            llama2_casual_lm.model.layers[0].self_attn.o_proj.weight.flatten(),
+            param_tensor[offsets_info["o_proj"][0] : offsets_info["o_proj"][1]],
+        )
+        assert torch.allclose(
+            llama2_casual_lm.model.layers[0].mlp.gate_proj.weight.flatten(),
+            param_tensor[offsets_info["gate_proj"][0] : offsets_info["gate_proj"][1]],
+        )
+        assert torch.allclose(
+            llama2_casual_lm.model.layers[0].mlp.up_proj.weight.flatten(),
+            param_tensor[offsets_info["up_proj"][0] : offsets_info["up_proj"][1]],
+        )
+        assert torch.allclose(
+            llama2_casual_lm.model.layers[0].mlp.down_proj.weight.flatten(),
+            param_tensor[offsets_info["down_proj"][0] : offsets_info["down_proj"][1]],
+        )
+        assert torch.allclose(
+            llama2_casual_lm.model.layers[0].input_layernorm.weight.flatten(),
+            param_tensor[offsets_info["input_layernorm"][0] : offsets_info["input_layernorm"][1]],
+        )
+        assert torch.allclose(
+            llama2_casual_lm.model.layers[0].input_layernorm.weight.flatten(),
+            param_tensor[offsets_info["post_attention_layernorm"][0] : offsets_info["post_attention_layernorm"][1]],
+        )
+        assert param_tensor.numel() == sum(offsets_parameters_num)
+
+    def test_llama_tp(self):
+        tp_sizes = [2, 2]
+        tp_ranks = [0, 1]
+        config = LlamaConfig()
+        config.num_attention_heads = 32
+        config.num_key_value_heads = 32
+        config.num_hidden_layers = 4
+        llama2_casual_lm = LlamaForCausalLM(config)
+        for p, q in llama2_casual_lm.named_parameters():
+            q.requires_grad = False
+
+        trainable_module = llama2_casual_lm.model.layers[-2:]
+        for p in trainable_module.parameters():
+            p.requires_grad = True
+        state_dict = {}
+        for p, q in llama2_casual_lm.named_parameters():
+            if q.requires_grad is True:
+                state_dict[p] = q
+
+        # state_dict = llama2_casual_lm.state_dict()
+        offsets_info = get_llama2_params_offsets(config)
+
+        # for rank-0 and rank-1
+        for tp_size, tp_rank in zip(tp_sizes, tp_ranks):
+            offsets_info = get_llama2_params_offsets(config=config, tp_size=tp_size)
+            offsets_parameters_num = [p[1] - p[0] for p in offsets_info.values()]
+
+            trainable_params = move_weight_to_continuous_buffer(
+                state_dict, config, offsets_info, tp_size=tp_size, tp_rank=tp_rank
+            )
+
+            # for layer -2 and layer -1
+            for layer_id in [2, 3]:
+                num_param_per_block = sum(offsets_parameters_num)
+                start_pos = (layer_id - 2) * num_param_per_block
+                param_tensor = trainable_params[start_pos : start_pos + num_param_per_block]
+                start = llama2_casual_lm.model.layers[layer_id].self_attn.q_proj.weight.shape[0] // tp_size * tp_rank
+                end = (
+                    llama2_casual_lm.model.layers[layer_id].self_attn.q_proj.weight.shape[0] // tp_size * (tp_rank + 1)
+                )
+
+                torch.allclose(
+                    llama2_casual_lm.model.layers[layer_id].self_attn.q_proj.weight[start:end].flatten(),
+                    param_tensor[offsets_info["q_proj"][0] : offsets_info["q_proj"][1]],
+                    rtol=1e-05,
+                    atol=1e-08,
+                )
+
+                start = llama2_casual_lm.model.layers[layer_id].self_attn.k_proj.weight.shape[0] // tp_size * tp_rank
+                end = (
+                    llama2_casual_lm.model.layers[layer_id].self_attn.k_proj.weight.shape[0] // tp_size * (tp_rank + 1)
+                )
+                torch.allclose(
+                    llama2_casual_lm.model.layers[layer_id].self_attn.k_proj.weight[start:end].flatten(),
+                    param_tensor[offsets_info["k_proj"][0] : offsets_info["k_proj"][1]],
+                    rtol=1e-05,
+                    atol=1e-08,
+                )
+                torch.allclose(
+                    llama2_casual_lm.model.layers[layer_id].self_attn.v_proj.weight[start:end].flatten(),
+                    param_tensor[offsets_info["v_proj"][0] : offsets_info["v_proj"][1]],
+                    rtol=1e-05,
+                    atol=1e-08,
+                )
+
+                start = llama2_casual_lm.model.layers[layer_id].self_attn.o_proj.weight.shape[1] // tp_size * tp_rank
+                end = (
+                    llama2_casual_lm.model.layers[layer_id].self_attn.o_proj.weight.shape[1] // tp_size * (tp_rank + 1)
+                )
+
+                torch.allclose(
+                    llama2_casual_lm.model.layers[layer_id].self_attn.o_proj.weight[:, start:end].flatten(),
+                    param_tensor[offsets_info["o_proj"][0] : offsets_info["o_proj"][1]],
+                    rtol=1e-05,
+                    atol=1e-08,
+                )
+                start = llama2_casual_lm.model.layers[layer_id].mlp.gate_proj.weight.shape[0] // tp_size * tp_rank
+                end = llama2_casual_lm.model.layers[layer_id].mlp.gate_proj.weight.shape[0] // tp_size * (tp_rank + 1)
+
+                torch.allclose(
+                    llama2_casual_lm.model.layers[layer_id].mlp.gate_proj.weight[start:end, :].flatten(),
+                    param_tensor[offsets_info["gate_proj"][0] : offsets_info["gate_proj"][1]],
+                    rtol=1e-05,
+                    atol=1e-08,
+                )
+                start = llama2_casual_lm.model.layers[layer_id].mlp.up_proj.weight.shape[0] // tp_size * tp_rank
+                end = llama2_casual_lm.model.layers[layer_id].mlp.up_proj.weight.shape[0] // tp_size * (tp_rank + 1)
+
+                torch.allclose(
+                    llama2_casual_lm.model.layers[layer_id].mlp.up_proj.weight[start:end, :].flatten(),
+                    param_tensor[offsets_info["up_proj"][0] : offsets_info["up_proj"][1]],
+                    rtol=1e-05,
+                    atol=1e-08,
+                )
+                start = llama2_casual_lm.model.layers[layer_id].mlp.down_proj.weight.shape[1] // tp_size * tp_rank
+                end = llama2_casual_lm.model.layers[layer_id].mlp.down_proj.weight.shape[1] // tp_size * (tp_rank + 1)
+
+                torch.allclose(
+                    llama2_casual_lm.model.layers[layer_id].mlp.down_proj.weight[:, start:end].flatten(),
+                    param_tensor[offsets_info["down_proj"][0] : offsets_info["down_proj"][1]],
+                    rtol=1e-05,
+                    atol=1e-08,
+                )
+                torch.allclose(
+                    llama2_casual_lm.model.layers[layer_id].input_layernorm.weight.flatten(),
+                    param_tensor[offsets_info["input_layernorm"][0] : offsets_info["input_layernorm"][1]],
+                    rtol=1e-05,
+                    atol=1e-08,
+                )
+                torch.allclose(
+                    llama2_casual_lm.model.layers[layer_id].input_layernorm.weight.flatten(),
+                    param_tensor[
+                        offsets_info["post_attention_layernorm"][0] : offsets_info["post_attention_layernorm"][1]
+                    ],
+                    rtol=1e-05,
+                    atol=1e-08,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/atorch/atorch/tests/rl_tests/rl_llama_vllm_backend_test.py
+++ b/atorch/atorch/tests/rl_tests/rl_llama_vllm_backend_test.py
@@ -1,0 +1,20 @@
+import unittest
+
+from transformers import LlamaForCausalLM
+
+from atorch.rl.inference_backend.vllm_backend import VLLMBackend
+
+
+@unittest.skipIf(True, "need weights and tokenizer")
+class TestVllmInferenceBackEnd(unittest.TestCase):
+    def test_vllm_backend_generate(self):
+        checkpoint_path = "/mnt1/xuantai.hxd/test/llama2_small"
+        # to do add param type
+        vllm_inference_backend = VLLMBackend(checkpoint_path=checkpoint_path, gen_kwargs={})
+        model = LlamaForCausalLM.from_pretrained(checkpoint_path)
+        model.half().to(0)
+        vllm_inference_backend.set_train_model_weights(model)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/atorch/atorch/tests/rl_tests/rl_load_init_model_test.py
+++ b/atorch/atorch/tests/rl_tests/rl_load_init_model_test.py
@@ -1,0 +1,121 @@
+import copy
+import os
+import tempfile
+import unittest
+
+import deepspeed
+import torch
+import torch.multiprocessing as mp
+from transformers import OPTConfig, OPTForCausalLM
+
+from atorch.common.util_func import find_free_port
+from atorch.rl.ds_hybrid_engine.initialize import initialize
+from atorch.rl.model_utils.load_init_model import load_ds_model_with_zero3_partition
+from atorch.tests.utils.test_utils import init_dist
+
+try:
+    from transformers import MixtralConfig, MixtralForCausalLM
+except Exception:
+    MixtralConfig = None
+    MixtralForCausalLM = None
+
+
+def _load_ds_model_with_zero3_partition(rank, world_size):
+    init_dist(rank, world_size)
+    torch.manual_seed(0)
+    opt_config = OPTConfig()
+    opt_model = OPTForCausalLM(opt_config)
+    opt_model_copy = copy.deepcopy(opt_model).to(rank)
+    folder = tempfile.mkdtemp()
+    model_class = OPTForCausalLM
+    model_config_class = OPTConfig
+    model_config_folder = folder
+    opt_model.save_pretrained(folder)
+    ds_config = {"train_batch_size": 4}
+    model = load_ds_model_with_zero3_partition(
+        model_class, model_config_class, model_config_folder=model_config_folder, ds_config_dict_or_path=ds_config
+    )
+    with deepspeed.zero.GatheredParameters(list(model.parameters(recurse=True)), modifier_rank=0):
+        for p1, p2 in zip(model.parameters(), opt_model_copy.parameters()):
+            assert torch.allclose(p1, p2, rtol=1e-05, atol=1e-08)
+    assert model is not None
+    # opt model tie lm_head.weight with embed_tokens.weight by default
+    config = {
+        "train_batch_size": 32,
+        "train_micro_batch_size_per_gpu": 2,
+        "steps_per_print": 10,
+        "zero_optimization": {"stage": 3, "stage3_param_persistence_threshold": 0},
+        "bf16": {
+            "enabled": True,
+        },
+        "gradient_clipping": 1.0,
+    }
+    kwargs = {}
+    kwargs["config"] = config
+    kwargs["model"] = model
+    m, _, _, _ = deepspeed.initialize(**kwargs)
+    assert m.model.decoder.embed_tokens.weight.ds_tensor.data_ptr() == m.lm_head.weight.ds_tensor.data_ptr()
+
+
+@unittest.skipIf(torch.cuda.device_count() < 2, "run with gpu_num >=2")
+class TestLoadDSModel(unittest.TestCase):
+    def test_load_ds_model_with_zero3_partition(self):
+        world_size = 2
+        os.environ["MASTER_ADDR"] = "localhost"  #
+        os.environ["MASTER_PORT"] = str(find_free_port())
+        mp.spawn(
+            _load_ds_model_with_zero3_partition,
+            args=(world_size,),
+            nprocs=world_size,
+            join=True,
+        )
+
+
+def _load_ds_model_with_zero3_partition_mixtral(rank, world_size):
+    init_dist(rank, world_size)
+    torch.manual_seed(0)
+    mixtral_config = MixtralConfig()
+    mixtral_config.num_hidden_layers = 2
+    mixtral_model = MixtralForCausalLM(mixtral_config)
+    mixtral_model_copy = copy.deepcopy(mixtral_model).to(rank)
+    folder = tempfile.mkdtemp()
+    model_class = MixtralForCausalLM
+    model_config_class = MixtralConfig
+    model_config_folder = folder
+    mixtral_model.save_pretrained(folder)
+    ds_config = {"train_batch_size": 4}
+    model = load_ds_model_with_zero3_partition(
+        model_class, model_config_class, model_config_folder=model_config_folder, ds_config_dict_or_path=ds_config
+    )
+    with deepspeed.zero.GatheredParameters(list(model.parameters(recurse=True)), modifier_rank=0):
+        for p1, p2 in zip(model.parameters(), mixtral_model_copy.parameters()):
+            assert torch.allclose(p1, p2, rtol=1e-05, atol=1e-08)
+    assert model is not None
+    config = {
+        "train_batch_size": 32,
+        "train_micro_batch_size_per_gpu": 2,
+        "steps_per_print": 10,
+        "zero_optimization": {"stage": 3, "stage3_param_persistence_threshold": 0},
+        "bf16": {
+            "enabled": True,
+        },
+        "gradient_clipping": 1.0,
+    }
+    kwargs = {}
+    kwargs["config"] = config
+    kwargs["model"] = model
+    m, _, _, _ = initialize(**kwargs)
+
+
+@unittest.skipIf(True, "works with transformers>=transformers==4.36.2")
+class TestLoadDSMixtralModel(unittest.TestCase):
+    def test_load_ds_model_with_zero3_partition_mixtral(self):
+        world_size = 2
+        os.environ["MASTER_ADDR"] = "localhost"  #
+        os.environ["MASTER_PORT"] = str(find_free_port())
+        mp.spawn(
+            _load_ds_model_with_zero3_partition_mixtral,
+            args=(world_size,),
+            nprocs=world_size,
+            join=True,
+        )

--- a/atorch/atorch/tests/rl_tests/rl_model_engine_test.py
+++ b/atorch/atorch/tests/rl_tests/rl_model_engine_test.py
@@ -1,0 +1,196 @@
+import json
+import os
+import tempfile
+import unittest
+
+import torch
+import torch.multiprocessing as mp
+from deepspeed import DeepSpeedEngine
+from deepspeed.ops.adam import DeepSpeedCPUAdam
+
+import atorch
+from atorch.common.util_func import find_free_port
+from atorch.rl.config import AtorchRLConfig
+from atorch.rl.model_engine import ModelEngine
+from atorch.utils.version import torch_version
+
+
+def init_dist(rank, world_size):
+    os.environ["LOCAL_RANK"] = str(rank)
+    os.environ["RANK"] = str(rank)
+    os.environ["WORLD_SIZE"] = str(world_size)
+    os.environ["NPROC_PER_NODE"] = str(world_size)
+
+    atorch.init_distributed("nccl")
+    torch.cuda.device(atorch.local_rank())
+
+
+def _run_test_model_engine_load_init_model(rank, world_size):
+    init_dist(rank, world_size)
+    config_path = "./atorch/tests/test_define_rl_models/independent_models/model_def.yaml"
+    atorch_rl_config = AtorchRLConfig.load_yaml(config_path)
+    model_engine = ModelEngine(atorch_rl_config)
+    assert model_engine is not None
+    assert model_engine.models_strategies["actor"][1] == "amp_native"
+    assert model_engine.models_strategies["actor"][2] == ("fsdp")
+    model_engine.apply_strategy_to_child_model("critic")
+    assert isinstance(model_engine.auto_accelerated_models["critic"], torch.nn.Module)
+    assert model_engine.models_strategies["critic"] == "torch_native"
+    critic_optimizer = model_engine.auto_accelerated_optimizer["critic"]
+    assert issubclass(type(critic_optimizer), torch.optim.Optimizer)
+    model_engine.apply_strategy_to_child_model("reward_model")
+    assert isinstance(model_engine.auto_accelerated_models["reward_model"], torch.nn.Module)
+    model_engine.apply_strategy_to_child_model("ref_model")
+    assert isinstance(model_engine.auto_accelerated_models["ref_model"], torch.nn.Module)
+    model_engine.apply_strategy_to_child_model("reward_model")
+    assert isinstance(model_engine.auto_accelerated_models["reward_model"], torch.nn.Module)
+    atorch.reset_distributed()
+
+
+def _model_engine_apply_strategy(rank, world_size):
+    init_dist(rank, world_size)
+    # TODO: test whether the strategies are applied successfully
+    # and models are wrapped by correspondding backbend
+    config_path = "./atorch/tests/test_define_rl_models/independent_models/model_def.yaml"
+    atorch_rl_config = AtorchRLConfig.load_yaml(config_path)
+    model_engine = ModelEngine(atorch_rl_config)
+    model_engine.models_strategies["actor"] = ["amp_native", ("fsdp", {"atorch_wrap_cls": {"Linear"}})]
+    model_engine.apply_strategy_to_child_model("actor")
+    actor = model_engine.auto_accelerated_models["actor"]
+    assert isinstance(actor.linear, torch.distributed.fsdp.fully_sharded_data_parallel.FullyShardedDataParallel)
+
+
+def _model_engine_support_ds_backend_with_offload_optimizer_and_param(rank, world_size):
+    init_dist(rank, world_size)
+    config_path = "./atorch/tests/test_define_rl_models/independent_models/model_def.yaml"
+    atorch_rl_config = AtorchRLConfig.load_yaml(config_path)
+    model_engine = ModelEngine(atorch_rl_config)
+    # ds_config
+    ds_json = {
+        "train_micro_batch_size_per_gpu": 2,
+        "gradient_accumulation_steps": 1,
+        "bf16": {"enabled": True},
+        "zero_optimization": {
+            "stage": 2,
+            "offload_optimizer": {"device": "cpu"},
+            "offload_param": {"device": "cpu"},
+            "allgather_partitions": True,
+            "allgather_bucket_size": 5e8,
+            "contiguous_gradients": True,
+            "overlap_comm": True,
+            "reduce_scatter": True,
+            "reduce_bucket_size": 5e8,
+        },
+        "gradient_clipping": 1.0,
+    }
+    folder = tempfile.TemporaryDirectory()
+    config_path = os.path.join(folder.name, "ds_config.json")
+    with open(config_path, "w") as f:
+        json.dump(ds_json, f)
+    model_type = "actor"
+    model = torch.nn.Linear(2, 3)
+    model_engine.models_strategies[model_type] = config_path
+    model_engine.models[model_type] = model
+
+    model_engine.apply_strategy_to_child_model(model_type)
+    assert isinstance(model_engine.auto_accelerated_models[model_type], DeepSpeedEngine)
+    for i in range(10):
+        inputs = torch.ones(4, 2).to(atorch.local_rank()).bfloat16()
+        outputs = model_engine.auto_accelerated_models[model_type](inputs)
+        loss = outputs.sum()
+        model_engine.auto_accelerated_models[model_type].backward(loss)
+        model_engine.auto_accelerated_models[model_type].step()
+    assert isinstance(model_engine.auto_accelerated_models[model_type].client_optimizer, DeepSpeedCPUAdam)
+
+
+def _model_engine_support_ds_backend_with_offload_param(rank, world_size):
+    init_dist(rank, world_size)
+    config_path = "./atorch/tests/test_define_rl_models/independent_models/model_def.yaml"
+    atorch_rl_config = AtorchRLConfig.load_yaml(config_path)
+    model_engine = ModelEngine(atorch_rl_config)
+    # ds_config
+    ds_json = {
+        "train_micro_batch_size_per_gpu": 2,
+        "gradient_accumulation_steps": 1,
+        "bf16": {"enabled": True},
+        "zero_optimization": {
+            "stage": 2,
+            "offload_param": {"device": "cpu"},
+            "allgather_partitions": True,
+            "allgather_bucket_size": 5e8,
+            "contiguous_gradients": True,
+            "overlap_comm": True,
+            "reduce_scatter": True,
+            "reduce_bucket_size": 5e8,
+        },
+        "gradient_clipping": 1.0,
+    }
+
+    folder = tempfile.TemporaryDirectory()
+    config_path = os.path.join(folder.name, "ds_config.json")
+    with open(config_path, "w") as f:
+        json.dump(ds_json, f)
+    model_type = "actor"
+    model = torch.nn.Linear(2, 3)
+    model_engine.models_strategies[model_type] = config_path
+    model_engine.models[model_type] = model
+    model_engine.apply_strategy_to_child_model(model_type)
+    assert isinstance(model_engine.auto_accelerated_models[model_type], DeepSpeedEngine)
+    for i in range(10):
+        inputs = torch.ones(4, 2).to(atorch.local_rank()).bfloat16()
+        outputs = model_engine.auto_accelerated_models[model_type](inputs)
+        loss = outputs.sum()
+        model_engine.auto_accelerated_models[model_type].backward(loss)
+        model_engine.auto_accelerated_models[model_type].step()
+    assert isinstance(model_engine.auto_accelerated_models[model_type].client_optimizer, torch.optim.Adam)
+
+
+@unittest.skipIf(torch.cuda.device_count() < 2 or torch_version() < (2, 0, 0), "run with gpu_num >=2")
+class TestModelEngine(unittest.TestCase):
+    def test_run_test_model_engine_load_init_model(self):
+        os.environ["MASTER_ADDR"] = "localhost"  #
+        os.environ["MASTER_PORT"] = str(find_free_port())
+        world_size = 2
+        mp.spawn(
+            _run_test_model_engine_load_init_model,
+            args=(world_size,),
+            nprocs=world_size,
+            join=True,
+        )
+
+    def test_model_engine_apply_strategy(self):
+        world_size = 2
+        os.environ["MASTER_ADDR"] = "localhost"  #
+        os.environ["MASTER_PORT"] = str(find_free_port())
+        mp.spawn(
+            _model_engine_apply_strategy,
+            args=(world_size,),
+            nprocs=world_size,
+            join=True,
+        )
+
+    def test_model_engine_support_ds_backend_with_offload_param(self):
+        world_size = 2
+        os.environ["MASTER_ADDR"] = "localhost"  #
+        os.environ["MASTER_PORT"] = str(find_free_port())
+        mp.spawn(
+            _model_engine_support_ds_backend_with_offload_param,
+            args=(world_size,),
+            nprocs=world_size,
+            join=True,
+        )
+
+    def test_model_engine_support_ds_backend_with_offload_optimizer_and_param(self):
+        world_size = 2
+        os.environ["MASTER_ADDR"] = "localhost"  #
+        os.environ["MASTER_PORT"] = str(find_free_port())
+        mp.spawn(
+            _model_engine_support_ds_backend_with_offload_optimizer_and_param,
+            args=(world_size,),
+            nprocs=world_size,
+            join=True,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/atorch/atorch/tests/rl_tests/rl_ppo_util_test.py
+++ b/atorch/atorch/tests/rl_tests/rl_ppo_util_test.py
@@ -1,0 +1,167 @@
+import unittest
+
+import torch
+
+from atorch.common.log_utils import DashBoardWriter
+from atorch.rl.config import AtorchRLConfig
+from atorch.rl.ppo_utils.ppo_util import get_advantages_and_returns, loss
+
+
+class TestRLTrainerUtil(unittest.TestCase):
+    def test_rl_trainer_util_cpu(self):
+        # TODO: test whether the result is right.
+        config_path = "./atorch/tests/test_define_rl_models/independent_models/model_def.yaml"
+        atorch_rl_config = AtorchRLConfig.load_yaml(config_path)
+
+        batch_size = 2
+        sequence_length = 20
+        embedding_size = 2048
+        response_tensor = torch.ones((batch_size, sequence_length))
+        logits = torch.ones((batch_size, sequence_length, embedding_size))
+        logprobs = torch.ones((batch_size, sequence_length, embedding_size))
+        values = torch.ones((batch_size, sequence_length))
+        rewards = torch.ones((batch_size, sequence_length))
+
+        response_length = response_tensor.shape[1]
+
+        advantages, returns = get_advantages_and_returns(
+            values, rewards, response_length, config=atorch_rl_config.ppo_config
+        )
+        self.assertEqual(advantages.dim(), returns.dim())
+
+        logprobs = torch.tensor(
+            [
+                [-1.3162, -4.4145, -2.9761, -1.5285, -2.4031, -0.7153, -1.3419, -0.9945],
+                [-1.3162, -4.4145, -2.9761, -1.5285, -2.4031, -0.7153, -1.3419, -0.9945],
+            ]
+        )
+
+        values = torch.tensor(
+            [
+                [-0.2439, -0.2515, -0.0448, -0.0810, -0.1800, -0.3194, -0.3549, -0.3704],
+                [-0.2439, -0.2515, -0.0448, -0.0810, -0.1800, -0.3194, -0.3549, -0.3704],
+            ]
+        )
+        old_logprobs = torch.tensor(
+            [
+                [-1.3162, -4.4145, -2.9761, -1.5285, -2.4031, -0.7153, -1.3419, -0.9945],
+                [-1.3162, -4.4145, -2.9761, -1.5285, -2.4031, -0.7153, -1.3419, -0.9945],
+            ]
+        )
+        old_values = torch.tensor(
+            [
+                [-0.2439, -0.2515, -0.0448, -0.0810, -0.1800, -0.3194, -0.3549, -0.3704],
+                [-0.2439, -0.2515, -0.0448, -0.0810, -0.1800, -0.3194, -0.3549, -0.3704],
+            ]
+        )
+        advantages = torch.tensor(
+            [
+                [0.2212, 0.2474, 0.0373, 0.0645, 0.1509, 0.2872, 0.3268, 0.8936],
+                [0.2212, 0.2474, 0.0373, 0.0645, 0.1509, 0.2872, 0.3268, 0.8936],
+            ]
+        )
+        returns = torch.tensor(
+            [
+                [-0.0227, -0.0041, -0.0075, -0.0165, -0.0291, -0.0322, -0.0281, 0.5232],
+                [-0.0227, -0.0041, -0.0075, -0.0165, -0.0291, -0.0322, -0.0281, 0.5232],
+            ]
+        )
+        mask = torch.tensor([[1, 1, 1, 1, 1, 1, 1, 1], [1, 1, 1, 1, 1, 1, 1, 1]])
+        logits = torch.ones((2, mask.shape[1], embedding_size))
+        ppo_loss, stats = loss(
+            logprobs,
+            values,
+            old_logprobs,
+            old_values,
+            advantages,
+            returns,
+            mask,
+            logits,
+            config=atorch_rl_config.ppo_config,
+        )
+        dashboard_writer = DashBoardWriter("./")
+        dashboard_writer.add_scalars(stats, 1)
+        self.assertEqual(ppo_loss.dim(), 0)
+
+    @unittest.skipIf(
+        not torch.cuda.is_available(),
+        "No gpu available for cuda tests",
+    )
+    def test_rl_trainer_util_gpu(self):
+        # TODO: test whether the result is right.
+        config_path = "./atorch/tests/test_define_rl_models/independent_models/model_def.yaml"
+        atorch_rl_config = AtorchRLConfig.load_yaml(config_path)
+
+        batch_size = 2
+        sequence_length = 20
+        embedding_size = 2048
+        response_tensor = torch.ones((batch_size, sequence_length)).cuda()
+        logits = torch.ones((batch_size, sequence_length, embedding_size)).cuda()
+        logprobs = torch.ones((batch_size, sequence_length, embedding_size)).cuda()
+        values = torch.ones((batch_size, sequence_length)).cuda()
+        rewards = torch.ones((batch_size, sequence_length)).cuda()
+
+        response_length = response_tensor.shape[1]
+
+        advantages, returns = get_advantages_and_returns(
+            values, rewards, response_length, config=atorch_rl_config.ppo_config
+        )
+        self.assertEqual(advantages.dim(), returns.dim())
+
+        logprobs = torch.tensor(
+            [
+                [-1.3162, -4.4145, -2.9761, -1.5285, -2.4031, -0.7153, -1.3419, -0.9945],
+                [-1.3162, -4.4145, -2.9761, -1.5285, -2.4031, -0.7153, -1.3419, -0.9945],
+            ]
+        ).cuda()
+
+        values = torch.tensor(
+            [
+                [-0.2439, -0.2515, -0.0448, -0.0810, -0.1800, -0.3194, -0.3549, -0.3704],
+                [-0.2439, -0.2515, -0.0448, -0.0810, -0.1800, -0.3194, -0.3549, -0.3704],
+            ]
+        ).cuda()
+        old_logprobs = torch.tensor(
+            [
+                [-1.3162, -4.4145, -2.9761, -1.5285, -2.4031, -0.7153, -1.3419, -0.9945],
+                [-1.3162, -4.4145, -2.9761, -1.5285, -2.4031, -0.7153, -1.3419, -0.9945],
+            ]
+        ).cuda()
+        old_values = torch.tensor(
+            [
+                [-0.2439, -0.2515, -0.0448, -0.0810, -0.1800, -0.3194, -0.3549, -0.3704],
+                [-0.2439, -0.2515, -0.0448, -0.0810, -0.1800, -0.3194, -0.3549, -0.3704],
+            ]
+        ).cuda()
+        advantages = torch.tensor(
+            [
+                [0.2212, 0.2474, 0.0373, 0.0645, 0.1509, 0.2872, 0.3268, 0.8936],
+                [0.2212, 0.2474, 0.0373, 0.0645, 0.1509, 0.2872, 0.3268, 0.8936],
+            ]
+        ).cuda()
+        returns = torch.tensor(
+            [
+                [-0.0227, -0.0041, -0.0075, -0.0165, -0.0291, -0.0322, -0.0281, 0.5232],
+                [-0.0227, -0.0041, -0.0075, -0.0165, -0.0291, -0.0322, -0.0281, 0.5232],
+            ]
+        ).cuda()
+        mask = torch.tensor([[1, 1, 1, 1, 1, 1, 1, 1], [1, 1, 1, 1, 1, 1, 1, 1]]).cuda()
+        logits = torch.ones((batch_size, mask.shape[1], embedding_size)).cuda()
+        ppo_loss, stats = loss(
+            logprobs,
+            values,
+            old_logprobs,
+            old_values,
+            advantages,
+            returns,
+            mask,
+            logits,
+            config=atorch_rl_config.ppo_config,
+        )
+        self.assertEqual(ppo_loss.dim(), 0)
+        dashboard_writer = DashBoardWriter("./")
+        dashboard_writer.add_scalars(stats, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/atorch/atorch/tests/rl_tests/rl_redis_test.py
+++ b/atorch/atorch/tests/rl_tests/rl_redis_test.py
@@ -1,0 +1,54 @@
+import subprocess
+import unittest
+
+from atorch.common.log_utils import default_logger as logger
+from atorch.rl.model_utils.redis_util import RMQ, RedisDataLoader
+
+try:
+    from vllm import LLM, SamplingParams  # type: ignore
+except Exception:
+    logger.warning("vllm not installed")
+
+
+class TestDsLlama2Container(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # start redis server
+        cls.redis_process = subprocess.Popen(["redis-server", "--port 6379"])
+
+    @classmethod
+    def tearDownClass(cls):
+        # stop redis server
+        cls.redis_process.terminate()
+        cls.redis_process.wait()
+
+    def test_redis_client(self):
+
+        client = RMQ("test")
+
+        model_dir = "/mnt1/xuantai.hxd/test/llama2_small"
+
+        sampling_params = SamplingParams(temperature=0, max_tokens=500)
+
+        llm = LLM(model=model_dir, trust_remote_code=True, gpu_memory_utilization=0.5, tensor_parallel_size=1)
+
+        res = llm.generate("大家对待男女明星差别那么大?", sampling_params=sampling_params)
+        import json
+
+        data = {"prompt": res[0].prompt, "output": res[0].outputs[0].text}
+
+        dataloader = RedisDataLoader()
+
+        for i in range(200000):
+            client.publish(json.dumps(data), str(0))
+
+        client.publish("STOP", "0")
+
+        for i, j in enumerate(dataloader):
+            if i == 4:
+                break
+            assert j["prompt"][0] == "大家对待男女明星差别那么大?"
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/atorch/atorch/tests/rl_tests/rl_replay_buffer_test.py
+++ b/atorch/atorch/tests/rl_tests/rl_replay_buffer_test.py
@@ -1,0 +1,53 @@
+import unittest
+
+import torch
+
+from atorch.rl.config import AtorchRLConfig
+from atorch.rl.replay_buffer import ReplayBuffer
+
+
+class TestReplayBuffer(unittest.TestCase):
+    def test_replay_buffer(self):
+        config_path = "./atorch/tests/test_define_rl_models/independent_models/model_def.yaml"
+        atorch_rl_config = AtorchRLConfig.load_yaml(config_path)
+        atorch_rl_config.tokenizer.pad_token_id = 50005
+        replay_buffer = ReplayBuffer(config=atorch_rl_config)
+        replay_buffer.reset()
+        batch_size = 4
+        sequence_length = 20
+        embedding_size = 2048
+        query_tensor = torch.rand((batch_size, sequence_length))
+        response_tensor = torch.rand((batch_size, sequence_length))
+        logprobs = torch.rand((batch_size, sequence_length, embedding_size))
+        values = torch.rand((batch_size, sequence_length))
+        rewards = torch.rand((batch_size, sequence_length))
+        ppo_element = {
+            "query_tensor": query_tensor,
+            "response_tensor": response_tensor,
+            "logprobs": logprobs,
+            "values": values,
+            "rewards": rewards,
+        }
+        replay_buffer.add_sample(ppo_element)
+        self.assertEqual(replay_buffer.num, 1)
+        replay_buffer.add_samples([ppo_element])
+        self.assertEqual(replay_buffer.num, 2)
+        replay_buffer.add_sample(ppo_element, index=2)
+        self.assertEqual(replay_buffer.num, 2)
+        new_query_tensor = torch.rand(1)
+        new_ppo_element = {
+            "query_tensor": new_query_tensor,
+            "response_tensor": response_tensor,
+            "logprobs": logprobs,
+            "values": values,
+            "rewards": rewards,
+        }
+        index = 1
+        replay_buffer.add_sample(new_ppo_element, index=index)
+        self.assertEqual(replay_buffer.data["query_tensor"][index].shape[0], 1)
+        rl_training_dataset = replay_buffer.create_dataset()
+        self.assertEqual(len(rl_training_dataset), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/atorch/atorch/tests/test_define_rl_models/independent_models/hg_model_def.yaml
+++ b/atorch/atorch/tests/test_define_rl_models/independent_models/hg_model_def.yaml
@@ -1,0 +1,70 @@
+model:
+  actor:
+      model_path: /home/glm-large-chinese
+      model_cls: transformers.AutoModelForSeq2SeqLM
+      model_params: 
+        features_in: 10
+        features_out: 10
+      train_strategy: null 
+      inference_strategy: null 
+  critic:
+      model_path: /home/glm-large-chinese
+      model_cls: transformers.AutoModelForSeq2SeqLM
+      model_params: 
+        dims_in: 2
+        dims_out: 2
+      train_strategy: null 
+      inference_strategy: null 
+  ref_model:
+      model_path: /home/glm-large-chinese
+      model_cls: transformers.AutoModelForSeq2SeqLM
+      model_params: 
+        dims_in: 2
+        dims_out: 2
+      inference_strategy: null
+  reward_model:
+      model_path: /home/glm-large-chinese
+      model_cls: transformers.AutoModelForSeq2SeqLM
+      model_params: 
+        dims_in: 2
+        dims_out: 2
+      inference_strategy: null
+train:
+  seq_length: 1024
+  batch_size: 4
+  epoch: 1
+  num_rollouts: 4 
+generation:
+    batch_size: 4
+    epoch: 10
+    gen_kwargs:
+      max_new_tokens: 512
+      top_k: 0
+      top_p: 1.0
+      do_sample: false
+    gen_experience_kwargs:
+      max_new_tokens: 512
+      do_sample: false
+      temperature: 1.0
+      top_k: 50
+      top_p: 0.95
+
+tokenizer:
+  tokenizer_path: /home/glm-large-chinese
+  params:
+    truncation_side: right
+method:
+  PPOConfig:
+      ppo_epoch: 2
+      init_kl_coef: 0.02
+      gamma: 1
+      lam: 0.95
+      cliprange: 0.2
+      cliprange_value: 0.2
+      vf_coef: 0.1
+      cliprange_reward: 50
+      clip_ratio: true
+      ent_coef: 0.01
+      scale_reward: running
+      ref_mean: null
+      ref_std: null

--- a/atorch/atorch/tests/test_define_rl_models/independent_models/model_def.yaml
+++ b/atorch/atorch/tests/test_define_rl_models/independent_models/model_def.yaml
@@ -1,0 +1,76 @@
+model:
+  actor:
+      model_path: ./atorch/tests/test_define_rl_models/independent_models/model_definition.py
+      model_cls: FakeActor
+      model_params: 
+        features_in: 10
+        features_out: 10
+      train_strategy: ./atorch/tests/test_define_rl_models/independent_models/strategy.py
+      inference_strategy: null
+      peft_config:
+        peft_type: LORA
+        task_type: ANT_CAUSAL_LM
+        r: 8
+        lora_alpha: 32
+        lora_dropout: 0.1
+  critic:
+      model_path: ./atorch/tests/test_define_rl_models/independent_models/model_definition.py
+      model_cls: FakeCritic
+      model_params: 
+        dims_in: 2
+        dims_out: 2
+      train_strategy: null 
+      inference_strategy: null 
+  ref_model:
+      model_path: ./atorch/tests/test_define_rl_models/independent_models/model_definition.py
+      model_cls: FakeRefModel
+      model_params: 
+        dims_in: 2
+        dims_out: 2
+      inference_strategy: null
+  reward_model:
+      model_path: ./atorch/tests/test_define_rl_models/independent_models/model_definition.py
+      model_cls: FakeRewardModel
+      model_params: 
+        dims_in: 2
+        dims_out: 2
+      inference_strategy: null
+train:
+  seq_length: 1024
+  batch_size: 4
+  epoch: 1
+  num_rollouts: 10 
+generation:
+    batch_size: 4
+    epoch: 10
+    gen_kwargs:
+      max_new_tokens: 512
+      top_k: 0
+      top_p: 1.0
+      do_sample: false
+    gen_experience_kwargs:
+      max_new_tokens: 512
+      do_sample: false
+      temperature: 1.0
+      top_k: 50
+      top_p: 0.95
+
+tokenizer:
+  tokenizer_path: /home/glm-large-chinese
+  params:
+    truncation_side: right
+method:
+  PPOConfig:
+      ppo_epoch: 2
+      init_kl_coef: 0.02
+      gamma: 1
+      lam: 0.95
+      cliprange: 0.2
+      cliprange_value: 0.2
+      vf_coef: 0.1
+      cliprange_reward: 50
+      clip_ratio: true
+      ent_coef: 0.01
+      scale_reward: running
+      ref_mean: null
+      ref_std: null

--- a/atorch/atorch/tests/test_define_rl_models/independent_models/model_definition.py
+++ b/atorch/atorch/tests/test_define_rl_models/independent_models/model_definition.py
@@ -1,0 +1,38 @@
+import torch
+import torch.nn as nn
+
+
+class FakeActor(nn.Module):
+    def __init__(self, features_in=10, features_out=10):
+        super().__init__()
+        self.linear = torch.nn.Linear(features_in, features_out)
+
+    def forward(self, x):
+        return self.linear(x)
+
+
+class FakeCritic(nn.Module):
+    def __init__(self, dims_in=10, dims_out=10):
+        super().__init__()
+        self.linear = torch.nn.Linear(dims_in, dims_out)
+
+    def forward(self, x):
+        return self.linear(x)
+
+
+class FakeRewardModel(nn.Module):
+    def __init__(self, dims_in=10, dims_out=10):
+        super().__init__()
+        self.linear = torch.nn.Linear(dims_in, dims_out)
+
+    def forward(self, x):
+        return self.linear(x)
+
+
+class FakeRefModel(nn.Module):
+    def __init__(self, dims_in=10, dims_out=10):
+        super().__init__()
+        self.linear = torch.nn.Linear(dims_in, dims_out)
+
+    def forward(self, x):
+        return self.linear(x)

--- a/atorch/atorch/tests/test_define_rl_models/share_weights_models/actor_critic_ref.py
+++ b/atorch/atorch/tests/test_define_rl_models/share_weights_models/actor_critic_ref.py
@@ -1,0 +1,170 @@
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+from transformers import AutoModelForSeq2SeqLM, AutoTokenizer
+from transformers.modeling_outputs import ModelOutput
+
+from atorch.rl.model_utils.model_util import (
+    freeze_bottom_causal_layers,
+    hf_get_decoder_blocks,
+    hf_get_decoder_final_norm,
+    hf_get_hidden_size,
+    make_head,
+)
+
+
+@dataclass
+class ActorCriticRefOutput(ModelOutput):
+    logits: Optional[torch.FloatTensor] = None
+    ref_logits: Optional[torch.FloatTensor] = None
+    values: Optional[Tuple[Tuple[torch.FloatTensor]]] = None
+
+
+class ActorCriticRef(torch.nn.Module):
+    def __init__(self, model, num_layers):
+        super().__init__()
+        self.model = model
+        self.checkpoint_activations = model.config.checkpoint_activations
+        self.num_layers = num_layers
+
+        # ref model
+        decoder_blocks = hf_get_decoder_blocks(model)
+        self.decoder_blocks = deepcopy(nn.ModuleList(list(decoder_blocks)[-num_layers:]))
+        self.final_norm = hf_get_decoder_final_norm(model)
+        self.word_embeddings_weight = model.glm.word_embeddings.weight
+
+        # critic model
+        self.critic_head = make_head(hf_get_hidden_size(model.config), 1)
+
+    def forward(self, *args, inference=False, **kwargs):
+        """
+        calculating logits, value and ref_logits
+
+        Args:
+            generate: bool, when it's True, forward is used for generating response sequenece
+            inference: bool, when it's True, forward is used for calculating logits, ref_logits and values
+            When generate and inference are both False, forward is used for training and calculating logits and values
+        """
+        logits = None
+        ref_logits = None
+        values = None
+        outs = self.model.glm(*args, **kwargs)
+        logits = outs.logits
+        values = self.critic_head(outs.last_hidden_states).squeeze(-1)
+        if inference:
+            ref_logits, _ = self.get_ref_logits(outs.mems, **inputs)
+        return ActorCriticRefOutput(logits=logits, ref_logits=ref_logits, values=values)
+
+    def generate(self, *args, **kwargs):
+
+        """
+        feeded with prompts and generating response sequences
+        """
+        return self.model.generate(*args, **kwargs)
+
+    def get_ref_logits(self, hidden_states, **forward_kwargs):
+        input_hidden_state = hidden_states[-(self.num_layers + 1)]
+        output_shape = hidden_states[-1].size()
+        forward_kwargs.pop("input_ids", None)  # Ignore `input_ids` for branch head
+        forward_kwargs.pop("inputs_embeds", None)  # Ignore `inputs_embeds` for branch head
+        forward_kwargs.pop("token_type_ids", None)
+        input_hidden_state = input_hidden_state.type(dtype=self.word_embeddings_weight.dtype)
+        outputs = self.ref_forward(input_hidden_state, output_shape, **forward_kwargs)
+        return outputs
+
+    def ref_forward(  # noqa: max-complexity
+        self,
+        hidden_states: torch.Tensor,  # Takes as input hidden_states instead of input_ids
+        output_shape: torch.Tensor,  # output_size given by main trunk
+        past_key_values: Optional[Tuple[Tuple[torch.Tensor]]] = None,
+        attention_mask: Optional[torch.FloatTensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        head_mask: Optional[torch.FloatTensor] = None,
+        encoder_hidden_states: Optional[torch.Tensor] = None,
+        encoder_attention_mask: Optional[torch.FloatTensor] = None,
+        use_cache: Optional[bool] = None,
+        output_attentions: Optional[bool] = None,
+        output_hidden_states: Optional[bool] = None,
+        return_dict: Optional[bool] = False,
+        memory_states=None,
+    ):
+        def check_detach(_hidden_states):
+            return _hidden_states.detach()
+
+        mem_layers = [check_detach(hidden_states)]
+        for i, layer in enumerate(self.decoder_blocks):
+            args = [hidden_states, attention_mask]
+
+            def create_custom_forward(module):
+                def custom_forward(*inputs):
+                    # None for past_key_value
+                    return module(*inputs)
+
+                return custom_forward
+
+            mem_i = memory_states[i] if memory_states else None
+            if self.checkpoint_activations:
+                hidden_states = torch.utils.checkpoint.checkpoint(
+                    create_custom_forward(layer),
+                    hidden_states,
+                    mem=mem_i,
+                )
+            else:
+                hidden_states = layer(*args, mem=mem_i)
+            mem_layers.append(check_detach(hidden_states))
+        output = self.final_norm(hidden_states)
+        mem_layers = self.update_mems(mem_layers, memory_states)
+
+        logits = F.linear(output, self.word_embeddings_weight)
+        # to do import CausalLMOutputWithValue
+        return logits, mem_layers
+
+    def update_mems(self, hiddens, mems):
+        memory_length = mems[0].size(1) if mems else 0
+        query_length = hiddens[0].size(1)
+        new_memory_length = memory_length + query_length
+
+        new_mems = []
+        # with torch.no_grad():
+        for i in range(len(hiddens)):
+            if new_memory_length <= query_length:
+                new_mems.append(hiddens[i][:, -new_memory_length:])
+            else:
+                new_mems.append(torch.cat((mems[i][:, -new_memory_length + query_length :], hiddens[i]), dim=1))
+        return new_mems
+
+    @classmethod
+    def from_pretrained(cls, path, num_layers=0):
+        model = AutoModelForSeq2SeqLM.from_pretrained(path, trust_remote_code=True)
+        freeze_bottom_causal_layers(model, num_layers)
+        return cls(model, num_layers)
+
+
+if __name__ == "__main__":
+    model_name = "/w/glm-large-chinese"
+    actor_ref_critic = ActorCriticRef.from_pretrained(model_name, num_layers=2)
+    tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)
+    str = ["今天天气真好 [MASK]"]
+    inputs = tokenizer(str)
+    for k, v in inputs.items():
+        inputs[k] = torch.tensor(v)
+    # default inference = False
+    outs = actor_ref_critic(**inputs)
+    logits = outs.logits
+    assert logits.dim() == 3
+
+    # inference = True
+    outs = actor_ref_critic(**inputs, inference=True)
+
+    assert (
+        torch.norm(outs.ref_logits - outs.logits, 1).detach().numpy() == 0.0
+    ), "logits calculated from input_ids and hidden states shoule equal"
+    assert outs.values.dim() == 2
+
+    # inference = False
+    outs = actor_ref_critic(**inputs, inference=False)
+    assert outs.ref_logits is None

--- a/atorch/atorch/tests/test_define_rl_models/share_weights_models/config.yaml
+++ b/atorch/atorch/tests/test_define_rl_models/share_weights_models/config.yaml
@@ -1,0 +1,61 @@
+model:
+  actor_critic_ref:
+      model_path: /home/glm-large-chinese
+      model_cls:  atorch.tests.test_define_rl_models.independent_models.actor_critic_ref.ActorCriticRef
+      model_params: 
+        num_layers: 2
+      train_strategy:  ./benchmarks/glm_rlhf/sequential_case_share_weights/strategy.py
+      inference_strategy: torch_native
+      loss: atorch.rl.ppo_utils.ppo_util.loss 
+      optimizer: 
+        name: torch.optim.adam
+        kwargs: 
+          lr: 1.0e-6
+          betas: 
+            - 0.9
+            - 0.95
+          eps: 1.0e-8
+          weight_decay: 0.01
+  reward_model:
+      model_path: /home/glm-large-chinese
+      model_cls: benchmarks.glm_rlhf.sequential_case_share_weights.reward_model.reward_model.RewardModel
+      train_strategy: ./benchmarks/glm_rlhf/sequential_case_share_weights/strategy.py
+train:
+  seq_length: 1024
+  batch_size: 4
+  epoch: 1
+  num_rollouts: 10 
+generation:
+    batch_size: 4
+    epoch: 10
+    gen_kwargs:
+      max_new_tokens: 512
+      top_k: 0
+      top_p: 1.0
+      do_sample: false
+    gen_experience_kwargs:
+      max_new_tokens: 512
+      do_sample: false
+      temperature: 1.0
+      top_k: 50
+      top_p: 0.95
+
+tokenizer:
+  tokenizer_path: /home
+  params:
+    truncation_side: right
+method:
+  PPOConfig:
+      ppo_epoch: 2
+      init_kl_coef: 0.02
+      gamma: 1
+      lam: 0.95
+      cliprange: 0.2
+      cliprange_value: 0.2
+      vf_coef: 0.1
+      cliprange_reward: 50
+      clip_ratio: true
+      ent_coef: 0.01
+      scale_reward: running
+      ref_mean: null
+      ref_std: null

--- a/atorch/atorch/tests/toy_modules/toy_module.py
+++ b/atorch/atorch/tests/toy_modules/toy_module.py
@@ -1,0 +1,281 @@
+import functools
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.optim as optim
+from torch.utils.data import Dataset
+from transformers.models.gpt2.configuration_gpt2 import GPT2Config
+from transformers.models.gpt2.modeling_gpt2 import GPT2MLP, GPT2Attention, GPT2Block, GPT2Model
+
+from atorch.auto.model_context import ModelContext
+from atorch.common.util_func import data_to_device, recursively_apply
+
+
+def get_gpt2_module_type(module="block"):
+    if module == "block":
+        return GPT2Block
+    elif module == "attn":
+        return GPT2Attention
+    elif module == "mlp":
+        return GPT2MLP
+    return None
+
+
+class ToyCustomModule(nn.Module):
+    def __init__(self, in_features=16, out_features=4):
+        super().__init__()
+        self.linears = torch.nn.ModuleList([nn.Linear(out_features, out_features) for _ in range(8)])
+
+    def forward(self, inputs, test_kwargs=True):
+        for op in self.linears:
+            inputs = op(inputs)
+        return inputs
+
+
+class ToyModel(nn.Module):
+    def __init__(self, in_features=16, out_features=4, use_custom_module=False):
+        """
+        Args:
+            in_feature (int): size of input feature.
+            out_feature (int): size of output feature.
+        """
+        super(ToyModel, self).__init__()
+        self.use_custom_module = use_custom_module
+        self.linear = torch.nn.Linear(in_features, out_features)
+        if use_custom_module:
+            self.linears = ToyCustomModule(in_features, out_features)
+        else:
+            self.linears = torch.nn.ModuleList([nn.Linear(out_features, out_features) for _ in range(8)])
+
+    def forward(self, inputs):
+        data = self.linear(inputs[0])
+        if self.use_custom_module:
+            data = self.linears(data, test_kwargs=True)
+        else:
+            for op in self.linears:
+                data = op(data)
+        return data
+
+
+def optim_func(model_parameters, **kwargs):
+    return optim.Adam(model_parameters, **kwargs)
+
+
+def optim_param_func(model):
+    no_decay = "bias"
+    parameters = [
+        {
+            "params": [p for n, p in model.named_parameters() if no_decay not in n],
+            "weight_decay": 0.01,
+        },
+        {
+            "params": [p for n, p in model.named_parameters() if no_decay in n],
+            "weight_decay": 0.0,
+        },
+    ]
+    return parameters
+
+
+def loss_func(inputs, output):
+    loss = nn.MSELoss()
+    return loss(inputs[1], output)
+
+
+def prepare_input(data, device):
+    return data_to_device(data, device)
+
+
+class ToyDataset(Dataset):
+    def __init__(self, size, data_size=(16,), output_size=(4,)):
+        """
+        Args:
+            size (int): the of samples.
+            data_size (tuple): the shape of one input, data_size[-1] must match the in_features
+                in ToyModule
+            output_size (tuple): the shape of output, output_size[-1] must match the out_feautes
+                in ToyModule
+        """
+        self.size = size
+        self.data_size = data_size
+        self.output_size = output_size
+
+    def __len__(self):
+        return self.size
+
+    def __getitem__(self, idx):
+        return np.ones(self.data_size, dtype=np.float32) * idx, np.ones(self.output_size, dtype=np.float32)
+
+
+# copy from pytorch/benchmarks/distributed/pipeline/benchmark_dataset.py with some modification
+def collate_sentences_lm(samples):
+    if len(samples) == 0:
+        return {}
+
+    src_tokens = torch.stack([s["source"] for s in samples], 0)
+    tgt_tokens = torch.stack([s["target"] for s in samples], 0)
+
+    batch = {
+        "input": src_tokens,
+        "target": tgt_tokens,
+    }
+    return batch
+
+
+# copy from pytorch/benchmarks/distributed/pipeline/benchmark_dataset.py with some modification
+class BenchmarkLMDataset(Dataset):
+    def __init__(
+        self,
+        vocab_size=10000,
+        max_source_positions=1024,
+        total_samples=10000,
+    ):
+        self.vocab_size = vocab_size
+        self.max_source_positions = max_source_positions
+        self.total_samples = total_samples
+        self.sizes = [self.max_source_positions] * self.total_samples
+
+    def __getitem__(self, index):
+        length = self.sizes[index]
+        source = torch.randint(1, self.vocab_size, (length,))
+        target = source.clone()
+        return {
+            "source": source,
+            "target": target,
+        }
+
+    def __len__(self):
+        return self.total_samples
+
+
+class ToyGPT2Model(GPT2Model):
+    def __init__(self, hidden_size=256, head_num=4, layer_num=3, seq_length=512):
+        config = GPT2Config()
+        c_s = f"n_embd={hidden_size},n_head={head_num},n_layer={layer_num},n_positions={seq_length}"
+        config.update_from_string(c_s)
+        super().__init__(config)
+        self.config = config
+        self.lm_head = torch.nn.Linear(config.n_embd, config.vocab_size, bias=False)
+
+    def forward(
+        self,
+        input_ids=None,
+        past_key_values=None,
+        attention_mask=None,
+        token_type_ids=None,
+        position_ids=None,
+        head_mask=None,
+        inputs_embeds=None,
+        encoder_hidden_states=None,
+        encoder_attention_mask=None,
+        labels=None,
+        use_cache=None,
+        output_attentions=None,
+        output_hidden_states=None,
+        return_dict=None,
+    ):
+
+        transformer_outputs = super().forward(
+            input_ids,
+            past_key_values=past_key_values,
+            attention_mask=attention_mask,
+            token_type_ids=token_type_ids,
+            position_ids=position_ids,
+            head_mask=head_mask,
+            inputs_embeds=inputs_embeds,
+            encoder_hidden_states=encoder_hidden_states,
+            encoder_attention_mask=encoder_attention_mask,
+            use_cache=use_cache,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            return_dict=return_dict,
+        )
+        hidden_states = transformer_outputs[0]
+        lm_logits = self.lm_head(hidden_states)
+        return lm_logits
+
+    def vocab_size(self):
+        return self.config.vocab_size
+
+
+def gpt2_loss_func(inputs, output, vocab_size):
+    criterion = torch.nn.CrossEntropyLoss()
+    return criterion(output.view(-1, vocab_size), inputs["target"].view(-1))
+
+
+def create_model_context(
+    data_size=16,
+    batch_size=2,
+    use_optim_param_func=False,
+    dataset=None,
+    distributed_sampler_cls=None,
+    use_custom_module=False,
+    use_gpt2=False,
+    hidden_size=256,
+    head_num=4,
+    layer_num=3,
+    seq_length=512,
+    extra_args=None,
+):
+    user_defined_optim_param_func = optim_param_func if use_optim_param_func else None
+    dataloader_args = {"batch_size": batch_size, "drop_last": True, "shuffle": True, "num_workers": 1}
+    if use_gpt2:
+        model = ToyGPT2Model(hidden_size=hidden_size, head_num=head_num, layer_num=layer_num, seq_length=seq_length)
+        dataset = BenchmarkLMDataset(
+            vocab_size=model.vocab_size(), max_source_positions=seq_length, total_samples=data_size
+        )
+        dataloader_args["collate_fn"] = collate_sentences_lm
+        model_loss_func = functools.partial(gpt2_loss_func, vocab_size=model.vocab_size())
+    else:
+        model = ToyModel(use_custom_module=use_custom_module)
+        dataset = ToyDataset(data_size) if dataset is None else dataset
+        model_loss_func = loss_func
+    model_context = ModelContext(
+        model=model,
+        optim_func=optim_func,
+        dataset=dataset,
+        loss_func=model_loss_func,
+        prepare_input=prepare_input,
+        optim_args={"lr": 0.001},
+        optim_param_func=user_defined_optim_param_func,
+        dataloader_args=dataloader_args,
+        distributed_sampler_cls=distributed_sampler_cls,
+        extra_args=extra_args,
+    )
+    return model_context
+
+
+def change_dtype(data, dtype, fp32_only=True):
+    if data.dtype == torch.float32 or not fp32_only:
+        return data.to(dtype)
+    else:
+        return data
+
+
+def run_train(
+    model,
+    dataloader,
+    optim,
+    prepare_input,
+    loss_func,
+    device="cpu",
+    input_dtype=torch.float32,
+    gpt2_model=False,
+    use_optim_backward=False,
+):
+    for idx, data in enumerate(dataloader):
+        pdata = prepare_input(data, device)
+        if input_dtype != torch.float32:
+            pdata = recursively_apply(change_dtype, pdata, input_dtype)
+        optim.zero_grad()
+        if gpt2_model:
+            output = model(pdata["input"])
+        else:
+            output = model(pdata)
+        loss = ModelContext.get_loss_from_loss_func_output(loss_func(pdata, output))
+        if use_optim_backward:
+            optim.backward(loss)
+        else:
+            loss.backward()
+        optim.step()
+    return idx + 1

--- a/atorch/atorch/tests/utils/test_utils.py
+++ b/atorch/atorch/tests/utils/test_utils.py
@@ -1,0 +1,102 @@
+import os
+import tempfile
+from unittest import mock
+
+import torch
+
+import atorch
+from atorch.common.util_func import find_free_port
+from atorch.distributed.launch import main, parse_args
+from atorch.distributed.run import elastic_run, parse_fault_tolerant_or_elastic_args
+
+
+def run_multi_process_init_distributed(codes=None, nproc=2, training_script=None, training_script_args=""):
+    if codes is not None:
+        fd, training_script = tempfile.mkstemp(suffix="py")
+        with open(fd, "w") as f:
+            f.write(codes)
+
+    os.environ["WORLD_SIZE"] = "1"
+    os.environ["MASTER_PORT"] = str(find_free_port())
+    input_args = [
+        f"--nproc_per_node={nproc}",
+        f"{training_script}",
+    ] + list(training_script_args)
+    args = parse_args(input_args)
+    main(args)
+
+
+def elastic_run_multi_process(codes=None, nproc=2, training_script=None, training_script_args=""):
+    if codes is not None:
+        fd, training_script = tempfile.mkstemp(suffix="py")
+        with open(fd, "w") as f:
+            f.write(codes)
+
+    os.environ["WORLD_SIZE"] = "1"
+    os.environ["MASTER_PORT"] = str(find_free_port())
+    input_args = [
+        f"--nproc_per_node={nproc}",
+        f"{training_script}",
+    ] + list(training_script_args)
+    args = parse_fault_tolerant_or_elastic_args(input_args, mode="fault_tolerant")
+    elastic_run(args)
+
+
+def create_sample_batch(value=1, start_v=0, y_dtype=torch.int64):
+    x = torch.ones([12], dtype=torch.float32).reshape(3, 4)
+    y = torch.arange(start_v, start_v + 8, dtype=y_dtype).reshape(2, 4)
+    z = torch.zeros([16])
+    z[:] = value
+    return x, {"y": y, "z": z}
+
+
+def start_coverage():
+    try:
+        import coverage
+
+        global ut_cov
+
+        ut_cov = coverage.Coverage()
+        ut_cov.start()
+        return True
+    except ImportError:
+        return False
+
+
+def stop_coverage():
+    global ut_cov
+    ut_cov.stop()
+    ut_cov.save()
+
+
+class DummyProcessGroup:
+    def __init__(self, rank: int, size: int):
+        self._rank = rank
+        self._size = size
+
+    def rank(self) -> int:
+        return self._rank
+
+    def size(self) -> int:
+        return self._size
+
+    def allreduce(self, *args, **kwargs):
+        dist_wait = mock.Mock()
+
+        def get_future():
+            future = torch.futures.Future()
+            future.set_result(1)
+            return future
+
+        dist_wait.get_future = get_future
+        return dist_wait
+
+
+def init_dist(rank, world_size):
+    os.environ["LOCAL_RANK"] = str(rank)
+    os.environ["RANK"] = str(rank)
+    os.environ["WORLD_SIZE"] = str(world_size)
+    os.environ["NPROC_PER_NODE"] = str(world_size)
+
+    atorch.init_distributed("nccl")
+    torch.cuda.device(atorch.local_rank())

--- a/atorch/atorch/trainer/atorch_args.py
+++ b/atorch/atorch/trainer/atorch_args.py
@@ -3,7 +3,7 @@ import os
 from dataclasses import dataclass, field
 from datetime import timedelta
 from enum import Enum
-from typing import Callable, Dict, List, Optional, Tuple, Union
+from typing import Callable, Dict, List, Optional, Tuple
 
 import torch
 from accelerate.state import PartialState
@@ -12,7 +12,6 @@ from transformers.training_args_seq2seq import Seq2SeqTrainingArguments
 from transformers.utils import cached_property
 
 import atorch
-from atorch.utils.trainer_utils import ATORCHSCHEDULER_NAMES, SCHEDULER_NAMES, AtorchSchedulerType
 
 logger = logging.getLogger(__name__)
 
@@ -109,36 +108,6 @@ class AtorchArguments(Seq2SeqTrainingArguments):
         default=None, metadata={"help": "If not None, a file name for saving the acceleration strategy."}
     )
 
-    atorch_checkpoint_cls: Optional[Tuple[Callable]] = field(
-        default=None,
-        metadata={
-            "help": (
-                "Tuple of module classes for gradient checkpointing. Applicable when --gradient_checkpointing is set."
-            )
-        },
-    )
-
-    use_default_data_collator: bool = field(
-        default=False,
-        metadata={
-            "help": (
-                "Whether to use default data collator DataCollatorWithPadding which may decrease the speed of "
-                "data retrieval."
-            )
-        },
-    )
-
-    ignore_write_errors: bool = field(
-        default=False, metadata={"help": ("Whether to ignore write errors when writting to disk.")}
-    )
-
-    async_save: bool = field(default=False, metadata={"help": ("Whether to use multiprocess to save model.")})
-
-    atorch_lr_scheduler_type: Union[AtorchSchedulerType, str] = field(
-        default=None,
-        metadata={"help": "The custom scheduler type to use."},
-    )
-
     # ATorch FSDP config
     atorch_wrap_cls: Optional[Tuple[Callable]] = field(
         default=None, metadata={"help": "Tuple of module classes to wrap with fsdp."}
@@ -149,9 +118,6 @@ class AtorchArguments(Seq2SeqTrainingArguments):
     sync_module_states: bool = field(default=True, metadata={"help": "Whether to sync_module_states"})
     limit_all_gathers: bool = field(default=True, metadata={"help": "Whether to limit_all_gathers"})
     forward_prefetch: bool = field(default=True, metadata={"help": "Whether to forward_prefetch"})
-
-    # ATorch amp config
-    skip_if_nonfinite: bool = field(default=True, metadata={"help": ("Whether to skip if nonfinite.")})
 
     # Other config
     max_shard_size: str = field(
@@ -166,7 +132,6 @@ class AtorchArguments(Seq2SeqTrainingArguments):
     @cached_property
     def _setup_devices(self) -> "torch.device":
         logger.info("PyTorch: setting up devices")
-
         if not torch.distributed.is_initialized():
             atorch.init_distributed(
                 os.getenv("TORCH_DISTRIBUTED_BACKEND", "nccl"), timeout=timedelta(seconds=self.ddp_timeout)
@@ -211,18 +176,6 @@ class AtorchArguments(Seq2SeqTrainingArguments):
             tensorboard_path = os.getenv("ATORCH_TENSORBOARD_PATH")
             tensorboard_path = os.path.expandvars(tensorboard_path) if tensorboard_path else None
             self.logging_dir = tensorboard_path
-
-        # check lr_scheduler_type
-        if self.atorch_lr_scheduler_type is not None and self.atorch_lr_scheduler_type not in ATORCHSCHEDULER_NAMES:
-            raise ValueError(
-                f"lr_scheduler_type={self.atorch_lr_scheduler_type} is invalid, please select one of "
-                f"{SCHEDULER_NAMES + ATORCHSCHEDULER_NAMES}."
-            )
-
         super().__post_init__()
-
         if self.atorch_wrap_cls is not None and not isinstance(self.atorch_wrap_cls, tuple):
             raise ValueError(f"atorch_wrap_cls has {type(self.atorch_wrap_cls)} type, required tuple type.")
-
-        if self.atorch_checkpoint_cls is not None and not isinstance(self.atorch_checkpoint_cls, tuple):
-            raise ValueError(f"atorch_checkpoint_cls has {type(self.atorch_checkpoint_cls)} type, required tuple type.")

--- a/atorch/atorch/trainer/atorch_trainer.py
+++ b/atorch/atorch/trainer/atorch_trainer.py
@@ -23,7 +23,6 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Un
 
 import datasets
 import numpy as np
-import psutil
 import safetensors
 import torch
 import torch.distributed as dist
@@ -34,9 +33,8 @@ from torch import nn
 from torch.distributed.fsdp import FullStateDictConfig
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from torch.distributed.fsdp import StateDictType
-from torch.multiprocessing import Manager, Pipe, Process
 from torch.utils.data import DataLoader, Dataset, RandomSampler, SequentialSampler
-from transformers import __version__
+from transformers import __version__, get_scheduler
 from transformers.configuration_utils import PretrainedConfig
 from transformers.data.data_collator import DataCollator, DataCollatorWithPadding, default_data_collator
 
@@ -45,7 +43,6 @@ from atorch.auto import auto_accelerate
 from atorch.distributed.distributed import is_distributed
 from atorch.trainer.atorch_args import AtorchArguments
 from atorch.utils.fsdp_save_util import ShardOptim, save_fsdp_flat_param, save_fsdp_optim_param
-from atorch.utils.trainer_utils import AsyncCheckpointSignal, PipeMessageEntity, get_scheduler
 from atorch.utils.version import torch_version
 
 # Integrations must be imported before ML frameworks:
@@ -75,10 +72,10 @@ from transformers.trainer_pt_utils import (
 from transformers.trainer_utils import (
     PREFIX_CHECKPOINT_DIR,
     EvalPrediction,
-    IntervalStrategy,
     PredictionOutput,
     RemoveColumnsCollator,
     TrainOutput,
+    find_executable_batch_size,
     get_last_checkpoint,
     has_length,
     seed_worker,
@@ -166,12 +163,8 @@ class AtorchTrainer:
         # force device and distributed setup init explicitly
         args._setup_devices
 
-        self.data_collator = None
-        if data_collator is not None:
-            self.data_collator = data_collator
-        elif args.use_default_data_collator:
-            self.data_collator = default_data_collator if tokenizer is None else DataCollatorWithPadding(tokenizer)
-
+        default_collator = default_data_collator if tokenizer is None else DataCollatorWithPadding(tokenizer)
+        self.data_collator = data_collator if data_collator is not None else default_collator
         self.train_dataset = train_dataset
         self.eval_dataset = eval_dataset
         self.tokenizer = tokenizer
@@ -189,7 +182,7 @@ class AtorchTrainer:
         self.add_callback(PrinterCallback if self.args.disable_tqdm else DEFAULT_PROGRESS_CALLBACK)
 
         if self.args.should_save:
-            self._write_safely(os.makedirs, self.args.output_dir, exist_ok=True)
+            os.makedirs(self.args.output_dir, exist_ok=True)
 
         if not callable(self.data_collator) and callable(getattr(self.data_collator, "collate_batch", None)):
             raise ValueError("The `data_collator` should be a simple callable (function, class with `__call__`).")
@@ -262,15 +255,6 @@ class AtorchTrainer:
                 "not support to load model at end."
             )
 
-        self._train_batch_size = self.args.train_batch_size
-
-        # Activate gradient checkpointing if needed
-        if args.gradient_checkpointing and args.atorch_checkpoint_cls is None:
-            self.model.gradient_checkpointing_enable()
-
-        # Call ATorch's auto_accelerate() to wrap model, optimizer, loss_function, ...
-        self._atorch_init()
-
     def add_callback(self, callback):
         """
         Add a callback to the current list of [`~transformer.TrainerCallback`].
@@ -306,7 +290,7 @@ class AtorchTrainer:
             self.load_strategy = []
             # Set parallel mode
             if self.args.atorch_parallel_mode:
-                self.load_strategy.append(("parallel_mode", ([("data", self.args.world_size)], None)))
+                self.load_strategy.append(("parallel_mode", ([("data", torch.distributed.get_world_size())], None)))
             # Set module replace
             if self.args.atorch_module_replace:
                 self.load_strategy.append("module_replace")
@@ -326,24 +310,23 @@ class AtorchTrainer:
 
             if self.args.bf16 or self.args.fp16:
                 if self.args.bf16:
-                    amp_config = {"dtype": torch.bfloat16, "skip_if_nonfinite": self.args.skip_if_nonfinite}
-                else:
+                    amp_config = {"dtype": torch.bfloat16}
+                    self.load_strategy.append(("amp_native", amp_config))
+                elif self.args.fp16:
                     amp_config = {"dtype": torch.float16}
-                self.load_strategy.append(("amp_native", amp_config))
-            if self.args.gradient_checkpointing and self.args.atorch_checkpoint_cls is not None:
-                self.load_strategy.append(("checkpoint", self.args.atorch_checkpoint_cls))
+                    self.load_strategy.append(("amp_native", amp_config))
+            if self.args.gradient_checkpointing:
+                self.load_strategy.append(("checkpoint", self.atorch_wrap_cls))
 
         # atorch auto_accelerate will restore batch_size by dividing by world size.
         train_dataloader_args = {
             "shuffle": True,
+            "collate_fn": self.data_collator,
             "batch_size": self._train_batch_size * self.args.world_size,
             "pin_memory": self.args.dataloader_pin_memory,
             "num_workers": self.args.dataloader_num_workers,
             "persistent_workers": self.args.dataloader_num_workers > 0,
         }
-
-        if self.data_collator is not None:
-            train_dataloader_args["collate_fn"] = self.data_collator
 
         if not isinstance(self.train_dataset, torch.utils.data.IterableDataset):
             train_dataloader_args["drop_last"] = self.args.dataloader_drop_last
@@ -370,12 +353,10 @@ class AtorchTrainer:
             else None,
             load_strategy=self.load_strategy,
             ignore_dryrun_on_load_strategy=self.args.ignore_dryrun_on_load_strategy,
-            sampler_seed=self.args.seed,
         )
         assert status, f"auto_accelerate failed. status: {status}, result: {result}, best_strategy: {best_strategy}"
         logger.info(f"Best strategy is: {best_strategy}")
 
-        logger.info("Calling auto_accelerate() will wrap model, optimizer, lr_scheduler, loss_func and prepare_input")
         self.model = result.model
         self.optimizer = result.optim
         self.lr_scheduler = result.lr_scheduler
@@ -389,9 +370,7 @@ class AtorchTrainer:
             signature = inspect.signature(self.model.forward)
             self._signature_columns = list(signature.parameters.keys())
             # Labels may be named label or label_ids, the default data collator handles that.
-            self._signature_columns += list(
-                set(["labels", "label", "label_ids"] + self.label_names + self.model_forward_args)
-            )
+            self._signature_columns += list(set(["label", "label_ids"] + self.label_names + self.model_forward_args))
 
     def _remove_unused_columns(self, dataset: "datasets.Dataset", description: Optional[str] = None):
         if not self.args.remove_unused_columns:
@@ -478,16 +457,15 @@ class AtorchTrainer:
         data_collator = self.data_collator
         if is_datasets_available() and isinstance(train_dataset, datasets.Dataset):
             train_dataset = self._remove_unused_columns(train_dataset, description="training")
-        elif data_collator is not None:
+        else:
             data_collator = self._get_collator_with_removed_columns(data_collator, description="training")
 
         dataloader_params = {
             "batch_size": self._train_batch_size,
+            "collate_fn": data_collator,
             "num_workers": self.args.dataloader_num_workers,
             "pin_memory": self.args.dataloader_pin_memory,
         }
-        if data_collator is not None:
-            dataloader_params["collate_fn"] = data_collator
 
         if not isinstance(train_dataset, torch.utils.data.IterableDataset):
             dataloader_params["sampler"] = self._get_train_sampler()
@@ -515,22 +493,20 @@ class AtorchTrainer:
         """
         if eval_dataset is None and self.eval_dataset is None:
             raise ValueError("Trainer: evaluation requires an eval_dataset.")
-
         eval_dataset = eval_dataset if eval_dataset is not None else self.eval_dataset
         data_collator = self.data_collator
 
         if is_datasets_available() and isinstance(eval_dataset, datasets.Dataset):
             eval_dataset = self._remove_unused_columns(eval_dataset, description="evaluation")
-        elif data_collator is not None:
+        else:
             data_collator = self._get_collator_with_removed_columns(data_collator, description="evaluation")
 
         dataloader_params = {
             "batch_size": self.args.eval_batch_size,
+            "collate_fn": data_collator,
             "num_workers": self.args.dataloader_num_workers,
             "pin_memory": self.args.dataloader_pin_memory,
         }
-        if data_collator is not None:
-            dataloader_params["collate_fn"] = data_collator
 
         if not isinstance(eval_dataset, torch.utils.data.IterableDataset):
             dataloader_params["sampler"] = self._get_eval_sampler(eval_dataset)
@@ -571,16 +547,7 @@ class AtorchTrainer:
             num_training_steps (int): The number of training steps to do.
         """
         # Do atorch create scheduler
-        if self.lr_scheduler is None:
-            self.lr_scheduler = get_scheduler(
-                self.args.atorch_lr_scheduler_type
-                if self.args.atorch_lr_scheduler_type is not None
-                else self.args.lr_scheduler_type,
-                optimizer=self.optimizer if optimizer is None else optimizer,
-                num_warmup_steps=self.args.get_warmup_steps(num_training_steps),
-                num_training_steps=num_training_steps,
-            )
-        return self.lr_scheduler
+        raise NotImplementedError("`create_scheduler` is not implemented.")
 
     def train(
         self,
@@ -614,6 +581,8 @@ class AtorchTrainer:
 
         if len(kwargs) > 0:
             raise TypeError(f"train() received got unexpected keyword arguments: {', '.join(list(kwargs.keys()))}.")
+        # This might change the seed so needs to run first.
+        self._train_batch_size = self.args.train_batch_size
 
         # Load potential model checkpoint
         if isinstance(resume_from_checkpoint, bool) and resume_from_checkpoint:
@@ -626,14 +595,24 @@ class AtorchTrainer:
         if resume_from_checkpoint is not None:
             self._load_from_checkpoint(resume_from_checkpoint)
 
-        return self._inner_training_loop(
+        inner_training_loop = find_executable_batch_size(
+            self._inner_training_loop, self._train_batch_size, args.auto_find_batch_size
+        )
+        return inner_training_loop(
             args=args,
             resume_from_checkpoint=resume_from_checkpoint,
             trial=trial,
             ignore_keys_for_eval=ignore_keys_for_eval,
         )
 
-    def _inner_training_loop(self, args=None, resume_from_checkpoint=None, trial=None, ignore_keys_for_eval=None):
+    def _inner_training_loop(
+        self, batch_size=None, args=None, resume_from_checkpoint=None, trial=None, ignore_keys_for_eval=None
+    ):
+        self._train_batch_size = batch_size
+        logger.debug(f"Currently training with a batch size of: {self._train_batch_size}")
+
+        # Set model, optimizer, train dataloader
+        self._atorch_init()
 
         # Data loader and number of training steps
         if self.args.use_atorch_dataloader and self.train_dataloader is not None:
@@ -689,11 +668,20 @@ class AtorchTrainer:
         self.state = TrainerState()
         self.state.is_hyper_param_search = trial is not None
 
+        # Activate gradient checkpointing if needed
+        if args.gradient_checkpointing:
+            self.model.gradient_checkpointing_enable()
+
         if self.optimizer is None:
             raise ValueError("Optimizer is None, please set optimizer via `auto_accelerate` function of ATorch.")
 
         if self.lr_scheduler is None:
-            self.create_scheduler(num_training_steps=max_steps, optimizer=self.optimizer)
+            self.lr_scheduler = get_scheduler(
+                self.args.lr_scheduler_type,
+                optimizer=self.optimizer,
+                num_warmup_steps=self.args.get_warmup_steps(max_steps),
+                num_training_steps=max_steps,
+            )
 
         # Check if saved optimizer or scheduler states exist
         self._load_optimizer_and_scheduler(resume_from_checkpoint)
@@ -763,10 +751,6 @@ class AtorchTrainer:
             for epoch in range(epochs_trained):
                 for _ in train_dataloader:
                     break
-
-        # Asynchronous saving model and optimizer.
-        if self.args.async_save:
-            self._init_async_save()
 
         total_batched_samples = 0
         for epoch in range(epochs_trained, num_train_epochs):
@@ -930,11 +914,6 @@ class AtorchTrainer:
 
         self.control = self.callback_handler.on_train_end(args, self.state, self.control)
 
-        # wait for all IO subprocess to finish
-        if args.async_save:
-            self._join()
-            dist.barrier()
-
         return TrainOutput(self.state.global_step, train_loss, metrics)
 
     def _issue_warnings_after_load(self, load_result):
@@ -979,15 +958,7 @@ class AtorchTrainer:
                 self.lr_scheduler.step(metrics[metric_to_check])
 
         if self.control.should_save:
-            # Save model checkpoint
-            checkpoint_folder = f"{PREFIX_CHECKPOINT_DIR}-{self.state.global_step}"
-            output_dir = os.path.join(self.args.output_dir, checkpoint_folder)
-            if not self._save_checkpoint(model, output_dir, trial, metrics=metrics):
-                if self.args.async_save:
-                    # Delete checkpoint directory with saving error after sending deleting signal
-                    self.pipe1.send(PipeMessageEntity(AsyncCheckpointSignal.DELETE_CKPT, output_dir))
-                elif os.path.exists(output_dir):
-                    shutil.rmtree(output_dir, ignore_errors=True)
+            self._save_checkpoint(model, trial, metrics=metrics)
             self.control = self.callback_handler.on_save(self.args, self.state, self.control)
 
     def _load_rng_state(self, checkpoint):
@@ -1217,32 +1188,50 @@ class AtorchTrainer:
         if self.do_grad_scaling and os.path.isfile(os.path.join(checkpoint, SCALER_NAME)):
             self.scaler.load_state_dict(torch.load(os.path.join(checkpoint, SCALER_NAME)))
 
-    def _save_checkpoint(self, model, output_dir, trial, metrics=None):
+    def _save_checkpoint(self, model, trial, metrics=None):
         # In all cases, including ddp/dp/deepspeed, self.model is always a reference to the model we
         # want to save except FullyShardedDDP.
         # assert unwrap_model(model) is self.model, "internal model should be a reference to self.model"
 
+        # Save model checkpoint
+        checkpoint_folder = f"{PREFIX_CHECKPOINT_DIR}-{self.state.global_step}"
+
         self.store_flos()
 
-        if not self._write_safely(os.makedirs, output_dir, exist_ok=True):
-            return False
+        output_dir = os.path.join(self.args.output_dir, checkpoint_folder)
+        self.save_model(output_dir, _internal_call=True)
 
+        # Save optimizer and scheduler
+        if self.atorch_fsdp:
+            if not isinstance(self.model, FSDP):
+                raise ValueError("Self.model is not 'FullyShardedDataParallel' type when using --atorch_opt 'fsdp'.")
+            if self.args.save_load_by_streaming:
+                streaming_ckpt_dir = os.path.join(output_dir, STREAMING_CKPT_DIR)
+                os.makedirs(streaming_ckpt_dir, exist_ok=True)
+                logger.info(f"Saving optimizer to {streaming_ckpt_dir}")
+                save_fsdp_optim_param(self.model, self.optimizer, streaming_ckpt_dir)
+                logger.info(f"Optimizer saved to {streaming_ckpt_dir}")
+            else:
+                save_policy = FullStateDictConfig(
+                    offload_to_cpu=self.args.cpu_offload, rank0_only=atorch.world_size() > 1
+                )
+                with FSDP.state_dict_type(self.model, StateDictType.FULL_STATE_DICT, save_policy):
+                    # may be removed after PyTorch 2.2
+                    full_osd = FSDP.full_optim_state_dict(self.model, self.optimizer)
+        else:
+            full_osd = self.optimizer.state_dict()
         if self.args.should_save:
+            if not self.args.save_load_by_streaming:
+                optimizer_file = os.path.join(output_dir, OPTIMIZER_NAME)
+                logger.info(f"Saving optimizer to {optimizer_file}")
+                torch.save(full_osd, optimizer_file)
+                logger.info(f"Optimizer saved to {optimizer_file}")
+
             with warnings.catch_warnings(record=True) as caught_warnings:
-                if not self._write_safely(
-                    torch.save,
-                    self.lr_scheduler.state_dict(),
-                    os.path.join(output_dir, SCHEDULER_NAME),
-                ):
-                    return False
+                torch.save(self.lr_scheduler.state_dict(), os.path.join(output_dir, SCHEDULER_NAME))
             reissue_pt_warnings(caught_warnings)
             if self.do_grad_scaling:
-                if not self._write_safely(
-                    torch.save,
-                    self.scaler.state_dict(),
-                    os.path.join(output_dir, SCALER_NAME),
-                ):
-                    return False
+                torch.save(self.scaler.state_dict(), os.path.join(output_dir, SCALER_NAME))
 
         # Determine the new best metric / best model checkpoint
         if metrics is not None and self.args.metric_for_best_model is not None:
@@ -1262,8 +1251,7 @@ class AtorchTrainer:
 
         # Save the Trainer state
         if self.args.should_save:
-            if not self._write_safely(self.state.save_to_json, os.path.join(output_dir, TRAINER_STATE_NAME)):
-                return False
+            self.state.save_to_json(os.path.join(output_dir, TRAINER_STATE_NAME))
 
         # Save RNG state in non-distributed training
         rng_states = {
@@ -1278,69 +1266,20 @@ class AtorchTrainer:
             else:
                 rng_states["cuda"] = torch.cuda.random.get_rng_state()
 
+        # A process can arrive here before the process 0 has a chance to save the model, in which case output_dir may
+        # not yet exist.
+        os.makedirs(output_dir, exist_ok=True)
+
         if self.args.world_size <= 1:
-            rng_path = os.path.join(output_dir, "rng_state.pth")
+            torch.save(rng_states, os.path.join(output_dir, "rng_state.pth"))
         else:
-            rng_path = os.path.join(output_dir, f"rng_state_{self.args.process_index}.pth")
-        if not self._write_safely(torch.save, rng_states, rng_path):
-            return False
-
-        # Save model
-        if not self.save_model(output_dir, _internal_call=True):
-            return False
-
-        # Save optimizer and scheduler
-        full_osd = None
-        if self.atorch_fsdp:
-            if not isinstance(self.model, FSDP):
-                raise ValueError("Self.model is not 'FullyShardedDataParallel' type when using --atorch_opt 'fsdp'.")
-            if self.args.save_load_by_streaming:
-                streaming_ckpt_dir = os.path.join(output_dir, STREAMING_CKPT_DIR)
-                if not self._write_safely(os.makedirs, streaming_ckpt_dir, exist_ok=True):
-                    return False
-                logger.info(f"Saving optimizer in {streaming_ckpt_dir}")
-                if self._write_safely(
-                    save_fsdp_optim_param,
-                    self.model,
-                    self.optimizer,
-                    streaming_ckpt_dir,
-                ):
-                    logger.info(f"Optimizer saved in {streaming_ckpt_dir}")
-                else:
-                    return False
-            else:
-                save_policy = FullStateDictConfig(
-                    offload_to_cpu=self.args.cpu_offload,
-                    rank0_only=atorch.world_size() > 1,
-                )
-                with FSDP.state_dict_type(self.model, StateDictType.FULL_STATE_DICT, save_policy):
-                    # may be removed after PyTorch 2.2
-                    full_osd = FSDP.full_optim_state_dict(self.model, self.optimizer)
-        else:
-            full_osd = self.optimizer.state_dict()
-        if self.args.should_save:
-            if full_osd is not None:
-                optimizer_file = os.path.join(output_dir, OPTIMIZER_NAME)
-                logger.info(f"Saving optimizer to {optimizer_file}")
-                if self.args.async_save:
-                    self._async_save(
-                        lambda state_dict, save_path: torch.save(state_dict, save_path),
-                        state_dict=full_osd,
-                        save_path=optimizer_file,
-                        checkpoint_dir=output_dir,
-                    )
-                else:
-                    if not self._write_safely(torch.save, full_osd, optimizer_file):
-                        return False
-                    logger.info(f"Optimizer saved to {optimizer_file}")
+            torch.save(rng_states, os.path.join(output_dir, f"rng_state_{self.args.process_index}.pth"))
 
         # Maybe delete some older checkpoints.
         if self.args.should_save:
             self._rotate_checkpoints(use_mtime=True, output_dir=self.args.output_dir)
 
-        return True
-
-    def save_model(self, output_dir: Optional[str] = None, _internal_call: bool = False) -> bool:
+    def save_model(self, output_dir: Optional[str] = None, _internal_call: bool = False):
         """
         Will save the model, so you can reload it using `from_pretrained()`.
 
@@ -1348,11 +1287,9 @@ class AtorchTrainer:
         """
         if output_dir is None:
             output_dir = self.args.output_dir
-        if not self._write_safely(os.makedirs, output_dir, exist_ok=True):
-            return False
+        os.makedirs(output_dir, exist_ok=True)
 
         if self.atorch_fsdp:
-            # Check if model is FSDP type
             if not isinstance(self.model, FSDP):
                 raise ValueError("Self.model is not 'FullyShardedDataParallel' type when using --atorch_opt 'fsdp'.")
             if self.args.save_load_by_streaming:
@@ -1361,60 +1298,30 @@ class AtorchTrainer:
                         "Non-PeftModel is required when using Atorch's streaming save function `save_fsdp_flat_param`."
                     )
                 streaming_ckpt_dir = os.path.join(output_dir, STREAMING_CKPT_DIR)
-                if not self._write_safely(os.makedirs, streaming_ckpt_dir, exist_ok=True):
-                    return False
+                os.makedirs(streaming_ckpt_dir, exist_ok=True)
                 logger.info(f"Saving streaming model to {streaming_ckpt_dir}")
-                # TODO: whether to use multiprocess to save model
-                if self._write_safely(save_fsdp_flat_param, self.model, streaming_ckpt_dir):
-                    logger.info(f"Streaming model saved to {streaming_ckpt_dir}")
-                else:
-                    return False
+                save_fsdp_flat_param(self.model, streaming_ckpt_dir)
+                logger.info(f"Streaming model saved to {streaming_ckpt_dir}")
             else:
                 save_policy = FullStateDictConfig(
-                    offload_to_cpu=self.args.world_size > 1,
-                    rank0_only=self.args.world_size > 1,
+                    offload_to_cpu=self.args.world_size > 1, rank0_only=self.args.world_size > 1
                 )
                 with FSDP.state_dict_type(self.model, StateDictType.FULL_STATE_DICT, save_policy):
-                    state_dict = self.model.state_dict()
-                if self.args.should_save:
-                    if _internal_call and self.args.async_save:
-                        self._async_save(
-                            self._save,
-                            output_dir,
-                            state_dict=state_dict,
-                            checkpoint_dir=output_dir,
-                        )
-                    else:
-                        if not self._write_safely(self._save, output_dir, state_dict):
-                            return False
-        elif self.args.should_save:
-            model = unwrap_model(self.model)
-            state_dict = model.state_dict()
-            if _internal_call and self.args.async_save:
-                self._async_save(
-                    self._save,
-                    output_dir,
-                    state_dict=state_dict,
-                    checkpoint_dir=output_dir,
-                )
-            else:
-                if not self._write_safely(self._save, output_dir, state_dict):
-                    return False
-        return True
+                    model_state_dict = self.model.state_dict()
+                self._save(output_dir, state_dict=model_state_dict, save_base_model=self.args.save_base_model)
+        else:
+            self._save(output_dir, save_base_model=self.args.save_base_model)
 
-    def _save(self, output_dir: Optional[str], state_dict) -> bool:
-        """
-        Save model in rank zero. `state_dict` is acquired outside.
+        if self.tokenizer is not None:
+            self.tokenizer.save_pretrained(output_dir)
 
-        Return:
-            (bool): Whether the model is saved successfully.
-        """
+        # Good practice: save your training arguments together with the trained model
+        torch.save(self.args, os.path.join(output_dir, TRAINING_ARGS_NAME))
 
+    def _save(self, output_dir: Optional[str] = None, state_dict=None, save_base_model: bool = False):
         # If we are executing this function, we are the process zero, so we don't check for that.
         output_dir = output_dir if output_dir is not None else self.args.output_dir
-
-        if not self._write_safely(os.makedirs, output_dir, exist_ok=True):
-            return False
+        os.makedirs(output_dir, exist_ok=True)
         logger.info(f"Saving model checkpoint to {output_dir}")
 
         supported_classes = (PreTrainedModel,) if not is_peft_available() else (PreTrainedModel, PeftModel)
@@ -1422,17 +1329,16 @@ class AtorchTrainer:
         # They can then be reloaded using `from_pretrained()`
         if not isinstance(self.model, supported_classes):
             model = unwrap_model(self.model)
+            if state_dict is None:
+                state_dict = model.state_dict()
             if isinstance(model, supported_classes):
-                if not self._write_safely(
-                    model.save_pretrained,
-                    output_dir,
-                    state_dict=state_dict,
-                    safe_serialization=self.args.save_safetensors,
-                    global_step=self.state.global_step,
-                ):
-                    return False
-                if isinstance(model, PeftModel) and self.args.save_base_model:
+                if self.args.should_save:
+                    model.save_pretrained(
+                        output_dir, state_dict=state_dict, safe_serialization=self.args.save_safetensors
+                    )
+                if isinstance(model, PeftModel) and save_base_model:
                     base_model = model.get_base_model()
+                    state_dict = base_model.state_dict()
                     # Filter the peft params ...
                     param_keys = list(state_dict.keys())
                     base_model_state_dict = {}
@@ -1445,50 +1351,23 @@ class AtorchTrainer:
                             base_model_state_dict[new_key] = value
                         else:
                             base_model_state_dict[key] = value
-                    logger.info(f"Saving base model checkpoint to {output_dir}")
-                    if not self._write_safely(
-                        base_model.save_pretrained,
-                        output_dir,
-                        state_dict=base_model_state_dict,
-                        safe_serialization=self.args.save_safetensors,
-                    ):
-                        return False
+                    if self.args.should_save:
+                        logger.info(f"Saving base model checkpoint to {output_dir}")
+                        base_model.save_pretrained(
+                            output_dir, state_dict=base_model_state_dict, safe_serialization=self.args.save_safetensors
+                        )
             else:
                 logger.info("Trainer.model is not a `PreTrainedModel`, only saving its state dict.")
-                if self.args.save_safetensors:
-                    if not self._write_safely(
-                        safetensors.torch.save_file,
-                        state_dict,
-                        os.path.join(output_dir, SAFE_WEIGHTS_NAME),
-                    ):
-                        return False
-                else:
-                    if not self._write_safely(torch.save, state_dict, os.path.join(output_dir, WEIGHTS_NAME)):
-                        return False
+                if self.args.should_save:
+                    if self.args.save_safetensors:
+                        safetensors.torch.save_file(state_dict, os.path.join(output_dir, SAFE_WEIGHTS_NAME))
+                    else:
+                        torch.save(state_dict, os.path.join(output_dir, WEIGHTS_NAME))
         else:
-            if not self._write_safely(
-                self.model.save_pretrained,
-                output_dir,
-                state_dict=state_dict,
-                safe_serialization=self.args.save_safetensors,
-            ):
-                return False
-
-        # Save tokenizer
-        if self.tokenizer is not None:
-            if not self._write_safely(self.tokenizer.save_pretrained, output_dir):
-                return False
-
-        # Good practice: save your training arguments together with the trained model
-        # TODO: check whether self.args contains local function
-        if not self._write_safely(
-            torch.save,
-            self.args.to_dict(),
-            os.path.join(output_dir, TRAINING_ARGS_NAME),
-        ):
-            return False
-
-        return True
+            if self.args.should_save:
+                self.model.save_pretrained(
+                    output_dir, state_dict=state_dict, safe_serialization=self.args.save_safetensors
+                )
 
     def log(self, logs: Dict[str, float]) -> None:
         """
@@ -1505,13 +1384,7 @@ class AtorchTrainer:
 
         output = {**logs, **{"step": self.state.global_step}}
         self.state.log_history.append(output)
-        try:
-            self.control = self.callback_handler.on_log(self.args, self.state, self.control, logs)
-        except Exception:
-            if self.args.ignore_write_errors:
-                logger.exception("Logging failed! Maybe no space left when tensorboard writting!")
-            else:
-                raise
+        self.control = self.callback_handler.on_log(self.args, self.state, self.control, logs)
 
     def is_local_process_zero(self) -> bool:
         """
@@ -1538,11 +1411,7 @@ class AtorchTrainer:
             if isinstance(dataset, IterableDatasetShard):
                 return len(dataloader.dataset.dataset)
             return len(dataloader.dataset)
-        except (
-            NameError,
-            AttributeError,
-            TypeError,
-        ):  # no dataset or length, estimate by length of dataloader
+        except (NameError, AttributeError, TypeError):  # no dataset or length, estimate by length of dataloader
             return len(dataloader) * self.args.per_device_train_batch_size
 
     def floating_point_ops(self, inputs: Dict[str, Union[torch.Tensor, Any]]):
@@ -1653,10 +1522,7 @@ class AtorchTrainer:
         checkpoints_to_be_deleted = checkpoints_sorted[:number_of_checkpoints_to_delete]
         for checkpoint in checkpoints_to_be_deleted:
             logger.info(f"Deleting older checkpoint [{checkpoint}] due to args.save_total_limit")
-            if self.args.async_save:
-                self.pipe1.send(PipeMessageEntity(AsyncCheckpointSignal.DELETE_CKPT, checkpoint))
-            else:
-                shutil.rmtree(checkpoint, ignore_errors=True)
+            shutil.rmtree(checkpoint, ignore_errors=True)
 
     def evaluate(
         self,
@@ -1769,13 +1635,8 @@ class AtorchTrainer:
         Return:
             `torch.Tensor`: The tensor with training loss on this batch.
         """
-        # model.train() is necessary for methods such as Dropout.
         model.train()
-        inputs = (
-            self.prepare_input(inputs, self.args.device)
-            if self.prepare_input is not None
-            else self._prepare_inputs(inputs)
-        )
+        inputs = self._prepare_inputs(inputs)
 
         with self.autocast_smart_context_manager():
             loss = self.compute_loss(model, inputs)
@@ -1939,125 +1800,3 @@ class AtorchTrainer:
 
         path = os.path.join(self.args.output_dir, "trainer_state.json")
         self.state.save_to_json(path)
-
-    def _write_safely(self, func, *args, **kwargs):
-        try:
-            func(*args, **kwargs)
-        except Exception:
-            if self.args.ignore_write_errors:
-                logger.exception(f"{func.__name__} writting error!")
-                return False
-            else:
-                raise
-        return True
-
-    def _save_state_dict(self, checkpoint_dir, save_func, *args, **kwargs):
-        save_success = self._write_safely(save_func, *args, **kwargs)
-
-        if not save_success:
-            self.pipe1.send(PipeMessageEntity(AsyncCheckpointSignal.DELETE_CKPT, checkpoint_dir))
-        self.pipe1.send(PipeMessageEntity(AsyncCheckpointSignal.SAVE_OVER, os.getpid()))
-        return save_success
-
-    def _terminate_process_by_pid(self, pid: int, exec_join: bool = False):
-        try:
-            p = psutil.Process(pid)
-            if exec_join:
-                p.join(timeout=1000)
-            p.terminate()
-        except psutil.NoSuchProcess:
-            logger.info(f"No process found with PID {pid}, maybe was terminated.")
-        except Exception:
-            if self.args.ignore_write_errors:
-                logging.exception(f"Error occured when getting process handle by PID {pid}!")
-            else:
-                raise
-
-    def _async_save(self, save_func, *args, **kwargs):
-        if "checkpoint_dir" not in kwargs:
-            logger.warning("Please pass 'checkpoint_dir' argument when calling self._async_save().")
-            return
-        # Get extra arguments from kwargs.
-        checkpoint_dir = kwargs.pop("checkpoint_dir")
-
-        # Wait if len(self.writing_processes) > total_limit
-        # Two processes will be created to save model and optimizer respectively during every saving.
-        start = time.time()
-        while len(self.writing_processes) > self.args.save_total_limit * 2:
-            time.sleep(1)
-            if time.time() - start > 1000:
-                pids = list(self.writing_processes.keys())
-                pids.sort()
-                logger.info(f"Kill the earliest process {pids[0]}")
-                # Kill the earliest process
-                self._terminate_process_by_pid(pids[0])
-                break
-
-        # Move state dict from device to CPU
-        state_dict = kwargs.pop("state_dict")
-        state_dict = torch.utils._pytree.tree_map(lambda x: x.cpu() if isinstance(x, torch.Tensor) else x, state_dict)
-        kwargs["state_dict"] = state_dict
-
-        p = Process(target=self._save_state_dict, args=(checkpoint_dir, save_func, *args), kwargs=kwargs)
-        p.start()
-        self.writing_processes[p.pid] = checkpoint_dir
-
-    def _async_manager(self):
-        while True:
-            recv: PipeMessageEntity = self.pipe2.recv()
-            if recv.signal_type == AsyncCheckpointSignal.DELETE_CKPT:
-                checkpoint_dir = recv.data
-                logger.info(f"Deleting {checkpoint_dir}")
-
-                # Stop the saving process with the working directory 'checkpoint_dir'
-                process_to_del = []
-                for pid, ckpt in self.writing_processes.items():
-                    if ckpt == checkpoint_dir:
-                        self._terminate_process_by_pid(pid)
-                        process_to_del.append(pid)
-                for pid in process_to_del:
-                    self.writing_processes.pop(pid)
-
-                # Delete 'checkpoint_dir'
-                shutil.rmtree(checkpoint_dir, ignore_errors=True)
-                logger.info(f"Checkpoint '{checkpoint_dir}' deleted!")
-            elif recv.signal_type == AsyncCheckpointSignal.SAVE_OVER:
-                pid = recv.data
-                logger.info(f"Destroying process {pid}")
-                # Remove finished process from self.writing_processes
-                self.writing_processes.pop(pid)
-                self._terminate_process_by_pid(pid)
-            elif recv.signal_type == AsyncCheckpointSignal.TRAIN_OVER:
-                logger.info("Join all saving processes!")
-                # Join for all save processes
-                for pid, ckpt in self.writing_processes.items():
-                    self._terminate_process_by_pid(pid, exec_join=True)
-                break
-            else:
-                raise ValueError("Receive error signal type! Signal type should be from `AsyncCheckpointSignal`.")
-
-    def _init_async_save(self):
-        if self.args.save_strategy != IntervalStrategy.NO and self.args.should_save:
-            self.data_manager = Manager()
-
-            # Duplex Pipe for inter-process communication
-            self.pipe1, self.pipe2 = Pipe()
-
-            # Record writing processes: [pid, checkpoint_dir]
-            self.writing_processes: Dict[int, str] = self.data_manager.dict()
-
-            self.manager_process = Process(target=self._async_manager)
-            self.manager_process.start()
-
-            # to disable TOKENIZERS_PARALLELISM=(true | false) warning
-            os.environ["TOKENIZERS_PARALLELISM"] = "false"
-
-    def _join(self):
-        if self.args.save_strategy != IntervalStrategy.NO and self.args.should_save:
-            self.pipe1.send(PipeMessageEntity(AsyncCheckpointSignal.TRAIN_OVER))
-            # Wait for the manager_process to end
-            self.manager_process.join(timeout=1000)
-            self.manager_process.terminate()
-
-            # Shutdown the data manager
-            self.data_manager.shutdown()

--- a/atorch/atorch/utils/manual_tp_utils.py
+++ b/atorch/atorch/utils/manual_tp_utils.py
@@ -2,6 +2,7 @@ import inspect
 
 import torch
 import torch.nn.functional as F
+from transformers.pytorch_utils import Conv1D
 
 from atorch.common.log_utils import default_logger as logger
 from atorch.common.util_func import divide, is_wrapped_by_context_manager
@@ -66,8 +67,6 @@ def tp_shard_helper(meta_module, tp_layer_cls, **tp_kwargs):
             builded_module = ori_build_fn(*args, **kwargs)
 
         # gpt2 Conv1D compat
-        from transformers.pytorch_utils import Conv1D
-
         if isinstance(builded_module, Conv1D):
             builded_module.in_features, builded_module.out_features = builded_module.weight.shape
             builded_module.weight.data = builded_module.weight.t()

--- a/atorch/atorch/utils/meta_model_utils.py
+++ b/atorch/atorch/utils/meta_model_utils.py
@@ -381,12 +381,7 @@ def _reload_meta_parameter(module, tensor_name, device, value=None, ckpt_name=No
             kwargs = module._parameters[tensor_name].__dict__
             if "checkpoint_name" in kwargs:
                 del kwargs["checkpoint_name"]
-            if param_cls == torch.nn.parameter.Parameter:
-                new_value = param_cls(new_value, requires_grad=old_value.requires_grad).to(device)
-                for name in kwargs:
-                    setattr(new_value, name, kwargs[name])
-            else:
-                new_value = param_cls(new_value, requires_grad=old_value.requires_grad, **kwargs).to(device)
+            new_value = param_cls(new_value, requires_grad=old_value.requires_grad, **kwargs).to(device)
             if ckpt_name is not None:
                 setattr(new_value, "checkpoint_name", ckpt_name)
             module._parameters[tensor_name] = new_value


### PR DESCRIPTION
### What changes were proposed in this pull request?
We add ATorch RLHF for large language model fine tuning. This pr fix some problems for deepspeed hybrid engine, enable training model from 7B to 70B using zero2( zero2 training and single gpu inferencing) and hybrid engine(zero3 training + tensor parallel inferencing).

As for RLHF, training data needs to be generated using latest model weights. If  we could increase data generation speed, total training time would be reduced. In addition, there are so many inferencing backend, like vllm/tgi/onnx_runtime.  ATorch RLHF  is designed support various inferencing backend by gathering trainable model weights and sending them to inference instance without creating torch process group between inference instance and training process.


### Why are the changes needed?

Deepspeed hybrid engine is an solution for large language model training and inferencing but encounters some bugs when used for RLHF training [issues821](https://github.com/microsoft/DeepSpeedExamples/issues/821)  [issues643](https://github.com/microsoft/DeepSpeedExamples/issues/643) [issues628](https://github.com/microsoft/DeepSpeedExamples/issues/628). We fix tp weight slicing error, applying tensor parallelism error and replace deepspeed custome op with native torch op.


### Does this PR introduce any user-facing change?

Specify whether this pull request introduces any changes that users will directly interact with or notice.

### How was this patch tested?

Detail the testing process you have undertaken to ensure the changes in this pull request are valid and working as intended.
