### PR TITLE
fix saver factory for creation after training process restarts.

### DIFF
--- a/dlrover/python/elastic_agent/torch/ckpt_saver.py
+++ b/dlrover/python/elastic_agent/torch/ckpt_saver.py
@@ -436,7 +436,10 @@ class AsyncCheckpointSaver(metaclass=ABCMeta):
                         continue
 
                     threading.Thread(
-                        target=_saver, args=(class_meta,), name="checkpoint-saver", daemon=True
+                        target=_saver,
+                        args=(class_meta,),
+                        name="checkpoint-saver",
+                        daemon=True
                     ).start()
 
         threading.Thread(

--- a/dlrover/python/elastic_agent/torch/ckpt_saver.py
+++ b/dlrover/python/elastic_agent/torch/ckpt_saver.py
@@ -431,7 +431,8 @@ class AsyncCheckpointSaver(metaclass=ABCMeta):
 
                     if cls._saver_instance is not None:
                         logger.info(
-                            "The saver is already created, skip creating the saver."
+                            "The saver is already created, "
+                            "skip creating the saver."
                         )
                         continue
 

--- a/dlrover/python/elastic_agent/torch/ckpt_saver.py
+++ b/dlrover/python/elastic_agent/torch/ckpt_saver.py
@@ -439,7 +439,7 @@ class AsyncCheckpointSaver(metaclass=ABCMeta):
                         target=_saver,
                         args=(class_meta,),
                         name="checkpoint-saver",
-                        daemon=True
+                        daemon=True,
                     ).start()
 
         threading.Thread(

--- a/dlrover/python/tests/test_ckpt_saver.py
+++ b/dlrover/python/tests/test_ckpt_saver.py
@@ -127,7 +127,8 @@ class CheckpointSaverTest(unittest.TestCase):
         self.assertIsNotNone(AsyncCheckpointSaver._saver_instance)
         AsyncCheckpointSaver.reset()
 
-        # test notify multiple times, see if it will skip and no exception raised
+        # test notify multiple times,
+        # see if it will skip and no exception raised
         sq.put(class_meta)
         sq.put(class_meta)
 

--- a/dlrover/python/tests/test_ckpt_saver.py
+++ b/dlrover/python/tests/test_ckpt_saver.py
@@ -127,6 +127,10 @@ class CheckpointSaverTest(unittest.TestCase):
         self.assertIsNotNone(AsyncCheckpointSaver._saver_instance)
         AsyncCheckpointSaver.reset()
 
+        # test notify multiple times, see if it will skip and no exception raised
+        sq.put(class_meta)
+        sq.put(class_meta)
+
     def test_close_saver(self):
         saver = DdpCheckpointSaver("test_ckpt", self.storage.get_class_meta())
         try:

--- a/dlrover/trainer/torch/flash_checkpoint/engine.py
+++ b/dlrover/trainer/torch/flash_checkpoint/engine.py
@@ -251,12 +251,7 @@ class CheckpointEngine(metaclass=ABCMeta):
         """Notify the agent in the main process to create a checkpoint saver"""
         if self._local_rank != 0:
             return
-        if self._restart_count > 0:
-            # Only local rank 0 notify to initialize the saver in
-            # the main process at the first start.
-            # Avoid the lock is locked by a failed process.
-            self._shm_lock.release()
-            return
+        # the agent side will release the lock if training process restarts.
         queue = SharedQueue(name="factory")
 
         local_shard_num = self.get_local_shard_num()
@@ -274,7 +269,6 @@ class CheckpointEngine(metaclass=ABCMeta):
         )
 
         queue.put(class_meta)
-        queue.unlink()
 
     def _update_saver_config(self):
         """Update the sharding configuration to the saver."""


### PR DESCRIPTION
### What changes were proposed in this pull request?

We propose to modify the agent's implementation to use a factory thread that continuously attempts to create the saver, rather than relying on a single creation attempt.

### Why are the changes needed?

In the current implementation, if the training process fails before the notification for asynchronous saver creation is sent, the saver will not be instantiated on the agent's side. This absence of the saver can result in an error during the next training process. The proposed change aims to ensure that the saver is reliably created, thereby preventing such errors.

### Does this PR introduce any user-facing change?

No

### How was this patch tested?

UT