### PR TITLE
Deletion Strategy to delete the abandoned checkpoints.

### DIFF
--- a/dlrover/python/common/storage.py
+++ b/dlrover/python/common/storage.py
@@ -14,7 +14,7 @@
 import os
 import shutil
 from abc import ABCMeta, abstractmethod
-from typing import List, Callable
+from typing import Callable, List
 
 from .log import default_logger as logger
 from .serialize import ClassMeta

--- a/dlrover/python/common/storage.py
+++ b/dlrover/python/common/storage.py
@@ -14,6 +14,7 @@
 import os
 import shutil
 from abc import ABCMeta, abstractmethod
+from typing import List
 
 from .log import default_logger as logger
 from .serialize import ClassMeta
@@ -185,5 +186,110 @@ class PosixDiskStorage(CheckpointStorage):
         class_mata = ClassMeta(
             module_path=self.__class__.__module__,
             class_name=self.__class__.__name__,
+        )
+        return class_mata
+
+
+class CheckpointDeletionStrategy(metaclass=ABCMeta):
+    @abstractmethod
+    def clean_up(self):
+        pass
+
+
+class KeepStepIntervalStrategy(CheckpointDeletionStrategy):
+    """
+    The strategy only keeps the step which is a multiple of the keep_interval
+    and clean the other previous step after saving a new step checkpoint.
+
+    Arguments:
+        keep_interval (int): The step interval to keep. If the step is not
+            a multiple of it, the strategy will clean up the step checkpoint
+            after saving a new step checkpoint.
+        checkpoint_dir (str): The common folder directory of checkpoint of
+            all steps.
+    """
+
+    def __init__(self, keep_interval: int, checkpoint_dir: str):
+        self._keep_interval = keep_interval
+        self._checkpoint_dir = checkpoint_dir
+
+    def clean_up(self, step):
+        if step % self._keep_interval == 0:
+            return
+        rm_dir = os.path.join(self._checkpoint_dir, str(step))
+        try:
+            shutil.rmtree(rm_dir)
+            print(f"Clean path {rm_dir}")
+        except Exception:
+            print(f"Fail to clean path {rm_dir}!")
+
+
+class KeepLatestStepStrategy(CheckpointDeletionStrategy):
+    """
+    The strategy only remains the latest steps and delete the outdated
+    checkpoints.
+    Arguments:
+        max_to_keep (int): An integer, the number of checkpoints to keep.
+        checkpoint_dir (str): The common folder directory of checkpoint of
+            all steps.
+    """
+
+    def __init__(self, max_to_keep: int, checkpoint_dir: str):
+        self._max_to_keep = max(max_to_keep, 1)
+        self._checkpoint_dir = checkpoint_dir
+        self._steps: List[int] = []
+
+    def clean_up(self, step):
+        self._steps.append(step)
+        if len(self._steps) == self._max_to_keep:
+            rm_step = self._steps.pop(0)
+            rm_dir = os.path.join(self._checkpoint_dir, str(rm_step))
+            try:
+                shutil.rmtree(rm_dir)
+                print(f"Clean path {rm_dir}")
+            except Exception:
+                print(f"Fail to clean path {rm_dir}!")
+
+
+class PosixStorageWithDeletion(PosixDiskStorage):
+    """
+    The storage will call a CheckpointDeletionStrategy to
+    delete the outdated checkpoints.
+
+    Arguments:
+        tracker_file (int): the file name to store the latest checkpoint step.
+        deletion_strategy (str): the strategy to clean outdated checkpoints.
+    """
+
+    def __init__(
+        self, tracker_file: str, deletion_strategy: CheckpointDeletionStrategy
+    ):
+        super().__init__()
+        self._deletion_strategy = deletion_strategy
+        self._tracker_file = tracker_file
+        self._pre_step = 0
+
+    def write(self, content, path: str):
+        if path.endswith(self._tracker_file):
+            pre_step = self.read(path)
+            if pre_step:
+                self._pre_step = int(pre_step)
+        super().write(content, path)
+
+    def commit(self, step, success):
+        super().commit(step, success)
+        if not success or self._pre_step == step:
+            return
+        self._deletion_strategy.clean_up(self._pre_step)
+
+    def get_class_meta(self):
+        kwargs = {
+            "tracker_file": self._tracker_file,
+            "deletion_strategy": self._deletion_strategy,
+        }
+        class_mata = ClassMeta(
+            module_path=self.__class__.__module__,
+            class_name=self.__class__.__name__,
+            kwargs=kwargs,
         )
         return class_mata

