### PR TITLE
clear used state dict

### DIFF
--- a/dlrover/trainer/torch/flash_checkpoint/megatron.py
+++ b/dlrover/trainer/torch/flash_checkpoint/megatron.py
@@ -167,6 +167,8 @@ def save_checkpoint(
     else:
         raise ValueError(f"No support storage type {storage_type}")
 
+    saver.state_dict.clear()
+
 
 def load_checkpoint(
     model,


### PR DESCRIPTION
### What changes were proposed in this pull request?

clear used state_dict

### Why are the changes needed?

When ckpt saved, the related state_dict can be cleared, or it will take up a lot of memory.
more than this, if not cleared, the duplicated mem will be copied into child process when evaluate

### Does this PR introduce any user-facing change?

no

### How was this patch tested?


