### PR TITLE
BugFix: Check the step is consistent before saving.

### DIFF
--- a/dlrover/trainer/torch/flash_checkpoint/ddp_engine.py
+++ b/dlrover/trainer/torch/flash_checkpoint/ddp_engine.py
@@ -15,6 +15,7 @@ import os
 from typing import Dict
 
 import torch
+import torch.distributed as dist
 
 from dlrover.python.common import env_utils
 from dlrover.python.common.constants import CheckpointConstant
@@ -119,6 +120,8 @@ class DdpCheckpointEngine(CheckpointEngine):
         if step > self._cached_step:
             succeed = self.save_to_memory(step, state_dict, paths)
         # Only rank 0 persist the checkpoint to the storage.
+        if dist.is_initialized():
+            dist.barrier()
         if succeed and self._rank == 0:
             event = CheckpointEvent(type=CheckpointEventType.SAVE, step=step)
             self._event_queue.put(event)

--- a/dlrover/trainer/torch/flash_checkpoint/deepspeed_engine.py
+++ b/dlrover/trainer/torch/flash_checkpoint/deepspeed_engine.py
@@ -102,6 +102,9 @@ class DeepSpeedCheckpointEngine(CheckpointEngine):
         if step > self._cached_step:
             succeed = self.save_to_memory(step, state_dict, paths)
 
+        if dist.is_initialized():
+            dist.barrier()
+
         # Only local rank 0 to notify the saving event to the agent.
         if self._local_rank == 0 and succeed:
             event = CheckpointEvent(type=CheckpointEventType.SAVE, step=step)

--- a/dlrover/trainer/torch/flash_checkpoint/megatron_engine.py
+++ b/dlrover/trainer/torch/flash_checkpoint/megatron_engine.py
@@ -107,6 +107,9 @@ class MegatronCheckpointEngine(CheckpointEngine):
         if step > self._cached_step:
             succeed = self.save_to_memory(step, state_dict, paths)
 
+        if dist.is_initialized():
+            dist.barrier()
+
         # Only local rank 0 to notify the saving event to the agent.
         if self._dp_rank != 0 or self._local_rank != 0:
             return


### PR DESCRIPTION
### What changes were proposed in this pull request?

Check the step is consistent before saving.

### Why are the changes needed?

Each rank asynchronously save the checkpoint into the memory the rank-0 should wait all ranks before saving
the checkpoint into the storage.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

UT.