### PR TITLE
Restore the tracker file after calling the megaton save_checkpoint.

### DIFF
--- a/dlrover/python/common/storage.py
+++ b/dlrover/python/common/storage.py
@@ -156,7 +156,7 @@ class PosixDiskStorage(CheckpointStorage):
 
     def safe_rmtree(self, dir):
         if os.path.exists(dir):
-            shutil.rmtree(dir)
+            shutil.rmtree(dir, ignore_errors=True)
 
     def safe_remove(self, path):
         if os.path.exists(path):

--- a/dlrover/trainer/torch/flash_checkpoint/engine.py
+++ b/dlrover/trainer/torch/flash_checkpoint/engine.py
@@ -190,7 +190,7 @@ class CheckpointEngine(metaclass=ABCMeta):
 
     def _init_sync_group(self, comm_backend):
         if not dist.is_initialized():
-            self._saving_ranks = [1]
+            self._saving_ranks = [0]
             return
 
         self._rank = dist.get_rank()


### PR DESCRIPTION
### What changes were proposed in this pull request?

Restore the tracker file after calling the megaton save_checkpoint.

### Why are the changes needed?

Flash Checkpoint asynchronously saves the checkpoint into the storage. Megatron-LM `save_checkpoint` will create an empty folder and write the tracker file after it is called. Flash Checkpoint needs to restore the tracker file and remove the empty folder to avoid the exception when loading the checkpoint.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

UT.