### PR TITLE
Do not reset the meta of checkpoint to empty before restarting workers.

### DIFF
--- a/dlrover/python/elastic_agent/torch/ckpt_saver.py
+++ b/dlrover/python/elastic_agent/torch/ckpt_saver.py
@@ -248,7 +248,7 @@ class SharedMemoryHandler(object):
             self.metadata.unlink()
 
     def reset(self):
-        self.metadata.set({})
+        # self.metadata.set({})
         self.shared_memory = None
 
     def _create_tensor_meta(self, value: torch.Tensor):

--- a/dlrover/python/elastic_agent/torch/ckpt_saver.py
+++ b/dlrover/python/elastic_agent/torch/ckpt_saver.py
@@ -248,7 +248,6 @@ class SharedMemoryHandler(object):
             self.metadata.unlink()
 
     def reset(self):
-        # self.metadata.set({})
         self.shared_memory = None
 
     def _create_tensor_meta(self, value: torch.Tensor):


### PR DESCRIPTION
### What changes were proposed in this pull request?

Do not reset the meta of checkpoint to empty before restarting workers.

### Why are the changes needed?

We cannot load the checkpoint from the shared memory if set the checkpoint meta to an empty dict.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

UT.