### PR TITLE
Use torch.save if the path is not a string.

### DIFF
--- a/dlrover/trainer/torch/flash_checkpoint/ddp_engine.py
+++ b/dlrover/trainer/torch/flash_checkpoint/ddp_engine.py
@@ -104,13 +104,7 @@ class DdpCheckpointEngine(CheckpointEngine):
                 ["model_states", "optim_states"] of the state dict and
                 the value is the path of storage to save.
         """
-        conf = CheckpointConfig(
-            rank=self._rank,
-            group_rank=self._group_rank,
-            world_size=self._world_size,
-            step=step,
-            paths=paths,
-        )
+        conf = CheckpointConfig(step=step, paths=paths)
         return self.save_state_dict_to_memory(state_dict, conf)
 
     @timer

--- a/dlrover/trainer/torch/flash_checkpoint/deepspeed.py
+++ b/dlrover/trainer/torch/flash_checkpoint/deepspeed.py
@@ -59,7 +59,7 @@ class AsyncSaveEngine(CheckpointEngine):
         pass
 
     def save(self, state_dict, path: str):
-        if not isinstance(path):
+        if not isinstance(path, str):
             torch_native_save(state_dict, path)
         if path.endswith(_DS_MODEL_SD_FILE_SUFFIX):
             sd_name = CheckpointConstant.MODEL_STATES_NAME

--- a/dlrover/trainer/torch/flash_checkpoint/deepspeed_engine.py
+++ b/dlrover/trainer/torch/flash_checkpoint/deepspeed_engine.py
@@ -88,13 +88,7 @@ class DeepSpeedCheckpointEngine(CheckpointEngine):
                 ["model_states", "optim_states"] of the state dict and
                 the value is the path of storage to save.
         """
-        conf = CheckpointConfig(
-            rank=self._rank,
-            group_rank=self._group_rank,
-            world_size=self._world_size,
-            step=step,
-            paths=paths,
-        )
+        conf = CheckpointConfig(step=step, paths=paths)
         return self.save_state_dict_to_memory(state_dict, conf)
 
     @timer

--- a/dlrover/trainer/torch/flash_checkpoint/engine.py
+++ b/dlrover/trainer/torch/flash_checkpoint/engine.py
@@ -270,8 +270,13 @@ class CheckpointEngine(metaclass=ABCMeta):
             self._event_queue.put(event)
 
     def save_state_dict_to_memory(self, state_dict, conf: CheckpointConfig):
+        """Save the state dict into the memory."""
         if self._local_rank != self.local_shard_id:
             return False
+
+        conf.rank = self._rank
+        conf.group_rank = self._group_rank
+        conf.world_size = self._world_size
 
         acquired = self._shm_lock.acquire(blocking=False)
         logger.info(f"Acquired the lock of shared memory: {acquired}.")

--- a/dlrover/trainer/torch/flash_checkpoint/megatron_engine.py
+++ b/dlrover/trainer/torch/flash_checkpoint/megatron_engine.py
@@ -83,13 +83,7 @@ class MegatronCheckpointEngine(CheckpointEngine):
             step (int): the global iteration step.
             state_dict (dict): the state dict of model and optimizer to save.
         """
-        conf = CheckpointConfig(
-            rank=self._rank,
-            group_rank=self._group_rank,
-            world_size=self._world_size,
-            step=step,
-            paths=paths,
-        )
+        conf = CheckpointConfig(step=step, paths=paths)
         return self.save_state_dict_to_memory(state_dict, conf)
 
     @timer


### PR DESCRIPTION
### What changes were proposed in this pull request?

If the path is not a string, use `torch.save` to save it.

### Why are the changes needed?

The DL framework may use `torch.save` to save to IO buffers.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

UT.