### PR TITLE
The job master only prints the exit reason if the pod fails.

### DIFF
--- a/dlrover/python/master/node/dist_job_manager.py
+++ b/dlrover/python/master/node/dist_job_manager.py
@@ -446,14 +446,13 @@ class DistributedJobManager(JobManager):
             if should_relaunch and self._wait_pending_relaunch:
                 self._pending_relaunch_count += 1
 
-        logger.info(
-            "%s status change: %s to %s, by evt_type %s reason %s",
-            cur_node.name,
-            old_status,
-            new_status,
-            event.event_type,
-            cur_node.exit_reason,
+        msg = (
+            f"{cur_node.name} status change: {old_status} to {new_status} "
+            f"by the event {event.event_type}. "
         )
+        if new_status in [NodeStatus.FAILED, NodeStatus.DELETED]:
+            msg += f"Exit reason is {cur_node.exit_reason}"
+        logger.info(msg)
 
         if should_relaunch:
             self._relaunch_node(cur_node)

--- a/dlrover/trainer/tests/torch/elastic_run_test.py
+++ b/dlrover/trainer/tests/torch/elastic_run_test.py
@@ -15,6 +15,7 @@ import unittest
 
 from dlrover.trainer.torch.elastic_run import (
     _check_dlrover_master_available,
+    _check_to_use_dlrover_run,
     _elastic_config_from_args,
     _launch_dlrover_local_master,
     parse_args,
@@ -23,10 +24,20 @@ from dlrover.trainer.torch.elastic_run import (
 
 class ElasticRunTest(unittest.TestCase):
     def test_launch_local_master(self):
+        available = _check_dlrover_master_available("")
+        self.assertFalse(available)
         handler, addr = _launch_dlrover_local_master("", "test", 1)
         available = _check_dlrover_master_available(addr)
         self.assertTrue(available)
         handler.close()
+
+    def test_check_to_use_dlrover_run(self):
+        use_dlrover_run = _check_to_use_dlrover_run("", 1)
+        self.assertFalse(use_dlrover_run)
+        with self.assertRaises(ValueError):
+            _check_to_use_dlrover_run("", 2)
+        with self.assertRaises(ValueError):
+            _check_to_use_dlrover_run("127.0.0.1:12345", 2)
 
     def test_elastic_config_from_args(self):
         args = [

--- a/docker/master.dockerfile
+++ b/docker/master.dockerfile
@@ -9,7 +9,7 @@ RUN pip install pyparsing -i https://pypi.org/simple
 
 RUN apt-get -qq update && apt-get install -y iputils-ping vim gdb
 
-ENV VERSION="0.3.0rc1"
+ENV VERSION="0.3.4rc0"
 COPY --from=builder /dlrover/dist/dlrover-${VERSION}-py3-none-any.whl /
 RUN pip install /dlrover-${VERSION}-py3-none-any.whl[k8s] --extra-index-url=https://pypi.org/simple && rm -f /*.whl
 RUN unset VERSION


### PR DESCRIPTION
### What changes were proposed in this pull request?

The job master only prints the exit reason if the pod fails.

### Why are the changes needed?

The job master prints the exit reason as Unknown Error even if the pod succeeds.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

UT.