--- a/dlrover/python/tests/test_storage.py
+++ b/dlrover/python/tests/test_storage.py
@@ -1,0 +1,69 @@
+# Copyright 2023 The DLRover Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import tempfile
+import unittest
+
+from dlrover.python.common.storage import (
+    KeepLatestStepStrategy,
+    KeepStepIntervalStrategy,
+    PosixStorageWithDeletion,
+)
+
+
+class TestLocalStrategyGenerator(unittest.TestCase):
+    def test_keep_latest_deletion_strategy(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            deletion_strategy = KeepLatestStepStrategy(3, tmpdir)
+            os.makedirs(os.path.join(tmpdir, "1"))
+            os.makedirs(os.path.join(tmpdir, "2"))
+            deletion_strategy.clean_up(1)
+            os.makedirs(os.path.join(tmpdir, "3"))
+            deletion_strategy.clean_up(2)
+            os.makedirs(os.path.join(tmpdir, "4"))
+            deletion_strategy.clean_up(3)
+            self.assertListEqual(sorted(os.listdir(tmpdir)), ["2", "3", "4"])
+
+    def test_keep_step_interval_deletion_strategy(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            deletion_strategy = KeepStepIntervalStrategy(4, tmpdir)
+            os.makedirs(os.path.join(tmpdir, "2"))
+            for i in range(2, 6):
+                step = i * 2
+                os.makedirs(os.path.join(tmpdir, str(step)))
+                deletion_strategy.clean_up(step - 2)
+            self.assertListEqual(sorted(os.listdir(tmpdir)), ["10", "4", "8"])
+
+    def test_posix_storage_with_deletion(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            deletion_strategy = KeepLatestStepStrategy(3, tmpdir)
+            tracker_file = "dlrover_latest.txt"
+            tracker_file_path = os.path.join(tmpdir, tracker_file)
+            storage = PosixStorageWithDeletion(tracker_file, deletion_strategy)
+
+            for step in range(1, 5):
+                storage.write(str(step), tracker_file_path)
+                os.makedirs(os.path.join(tmpdir, str(step)))
+                storage.commit(step, True)
+
+            files = os.listdir(tmpdir)
+            files.remove(tracker_file)
+            self.assertListEqual(sorted(files), ["2", "3", "4"])
+
+            class_meta = storage.get_class_meta()
+            self.assertEqual(class_meta.class_name, "PosixStorageWithDeletion")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/dlrover/python/tests/test_storage.py
+++ b/dlrover/python/tests/test_storage.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 
 import os
+import shutil
 import tempfile
 import unittest
 
@@ -27,12 +28,9 @@ class TestLocalStrategyGenerator(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             deletion_strategy = KeepLatestStepStrategy(3, tmpdir)
             os.makedirs(os.path.join(tmpdir, "1"))
-            os.makedirs(os.path.join(tmpdir, "2"))
-            deletion_strategy.clean_up(1)
-            os.makedirs(os.path.join(tmpdir, "3"))
-            deletion_strategy.clean_up(2)
-            os.makedirs(os.path.join(tmpdir, "4"))
-            deletion_strategy.clean_up(3)
+            for step in range(2, 5):
+                os.makedirs(os.path.join(tmpdir, str(step)))
+                deletion_strategy.clean_up(step - 1, shutil.rmtree)
             self.assertListEqual(sorted(os.listdir(tmpdir)), ["2", "3", "4"])
 
     def test_keep_step_interval_deletion_strategy(self):
@@ -42,7 +40,7 @@ class TestLocalStrategyGenerator(unittest.TestCase):
             for i in range(2, 6):
                 step = i * 2
                 os.makedirs(os.path.join(tmpdir, str(step)))
-                deletion_strategy.clean_up(step - 2)
+                deletion_strategy.clean_up(step - 2, shutil.rmtree)
             self.assertListEqual(sorted(os.listdir(tmpdir)), ["10", "4", "8"])
 
     def test_posix_storage_with_deletion(self):

--- a/dlrover/trainer/tests/torch/checkpoint_egine_test.py
+++ b/dlrover/trainer/tests/torch/checkpoint_egine_test.py
@@ -313,7 +313,7 @@ class CheckpointEngineTest(unittest.TestCase):
             with tempfile.TemporaryDirectory() as tmpdirname:
                 engine = DdpCheckpointEngine(tmpdirname, storage)
                 engine._init_sync_group("gloo")
-                self.assertIsNotNone(engine._saver_group)
+                self.assertIsNone(engine._saver_group)
         finally:
             dist.destroy_process_group()
 

--- a/dlrover/trainer/torch/flash_checkpoint/engine.py
+++ b/dlrover/trainer/torch/flash_checkpoint/engine.py
@@ -210,7 +210,10 @@ class CheckpointEngine(metaclass=ABCMeta):
                 timeout=timedelta(seconds=60),
             )
         self._saving_ranks = self.get_saving_ranks()
-        if backend == dist.get_backend() and self._saving_ranks is None:
+        if backend == dist.get_backend() and (
+            self._saving_ranks is None
+            or len(self._saving_ranks) == dist.get_world_size()
+        ):
             self._saver_group = None
             message = (
                 "Use the default process group to sync "

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ extra_require = {
 
 setup(
     name="dlrover",
-    version="0.3.1rc0",
+    version="0.3.4rc0",
     description="An Automatic Distributed Deep Learning Framework",
     long_description="DLRover helps model developers focus on model algorithm"
     " itself, without taking care of any engineering stuff,"


### PR DESCRIPTION
### What changes were proposed in this pull request?

Implement the deletion Strategy to delete the abandoned checkpoints.

### Why are the changes needed?

Using flash checkpoint, users can save checkpoints into the storage with a high frequency. A large number of checkpoints will take up a lot of storage space. The deletion strategy can automatically delete the abandoned checkpoint after saving a new checkpoint.

### Does this PR introduce any user-facing change?

Yes.

### How was this patch tested?

UT.