### PR TITLE
Do not unlink the shared memory after restarting the training.

### DIFF
--- a/dlrover/python/common/multi_process.py
+++ b/dlrover/python/common/multi_process.py
@@ -606,4 +606,4 @@ class SharedMemory(shared_memory.SharedMemory):
                 _posixshmem.shm_unlink(self._name)
             except FileNotFoundError:
                 pass
-            logger.info(f"Unlink the shared memory {self._shm_name}")
+            logger.info(f"Unlink the shared memory {self._name}")

--- a/dlrover/python/common/multi_process.py
+++ b/dlrover/python/common/multi_process.py
@@ -606,3 +606,4 @@ class SharedMemory(shared_memory.SharedMemory):
                 _posixshmem.shm_unlink(self._name)
             except FileNotFoundError:
                 pass
+            logger.info(f"Unlink the shared memory {self._shm_name}")

--- a/dlrover/python/elastic_agent/torch/ckpt_saver.py
+++ b/dlrover/python/elastic_agent/torch/ckpt_saver.py
@@ -154,7 +154,10 @@ def _create_shared_memory(name, create, size=0):
     except FileExistsError:
         shm = SharedMemory(name=name)
         if shm.size != size:
-            logger.info("Re-create a new memory buffer.")
+            logger.info(
+                f"The old size is {shm.size} and "
+                f"create a new memory buffer with size {size}."
+            )
             shm.unlink()
             shm = SharedMemory(
                 name=name,
@@ -238,14 +241,10 @@ class SharedMemoryHandler(object):
             self.init_shared_memory()
         if self.shared_memory:
             self.shared_memory.unlink()
-            logger.info(f"Unlink the shared memory {self._shm_name}")
         if self.metadata:
             self.metadata.unlink()
 
     def reset(self):
-        self.close()
-        if self.shared_memory:
-            self.shared_memory.unlink()
         self.metadata.set({})
         self.shared_memory = None
 

--- a/dlrover/python/elastic_agent/torch/training.py
+++ b/dlrover/python/elastic_agent/torch/training.py
@@ -623,7 +623,7 @@ class ElasticTrainingAgent(LocalElasticAgent):
         self._restart_count += 1
         self._remaining_restarts -= 1
         # Relase the shared memory lock before starting workers.
-        AsyncCheckpointSaver.release_shm_lock()
+        AsyncCheckpointSaver.reset()
         super()._restart_workers(worker_group)
 
     def _start_workers(self, worker_group: WorkerGroup):

--- a/dlrover/python/tests/test_ckpt_saver.py
+++ b/dlrover/python/tests/test_ckpt_saver.py
@@ -214,7 +214,7 @@ class CheckpointSaverTest(unittest.TestCase):
             saver._shm_handlers[0].init_shared_memory(create=True, size=1024)
             saver._shm_handlers[0].metadata.set({"step": 100})
             event = CheckpointEvent(
-                type=CheckpointEventType.UPDATE_SHARD, global_shard_num=2
+                type=CheckpointEventType.RESET_SHM, global_shard_num=2
             )
             saver._event_queue.put(event)
             sq.unlink()

--- a/dlrover/python/tests/test_ckpt_saver.py
+++ b/dlrover/python/tests/test_ckpt_saver.py
@@ -219,8 +219,8 @@ class CheckpointSaverTest(unittest.TestCase):
             saver._event_queue.put(event)
             sq.unlink()
             time.sleep(0.3)
+            self.assertEqual(saver.global_shard_num, 2)
             self.assertTrue(saver._shm_handlers[0].no_checkpint_state())
-            self.assertIsNone(saver._shm_handlers[0].shared_memory)
             saver.close()
 
     def test_commit_checkpoint(self):

--- a/dlrover/python/tests/test_ckpt_saver.py
+++ b/dlrover/python/tests/test_ckpt_saver.py
@@ -102,7 +102,6 @@ class CheckpointSaverTest(unittest.TestCase):
     def setUp(self) -> None:
         self.storage = PosixDiskStorage()
         AsyncCheckpointSaver._saver_instance = None
-        AsyncCheckpointSaver.reset()
         AsyncCheckpointSaver.start_async_saving_ckpt()
 
     def tearDown(self) -> None:
@@ -126,6 +125,7 @@ class CheckpointSaverTest(unittest.TestCase):
             else:
                 break
         self.assertIsNotNone(AsyncCheckpointSaver._saver_instance)
+        AsyncCheckpointSaver.reset()
 
     def test_close_saver(self):
         saver = DdpCheckpointSaver("test_ckpt", self.storage.get_class_meta())

--- a/dlrover/python/tests/test_ckpt_saver.py
+++ b/dlrover/python/tests/test_ckpt_saver.py
@@ -102,7 +102,7 @@ class CheckpointSaverTest(unittest.TestCase):
     def setUp(self) -> None:
         self.storage = PosixDiskStorage()
         AsyncCheckpointSaver._saver_instance = None
-        AsyncCheckpointSaver.release_shm_lock()
+        AsyncCheckpointSaver.reset()
         AsyncCheckpointSaver.start_async_saving_ckpt()
 
     def tearDown(self) -> None:
@@ -214,7 +214,7 @@ class CheckpointSaverTest(unittest.TestCase):
             saver._shm_handlers[0].init_shared_memory(create=True, size=1024)
             saver._shm_handlers[0].metadata.set({"step": 100})
             event = CheckpointEvent(
-                type=CheckpointEventType.RESET_SHM, global_shard_num=2
+                type=CheckpointEventType.UPDATE_SHARD, global_shard_num=2
             )
             saver._event_queue.put(event)
             sq.unlink()

--- a/dlrover/trainer/torch/flash_checkpoint/engine.py
+++ b/dlrover/trainer/torch/flash_checkpoint/engine.py
@@ -276,7 +276,7 @@ class CheckpointEngine(metaclass=ABCMeta):
         if self._local_rank == 0:
             global_shard_num = self.get_global_shard_num()
             event: CheckpointEvent = CheckpointEvent(
-                type=CheckpointEventType.UPDATE_SHARD,
+                type=CheckpointEventType.RESET_SHM,
                 global_shard_num=global_shard_num,
             )
             if self._event_queue is None:

--- a/dlrover/trainer/torch/flash_checkpoint/engine.py
+++ b/dlrover/trainer/torch/flash_checkpoint/engine.py
@@ -276,7 +276,7 @@ class CheckpointEngine(metaclass=ABCMeta):
         if self._local_rank == 0:
             global_shard_num = self.get_global_shard_num()
             event: CheckpointEvent = CheckpointEvent(
-                type=CheckpointEventType.RESET_SHM,
+                type=CheckpointEventType.UPDATE_SHARD,
                 global_shard_num=global_shard_num,
             )
             if self._event_queue is None:


### PR DESCRIPTION
### What changes were proposed in this pull request?

Do not unlink the shared memory after restarting the training.

### Why are the changes needed?

If the size of the checkpoint shard changes, the engine will create a new shared memory.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

UT.