### PR TITLE
The ElasticJob can recover the master pod if it is evicted.

### DIFF
--- a/dlrover/go/operator/pkg/controllers/master/master_test.go
+++ b/dlrover/go/operator/pkg/controllers/master/master_test.go
@@ -59,7 +59,7 @@ func TestCreateMasterPodWithImage(t *testing.T) {
 		ImagePullPolicy: "Always",
 	}
 	job.Spec.ReplicaSpecs = make(map[commonv1.ReplicaType]*elasticv1alpha1.ReplicaSpec)
-	job.Spec.ReplicaSpecs[ReplicaTypeTrainerMaster] = &elasticv1alpha1.ReplicaSpec{
+	job.Spec.ReplicaSpecs[ReplicaTypeJobMaster] = &elasticv1alpha1.ReplicaSpec{
 		ReplicaSpec: commonv1.ReplicaSpec{
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{

--- a/dlrover/python/master/dist_master.py
+++ b/dlrover/python/master/dist_master.py
@@ -70,7 +70,7 @@ def _create_master_service_on_k8s(namespace, job_name, job_uuid, target_port):
     )
 
     svc_factory = k8sServiceFactory(namespace, job_name)
-    svc_name = "elasticjob-{job_name}-dlrover-master"
+    svc_name = f"elasticjob-{job_name}-dlrover-master"
     port = NODE_SERVICE_PORTS[NodeType.DLROVER_MASTER]
     selector = {
         ElasticJobLabel.JOB_KEY: job_name,

--- a/dlrover/python/master/dist_master.py
+++ b/dlrover/python/master/dist_master.py
@@ -16,12 +16,15 @@ from typing import Dict
 
 from dlrover.python.common.constants import (
     DistributionStrategy,
+    ElasticJobLabel,
     JobExitReason,
     NodeType,
     OptimizeMode,
+    PlatformType,
     RendezvousName,
     ReporterType,
 )
+from dlrover.python.common.global_context import Context
 from dlrover.python.common.log import default_logger as logger
 from dlrover.python.master.elastic_training.elastic_ps import ElasticPsService
 from dlrover.python.master.elastic_training.rdzv_manager import (
@@ -43,11 +46,44 @@ from dlrover.python.master.shard.task_manager import TaskManager
 from dlrover.python.master.stats.job_collector import JobMetricCollector
 from dlrover.python.scheduler.job import JobArgs
 
+_dlrover_context = Context.singleton_instance()
+
 
 def _create_elastic_ps_service_if_needed(params: JobArgs):
     if params.distribution_strategy == DistributionStrategy.PS:
         return ElasticPsService()
     return None
+
+
+def _create_master_service_on_k8s(namespace, job_name, job_uuid, target_port):
+    from dlrover.python.scheduler.kubernetes import (
+        NODE_SERVICE_PORTS,
+        k8sClient,
+        k8sServiceFactory,
+    )
+
+    owner_ref = k8sClient.create_owner_reference(
+        api_version="elastic.iml.github.io/v1alpha1",
+        kind="ElasticJob",
+        name=job_name,
+        uid=job_uuid,
+    )
+
+    svc_factory = k8sServiceFactory(namespace, job_name)
+    svc_name = "elasticjob-{job_name}-dlrover-master"
+    port = NODE_SERVICE_PORTS[NodeType.DLROVER_MASTER]
+    selector = {
+        ElasticJobLabel.JOB_KEY: job_name,
+        ElasticJobLabel.REPLICA_TYPE_KEY: NodeType.DLROVER_MASTER,
+    }
+    succeed = svc_factory.create_service(
+        name=svc_name,
+        port=port,
+        target_port=target_port,
+        selector=selector,
+        owner_ref=owner_ref,
+    )
+    return succeed
 
 
 class DistributedJobMaster(JobMaster):
@@ -71,6 +107,19 @@ class DistributedJobMaster(JobMaster):
     """
 
     def __init__(self, port, args: JobArgs):
+        if args.platform in [
+            PlatformType.KUBERNETES,
+            PlatformType.PY_KUBERNETES,
+        ]:
+            succeed = _create_master_service_on_k8s(
+                args.namespace, args.job_name, args.job_uuid, port
+            )
+            if not succeed:
+                logger.warning(
+                    "Fail to create the master service. "
+                    "The master cannot recover from the failure."
+                )
+
         self.speed_monitor = SpeedMonitor()
         self.job_manager = (
             create_job_manager(args, self.speed_monitor)

--- a/dlrover/python/master/main.py
+++ b/dlrover/python/master/main.py
@@ -38,7 +38,7 @@ def run(args):
     job_args = new_job_args(args.platform, args.job_name, args.namespace)
     job_args.initilize()
     logger.info("Job args : %s", job_args.to_json(indent=4))
-    _dlrover_context.config_master_port(port=args.port)
+    _dlrover_context.config_master_port()
     if job_args.platform == PlatformType.LOCAL:
         from dlrover.python.master.local_master import LocalJobMaster
 

--- a/dlrover/python/master/main.py
+++ b/dlrover/python/master/main.py
@@ -38,7 +38,7 @@ def run(args):
     job_args = new_job_args(args.platform, args.job_name, args.namespace)
     job_args.initilize()
     logger.info("Job args : %s", job_args.to_json(indent=4))
-    _dlrover_context.config_master_port()
+    _dlrover_context.config_master_port(port=args.port)
     if job_args.platform == PlatformType.LOCAL:
         from dlrover.python.master.local_master import LocalJobMaster
 

--- a/dlrover/python/master/node/dist_job_manager.py
+++ b/dlrover/python/master/node/dist_job_manager.py
@@ -178,6 +178,7 @@ class DistributedJobManager(JobManager):
         self._init_training_node_manager()
 
     def start(self):
+        self._scaler.start()
         self._job_optimizer.update_job_uuid(self._job_args.job_uuid)
         self._job_optimizer.init_job_resource(self._job_resource)
         self._adjust_worker_for_estimator()
@@ -794,7 +795,6 @@ def create_job_manager(args: JobArgs, speed_monitor) -> DistributedJobManager:
         args.platform, args.job_name, args.namespace
     )
     job_scaler = new_job_scaler(args.platform, args.job_name, args.namespace)
-    job_scaler.start()
 
     return DistributedJobManager(
         job_args=args,

--- a/dlrover/python/master/node/dist_job_manager.py
+++ b/dlrover/python/master/node/dist_job_manager.py
@@ -191,7 +191,7 @@ class DistributedJobManager(JobManager):
             self._scaler.scale(plan)
         else:
             logger.info(
-                "The relaunched master skip launching workers at begining."
+                "The recovered master skips launching workers at begining."
             )
         worker_num = 0
         if NodeType.WORKER in plan.node_group_resources:

--- a/dlrover/python/master/node/dist_job_manager.py
+++ b/dlrover/python/master/node/dist_job_manager.py
@@ -189,6 +189,10 @@ class DistributedJobManager(JobManager):
             # The the job relaunches the evicted master, there are alive
             # worker nodes and the master does not need to launch workers.
             self._scaler.scale(plan)
+        else:
+            logger.info(
+                "The relaunched master skip launching workers at begining."
+            )
         worker_num = 0
         if NodeType.WORKER in plan.node_group_resources:
             worker_num = plan.node_group_resources[NodeType.WORKER].count

--- a/dlrover/python/master/resource/job.py
+++ b/dlrover/python/master/resource/job.py
@@ -142,7 +142,7 @@ class JobResource(JsonSerializable):
                 )
             job_nodes[node_type] = group_nodes
         logger.info(
-            "after initiating job node meta job_nodes are %s" % job_nodes
+            "after initializing job node meta job_nodes are %s" % job_nodes
         )
         return job_nodes
 

--- a/dlrover/python/master/scaler/pod_scaler.py
+++ b/dlrover/python/master/scaler/pod_scaler.py
@@ -112,6 +112,11 @@ class PodScaler(Scaler):
         port = NODE_SERVICE_PORTS[NodeType.DLROVER_MASTER]
         master_addr = f"{svc_name}:{port}"
         if not self._check_master_service_avaliable(svc_name):
+            # On some clusters, the k8s service may not be avaliable because of
+            # incorrect DNS configurations. In such cases, it is necessary to
+            # revert to use the Master's IP address for worker to connect with
+            # the master. Note, that failover of master is not supported if
+            # the service is not avalilable.
             logger.info(
                 f"The service {master_addr} is not available and "
                 "use the IP of master Pod."

--- a/dlrover/python/scheduler/kubernetes.py
+++ b/dlrover/python/scheduler/kubernetes.py
@@ -471,16 +471,32 @@ class K8sJobArgs(JobArgs):
 
 
 class k8sServiceFactory(object):
-    """The factory creates the k8s service for Pods."""
+    """
+    The factory creates the k8s service for Pods.
 
-    def __init__(self, namespace, job_name):
+    Arguments:
+        namespace (str): the namespace on a k8s cluster.
+        job_name (str): the name of an ElasticJob.
+    """
+
+    def __init__(self, namespace: str, job_name: str):
         self._namespace = namespace
         self._job_name = job_name
         self._k8s_client = k8sClient.singleton_instance(self._namespace)
 
     def create_service(
-        self, name, port, target_port, selector, owner_ref, retry_num=5
+        self,
+        name: str,
+        port: int,
+        target_port: int,
+        selector: Dict[str, str],
+        owner_ref: client.V1OwnerReference,
+        retry_num=5,
     ):
+        """
+        Create a new service if the service dose not exist, otherwise
+        the method patch the service with modifications.
+        """
         service = self._create_service_obj(
             name=name,
             port=port,
@@ -494,7 +510,7 @@ class k8sServiceFactory(object):
         else:
             return self._patch_service(name, service, retry_num)
 
-    def _create_new_service(self, service, retry_num):
+    def _create_new_service(self, service: client.V1Service, retry_num: int):
         for _ in range(retry_num):
             succeed = self._k8s_client.create_service(service)
             if succeed:
@@ -502,7 +518,9 @@ class k8sServiceFactory(object):
             time.sleep(5)
         return False
 
-    def _patch_service(self, name, service, retry_num):
+    def _patch_service(
+        self, name: str, service: client.V1Service, retry_num: int
+    ):
         for _ in range(retry_num):
             succeed = self._k8s_client.patch_service(name, service)
             if succeed:
@@ -511,9 +529,17 @@ class k8sServiceFactory(object):
         return False
 
     def _create_service_obj(
-        self, name, port, target_port, selector, owner_ref
+        self,
+        name: str,
+        port: int,
+        target_port: int,
+        selector: Dict[str, str],
+        owner_ref: client.V1OwnerReference,
     ):
-        labels = self._get_common_labels()
+        labels = {
+            "app": ElasticJobLabel.APP_NAME,
+            ElasticJobLabel.JOB_KEY: self._job_name,
+        }
 
         metadata = client.V1ObjectMeta(
             name=name,
@@ -534,12 +560,3 @@ class k8sServiceFactory(object):
             api_version="v1", kind="Service", metadata=metadata, spec=spec
         )
         return service
-
-    def _get_common_labels(self):
-        """Labels that should be attached to all k8s objects belong to
-        current job.
-        """
-        return {
-            "app": ElasticJobLabel.APP_NAME,
-            ElasticJobLabel.JOB_KEY: self._job_name,
-        }

--- a/dlrover/python/scheduler/kubernetes.py
+++ b/dlrover/python/scheduler/kubernetes.py
@@ -20,6 +20,7 @@ from kubernetes.utils.quantity import parse_quantity
 
 from dlrover.python.common.constants import (
     DefaultResourceLimits,
+    ElasticJobLabel,
     NodeType,
     OptimizeMode,
     k8sAPIExceptionReason,
@@ -35,6 +36,7 @@ NODE_SERVICE_PORTS = {
     NodeType.CHIEF: 3333,
     NodeType.PS: 2222,
     NodeType.MASTER: 3333,
+    NodeType.DLROVER_MASTER: 50001,
 }
 
 JOB_SUFFIX = "-edljob-"
@@ -466,3 +468,78 @@ class K8sJobArgs(JobArgs):
         if job and "uid" in job["metadata"]:
             return job["metadata"]["uid"]
         return ""
+
+
+class k8sServiceFactory(object):
+    """The factory creates the k8s service for Pods."""
+
+    def __init__(self, namespace, job_name):
+        self._namespace = namespace
+        self._job_name = job_name
+        self._k8s_client = k8sClient.singleton_instance(self._namespace)
+
+    def create_service(
+        self, name, port, target_port, selector, owner_ref, retry_num=5
+    ):
+        service = self._create_service_obj(
+            name=name,
+            port=port,
+            target_port=target_port,
+            selector=selector,
+            owner_ref=owner_ref,
+        )
+
+        if not self._k8s_client.get_service(name):
+            return self._create_new_service(service, retry_num)
+        else:
+            return self._patch_service(name, service, retry_num)
+
+    def _create_new_service(self, service, retry_num):
+        for _ in range(retry_num):
+            succeed = self._k8s_client.create_service(service)
+            if succeed:
+                return succeed
+            time.sleep(5)
+        return False
+
+    def _patch_service(self, name, service, retry_num):
+        for _ in range(retry_num):
+            succeed = self._k8s_client.patch_service(name, service)
+            if succeed:
+                return succeed
+            time.sleep(5)
+        return False
+
+    def _create_service_obj(
+        self, name, port, target_port, selector, owner_ref
+    ):
+        labels = self._get_common_labels()
+
+        metadata = client.V1ObjectMeta(
+            name=name,
+            labels=labels,
+            # Note: We have to add at least one annotation here.
+            # Otherwise annotation is `None` and cannot be modified
+            # using `with_service()` for cluster specific information.
+            annotations=labels,
+            owner_references=[owner_ref],
+            namespace=self._namespace,
+        )
+        spec = client.V1ServiceSpec(
+            ports=[client.V1ServicePort(port=port, target_port=target_port)],
+            selector=selector,
+            type=None,
+        )
+        service = client.V1Service(
+            api_version="v1", kind="Service", metadata=metadata, spec=spec
+        )
+        return service
+
+    def _get_common_labels(self):
+        """Labels that should be attached to all k8s objects belong to
+        current job.
+        """
+        return {
+            "app": ElasticJobLabel.APP_NAME,
+            ElasticJobLabel.JOB_KEY: self._job_name,
+        }

--- a/dlrover/python/tests/test_k8s_utils.py
+++ b/dlrover/python/tests/test_k8s_utils.py
@@ -18,12 +18,16 @@ from kubernetes import client
 from dlrover.python.common.node import NodeResource
 from dlrover.python.scheduler.kubernetes import (
     get_main_container,
+    k8sServiceFactory,
     set_container_resource,
 )
-from dlrover.python.tests.test_utils import create_pod
+from dlrover.python.tests.test_utils import create_pod, mock_k8s_client
 
 
 class KubernetesTest(unittest.TestCase):
+    def setUp(self) -> None:
+        mock_k8s_client()
+
     def test_get_main_container(self):
         labels = {"class": "test"}
         pod = create_pod(labels)
@@ -69,3 +73,9 @@ class KubernetesTest(unittest.TestCase):
         self.assertEqual(container.resources.requests["memory"], "1024Mi")
         self.assertEqual(container.resources.limits["cpu"], 4)
         self.assertEqual(container.resources.limits["memory"], "1024Mi")
+
+    def test_service_factory(self):
+        fac = k8sServiceFactory("dlrover", "test")
+        svc = fac._create_service_obj("test-master", 12345, 34567, {}, None)
+        succeed = fac._patch_service("test-master", svc, 5)
+        self.assertTrue(succeed)

--- a/dlrover/python/tests/test_master.py
+++ b/dlrover/python/tests/test_master.py
@@ -22,7 +22,10 @@ from dlrover.python.common.constants import (
 )
 from dlrover.python.common.global_context import Context
 from dlrover.python.elastic_agent.master_client import build_master_client
-from dlrover.python.master.dist_master import DistributedJobMaster
+from dlrover.python.master.dist_master import (
+    DistributedJobMaster,
+    _create_master_service_on_k8s,
+)
 from dlrover.python.master.main import update_context
 from dlrover.python.master.shard.dataset_splitter import new_dataset_splitter
 from dlrover.python.tests.test_utils import (
@@ -103,6 +106,12 @@ class DistributedJobMasterTest(unittest.TestCase):
         self.assertTrue(_dlrover_context.relaunch_always)
         self.assertTrue(_dlrover_context.auto_ps_enabled)
         self.assertTrue(_dlrover_context.auto_worker_enabled)
+
+    def test_create_master_service_on_k8s(self):
+        succeed = _create_master_service_on_k8s(
+            "dlrover", "test", "12345", 12345
+        )
+        self.assertTrue(succeed)
 
 
 class LocalJobMasterTest(unittest.TestCase):

--- a/dlrover/python/tests/test_master.py
+++ b/dlrover/python/tests/test_master.py
@@ -96,6 +96,7 @@ class DistributedJobMasterTest(unittest.TestCase):
             node.is_recovered_oom = True
             node.create_time = datetime.now() + timedelta(days=-1)
         exit_code = self.master.run()
+        self.master.job_manager.clear_all_nodes()
         self.assertEqual(exit_code, 1)
 
     def test_update_context(self):

--- a/dlrover/python/tests/test_pod_scaler.py
+++ b/dlrover/python/tests/test_pod_scaler.py
@@ -14,11 +14,7 @@
 import os
 import unittest
 
-from dlrover.python.common.constants import (
-    DistributionStrategy,
-    ElasticJobLabel,
-    NodeType,
-)
+from dlrover.python.common.constants import DistributionStrategy, NodeType
 from dlrover.python.common.global_context import Context
 from dlrover.python.common.node import Node, NodeGroupResource, NodeResource
 from dlrover.python.master.scaler.base_scaler import ScalePlan
@@ -148,23 +144,6 @@ class PodScalerTest(unittest.TestCase):
                 rank = int(env.value)
         self.assertEqual(world_size, 2)
         self.assertEqual(rank, 0)
-
-    def test_create_service(self):
-        scaler = PodScaler("elasticjob-sample", "default")
-        scaler.start()
-        service = scaler._create_service_obj(
-            name="elasticjob-sample-edljob-worker-0",
-            port="2222",
-            target_port="2222",
-            replica_type=NodeType.WORKER,
-            rank_index=0,
-        )
-        self.assertEqual(
-            service.spec.selector[ElasticJobLabel.RANK_INDEX_KEY], "0"
-        )
-        self.assertEqual(
-            service.spec.selector[ElasticJobLabel.REPLICA_TYPE_KEY], "worker"
-        )
 
     def test_scale(self):
         scaler = PodScaler("elasticjob-sample", "default")

--- a/dlrover/python/tests/test_utils.py
+++ b/dlrover/python/tests/test_utils.py
@@ -259,6 +259,9 @@ def mock_k8s_client():
     k8s_client.create_service = mock.MagicMock(  # type: ignore
         return_value=True
     )
+    k8s_client.patch_service = mock.MagicMock(  # type: ignore
+        return_value=True
+    )
     k8s_client.get_service = mock.MagicMock(return_value=False)  # type: ignore
 
 

--- a/dlrover/trainer/tensorflow/failover/failover_client.py
+++ b/dlrover/trainer/tensorflow/failover/failover_client.py
@@ -25,7 +25,7 @@ class FailoverClient:
     """
 
     def __init__(self, role=None):
-        logger.info("initiating FailoverClient")
+        logger.info("initializing FailoverClient")
         self.role = role
         task_type, task_id = role.split(":")
         task_id = int(task_id)
@@ -70,7 +70,7 @@ class FailoverClient:
         return [n.addr for n in ps_nodes], ps_failure
 
     def init_version(self, version=0):
-        logger.info("initiating local and global version")
+        logger.info("initializing local and global version")
         local_version = self.get_local_version()
         global_version = self.get_global_version()
         if local_version == 0 and self.task_type == TFConstants.PS():

--- a/dlrover/trainer/tensorflow/failover/tensorflow_failover.py
+++ b/dlrover/trainer/tensorflow/failover/tensorflow_failover.py
@@ -39,7 +39,7 @@ class TensorflowFailover:
             failover_level: switch for dynet
         """
         logger.info(
-            "initiating tensorflow_failover and failover level is {}".format(
+            "initializing tensorflow_failover and failover level is {}".format(
                 failover_level
             )
         )


### PR DESCRIPTION
### What changes were proposed in this pull request?

Create a service for the master Pod after the master starts.

### Why are the changes needed?

Fault tolerance of job master. Workers can connect with the new master by the service.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

UT.