### PR TITLE
Use the default group to sync if the backend is default and all ranks save checkpoint.

### DIFF
--- a/dlrover/python/common/storage.py
+++ b/dlrover/python/common/storage.py
@@ -83,7 +83,7 @@ class CheckpointStorage(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def commit(self, step: int, succeed: bool):
+    def commit(self, step: int, success: bool):
         """
         We can implement the method to commit the checkpoint step.
 
@@ -142,8 +142,8 @@ class PosixDiskStorage(CheckpointStorage):
         if os.path.exists(src_path) and not os.path.exists(dst_path):
             shutil.move(src_path, dst_path)
 
-    def commit(self, step, succeed):
+    def commit(self, step, success):
         logger.info(
-            f"Succeed {succeed} in persisting the checkpoint to "
+            f"Succeed {success} in persisting the checkpoint to "
             f"{self._latest_path} for step {step}"
         )

--- a/dlrover/python/common/storage.py
+++ b/dlrover/python/common/storage.py
@@ -79,12 +79,17 @@ class CheckpointStorage(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def commit(self, step):
+    def safe_move(self, src_path, dst_path):
+        pass
+
+    @abstractmethod
+    def commit(self, step: int, succeed: bool):
         """
         We can implement the method to commit the checkpoint step.
 
         Args:
             step (int): the iteration step.
+            succeed (bool): whether to persist the checkpoint of step.
         """
         pass
 
@@ -133,8 +138,12 @@ class PosixDiskStorage(CheckpointStorage):
     def safe_makedirs(self, dir):
         os.makedirs(dir, exist_ok=True)
 
-    def commit(self, step):
+    def safe_move(self, src_path, dst_path):
+        if os.path.exists(src_path) and not os.path.exists(dst_path):
+            shutil.move(src_path, dst_path)
+
+    def commit(self, step, succeed):
         logger.info(
-            f"Finish persisting the checkpoint to {self._latest_path} "
-            f"for step {step}"
+            f"Succeed {succeed} in persisting the checkpoint to "
+            f"{self._latest_path} for step {step}"
         )

--- a/dlrover/python/elastic_agent/torch/ckpt_saver.py
+++ b/dlrover/python/elastic_agent/torch/ckpt_saver.py
@@ -733,7 +733,7 @@ class CommonDirCheckpointSaver(AsyncCheckpointSaver):
                 default 600s.
         """
         start_time = time.time()
-        succeed = False
+        suceess = False
         while True:
             if len(os.listdir(step_done_dir)) == self.global_shard_num:
                 # all local rank done
@@ -744,7 +744,7 @@ class CommonDirCheckpointSaver(AsyncCheckpointSaver):
                 logger.info(
                     f"All agents finish saving checkpoint for step {step}"
                 )
-                succeed = True
+                suceess = True
                 break
             # timeout
             elapsed_time = round(time.time() - start_time, 2)
@@ -758,7 +758,7 @@ class CommonDirCheckpointSaver(AsyncCheckpointSaver):
                 break
 
             time.sleep(2)
-        self.storage.commit(step, succeed)
+        self.storage.commit(step, suceess)
 
     def persist_to_storage(
         self, local_shard_id: int, ckpt_config: CheckpointConfig
@@ -904,7 +904,7 @@ class TempDirCheckpointSaver(AsyncCheckpointSaver):
             f"path: {target_path}"
         )
         start_time = time.time()
-        succeed = False
+        success = False
         while True:
             # check all local rank done
             if len(os.listdir(step_done_dir)) == self.global_shard_num:
@@ -926,7 +926,7 @@ class TempDirCheckpointSaver(AsyncCheckpointSaver):
                     f"Commit checkpoint tmp_path: {tmp_path}, "
                     f"path: {target_path}"
                 )
-                succeed = True
+                success = True
                 break
 
             # timeout
@@ -942,7 +942,7 @@ class TempDirCheckpointSaver(AsyncCheckpointSaver):
                 break
 
             time.sleep(2)
-        self.storage.commit(step, succeed)
+        self.storage.commit(step, success)
 
 
 class DdpCheckpointSaver(CommonDirCheckpointSaver):

--- a/dlrover/trainer/tests/torch/checkpoint_egine_test.py
+++ b/dlrover/trainer/tests/torch/checkpoint_egine_test.py
@@ -313,7 +313,7 @@ class PosixDiskStorageTest(unittest.TestCase):
             state_dict = {"weights": torch.rand(4, 4)}
             ckpt_path = os.path.join(tmpdir, "checkpoint.pt")
             storage.write_state_dict(state_dict, ckpt_path, torch.save)
-            storage.commit(100)
+            storage.commit(100, True)
             sd = storage.read_state_dict(
                 ckpt_path,
                 read_func=lambda path: torch.load(path, map_location="cpu"),

--- a/dlrover/trainer/torch/flash_checkpoint/engine.py
+++ b/dlrover/trainer/torch/flash_checkpoint/engine.py
@@ -286,8 +286,6 @@ class CheckpointEngine(metaclass=ABCMeta):
         if acquired:
             self._shm_lock.release()
         self._cached_step = conf.step
-        if dist.is_initialized():
-            dist.barrier(group=self._saver_group)
         return True
 
     def get_state_dict_from_memory(self):

--- a/dlrover/trainer/torch/flash_checkpoint/engine.py
+++ b/dlrover/trainer/torch/flash_checkpoint/engine.py
@@ -66,7 +66,10 @@ def verify_all_rank_step_consistent(group: dist.ProcessGroup, step):
     local_rank = env_utils.get_local_rank()
     device = "cpu" if backend == "gloo" else f"cuda:{local_rank}"
     t = torch.tensor([float(step)]).to(device)
-    world_size = group.size()
+    if group:
+        world_size = group.size()
+    else:
+        world_size = dist.get_world_size()
     outputs = [torch.tensor([0.0]) for _ in range(world_size)]
     dist.all_gather(outputs, t, group=group)
     succeed = True

--- a/dlrover/trainer/torch/flash_checkpoint/engine.py
+++ b/dlrover/trainer/torch/flash_checkpoint/engine.py
@@ -196,7 +196,7 @@ class CheckpointEngine(metaclass=ABCMeta):
                 timeout=timedelta(seconds=60),
             )
         saving_ranks = self.get_saving_ranks()
-        if backend == dist.get_backend() or saving_ranks is None:
+        if backend == dist.get_backend() and saving_ranks is None:
             self._saver_group = None
         else:
             saving_ranks = self.get_saving_ranks()

--- a/dlrover/trainer/torch/flash_checkpoint/engine.py
+++ b/dlrover/trainer/torch/flash_checkpoint/engine.py
@@ -205,7 +205,7 @@ class CheckpointEngine(metaclass=ABCMeta):
             if saving_ranks is None:
                 saving_ranks = "all"
             logger.info(
-                f"Create a {backend }commumication group between "
+                f"Create a {backend} commumication group between "
                 f"{saving_ranks} ranks."
             )
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Use the default group to sync if the backend is default and all ranks save checkpoint.

### Why are the changes needed?

We can use the default group to sync not create a new group if the backend is default and all ranks save checkpoint.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

UT.