### PR TITLE
Auto set the nnodes and nproc_per_nodes if auto_config is True.

### DIFF
--- a/dlrover/python/tests/test_elastic_training_agent.py
+++ b/dlrover/python/tests/test_elastic_training_agent.py
@@ -102,6 +102,20 @@ class ElasticTrainingAgentTest(unittest.TestCase):
         node_unit = int(self.rdzv_handler._rdzv_params.get("node_unit", "1"))
         self.assertEqual(node_unit, 2)
 
+    def test_auto_configure(self):
+        config = ElasticLaunchConfig(
+            min_nodes=1,
+            max_nodes=1,
+            nproc_per_node=8,
+            run_id="test",
+            auto_config=True,
+        )
+        os.environ["NODE_NUM"] = "4"
+        config.auto_configure_params()
+        self.assertEqual(config.max_nodes, 4)
+        self.assertEqual(config.min_nodes, 4)
+        self.assertTrue(config.network_check)
+
     def test_rank0_rendzevous(self):
         node_id = 0
         agent = ElasticTrainingAgent(

--- a/dlrover/trainer/torch/elastic_run.py
+++ b/dlrover/trainer/torch/elastic_run.py
@@ -24,6 +24,15 @@ multi-node multi-worker.
 Usage
 --------
 
+Run in the worker Pod with GPU of ElasticJob.
+++++++++++++++++++++++++++++++
+
+::
+
+    dlrover-run
+        --auto-config
+        YOUR_TRAINING_SCRIPT.py (--arg1 ... train script args...)
+
 Single-node multi-worker
 ++++++++++++++++++++++++++++++
 
@@ -39,7 +48,7 @@ multi-node multi-worker
 
 ::
 
-    torchrun
+    dlrover-run
         --nnodes=$NUM_NODES
         --nproc-per-node=$NUM_TRAINERS
         --max-restarts=3
@@ -51,7 +60,7 @@ changes or failures)
 
 ::
 
-    torchrun
+    dlrover-run
         --nnodes=1:4
         --nproc-per-node=$NUM_TRAINERS
         --max-restarts=3
@@ -119,8 +128,15 @@ def parse_args(args):
         "nodes should be a multiple of node_unit.",
     )
     parser.add_argument(
+        "--auto_config",
+        "--auto-config",
+        action=check_env,
+        help="Whether to automatically configure the nnodes "
+        "and nproc_per_nodes.",
+    )
+    parser.add_argument(
         "--auto_tunning",
-        "--auto-tunning",
+        "--auto_tunning",
         action=check_env,
         help="Whether to auto-tune the parallel configuraion.",
     )
@@ -243,6 +259,7 @@ def _elastic_config_from_args(
     elastic_config = ElasticLaunchConfig(**config.__dict__)
     elastic_config.network_check = getattr(args, "network_check", False)
     elastic_config.auto_tunning = getattr(args, "auto_tunning", False)
+    elastic_config.auto_config = getattr(args, "auto_config", False)
     elastic_config.exclude_straggler = getattr(
         args, "exclude_straggler", False
     )
@@ -250,6 +267,7 @@ def _elastic_config_from_args(
     elastic_config.save_at_breakpoint = getattr(
         args, "save_at_breakpoint", False
     )
+    elastic_config.auto_configure_params()
     return elastic_config, cmd, cmd_args
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Auto set the nnodes and nproc_per_nodes if auto_config is True.

### Why are the changes needed?

Users do not need to set `--nnodes` and `--nproc_per_nodes` using ElasticJob.

### Does this PR introduce any user-facing change?

Yes.

### How was this patch tested?

UT.