### PR TITLE
An argument to enable saving checkpoint at the breakpoint.

### DIFF
--- a/dlrover/python/elastic_agent/torch/training.py
+++ b/dlrover/python/elastic_agent/torch/training.py
@@ -119,6 +119,7 @@ class ElasticLaunchConfig(LaunchConfig):
     node_unit: int = 1
     auto_tunning: bool = False
     exclude_straggler: bool = False
+    save_at_breakpoint: bool = False
 
     def set_node_unit(self, node_unit):
         """Set the number unint of ndoes."""
@@ -588,7 +589,7 @@ class ElasticTrainingAgent(LocalElasticAgent):
         memory into the storage before restarting training processes.
         """
         saver: AsyncCheckpointSaver = AsyncCheckpointSaver.get_ckpt_saver()
-        if saver:
+        if saver and self._config.save_at_breakpoint:
             self._save_ckpt_future = self._save_ckpt_executor.submit(
                 saver.save_shm_to_storage
             )

--- a/dlrover/trainer/torch/elastic_run.py
+++ b/dlrover/trainer/torch/elastic_run.py
@@ -131,6 +131,14 @@ def parse_args(args):
         "the argument is True. The argument only works when network-check "
         "is True.",
     )
+    parser.add_argument(
+        "--save-at-breakpoint",
+        "--save_at_breakpoint",
+        action=check_env,
+        help="Bool. If True, the agent in the main process will save the "
+        "checkpoint in the memory to the storage if the training "
+        "process fails.",
+    )
     return parser.parse_args(args)
 
 
@@ -238,6 +246,9 @@ def _elastic_config_from_args(
         args, "exclude_straggler", False
     )
     elastic_config.set_node_unit(getattr(args, "node_unit", 1))
+    elastic_config.save_at_breakpoint = getattr(
+        args, "save_at_breakpoint", False
+    )
     return elastic_config, cmd, cmd_args
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

An argument to enable saving checkpoint at the breakpoint.

### Why are the changes needed?

After a failure occurs, the agent restarts the worker until it finishes saving the checkpoint from the memory to the storage. However, it may takes  a long time to save the checkpoint to storage.

### Does this PR introduce any user-facing change?

Yes.

### How was this patch tested?

UT.