### PR TITLE
Always relaunch the failed pod for allreduce jobs.

### DIFF
--- a/dlrover/python/master/main.py
+++ b/dlrover/python/master/main.py
@@ -13,7 +13,11 @@
 
 import os
 
-from dlrover.python.common.constants import NodeType, PlatformType
+from dlrover.python.common.constants import (
+    DistributionStrategy,
+    NodeType,
+    PlatformType,
+)
 from dlrover.python.common.global_context import Context
 from dlrover.python.common.log import default_logger as logger
 from dlrover.python.master.args import parse_master_args
@@ -30,6 +34,8 @@ def update_context(job_args: JobArgs):
         elif node_type == NodeType.PS:
             _dlrover_context.auto_ps_enabled = node_args.auto_scale
     _dlrover_context.relaunch_always = job_args.relaunch_always
+    if job_args.distribution_strategy == DistributionStrategy.ALLREDUCE:
+        _dlrover_context.relaunch_always = True
     _dlrover_context.set_params_from_brain()
     _dlrover_context.print_config()
 

--- a/dlrover/python/tests/test_master.py
+++ b/dlrover/python/tests/test_master.py
@@ -15,6 +15,7 @@ import unittest
 from datetime import datetime, timedelta
 
 from dlrover.python.common.constants import (
+    DistributionStrategy,
     JobExitReason,
     NodeStatus,
     NodeType,
@@ -102,7 +103,8 @@ class DistributedJobMasterTest(unittest.TestCase):
     def test_update_context(self):
         job_args = MockK8sPSJobArgs()
         job_args.initilize()
-        job_args.relaunch_always = True
+        job_args.relaunch_always = False
+        job_args.distribution_strategy = DistributionStrategy.ALLREDUCE
         update_context(job_args)
         self.assertTrue(_dlrover_context.relaunch_always)
         self.assertTrue(_dlrover_context.auto_ps_enabled)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Always relaunch the failed pod for allreduce jobs.

### Why are the changes needed?

We cannot distinguish the failure reason by the exit code of GPU Pod. It is better to always relaunch the failed Pod for fault tolerance.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

UT.