### PR TITLE
Update atorch precommit mypy version to v0.981

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     hooks:
       - id: flake8
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.812
+    rev: v0.981
     hooks:
       - id: mypy
         args: [--ignore-missing-imports, --follow-imports=skip]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     hooks:
       - id: flake8
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.981
+    rev: v0.812
     hooks:
       - id: mypy
         args: [--ignore-missing-imports, --follow-imports=skip]

--- a/atorch/.pre-commit-config.yaml
+++ b/atorch/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
           "--ignore=E721,W503,E203,E266",
         ]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.900
+    rev: v0.981
     hooks:
       - id: mypy
         exclude: _pb2.py|_pb2_grpc.py|auto/engine/servicer.py


### PR DESCRIPTION
See issue #1027, we update atorch mypy version to v0.981 to solve the problem of "Positional-only parameters are only supported in Python 3.8 and greater" during pre-commit.
