### PR TITLE
Update atorch precommit mypy version to v0.981

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     hooks:
       - id: flake8
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.812
+    rev: v0.981
     hooks:
       - id: mypy
         args: [--ignore-missing-imports, --follow-imports=skip]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     hooks:
       - id: flake8
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.981
+    rev: v0.812
     hooks:
       - id: mypy
         args: [--ignore-missing-imports, --follow-imports=skip]

--- a/atorch/.pre-commit-config.yaml
+++ b/atorch/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
           "--ignore=E721,W503,E203,E266",
         ]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.900
+    rev: v0.981
     hooks:
       - id: mypy
         exclude: _pb2.py|_pb2_grpc.py|auto/engine/servicer.py

--- a/atorch/atorch/auto/opt_lib/amp_optimization.py
+++ b/atorch/atorch/auto/opt_lib/amp_optimization.py
@@ -13,7 +13,7 @@ from atorch.distributed.distributed import parallel_group
 from atorch.utils.grad_scaler import BF16GradScaler, BF16ShardedGradScaler
 from atorch.utils.version import torch_version
 
-if torch_version() >= (1, 12, 0):
+if torch_version() >= (1, 12, 0):  # type: ignore
     from torch.distributed.fsdp.sharded_grad_scaler import ShardedGradScaler
 
 else:

--- a/atorch/atorch/modules/distributed_modules/activation_checkpointing.py
+++ b/atorch/atorch/modules/distributed_modules/activation_checkpointing.py
@@ -27,7 +27,7 @@ from atorch.utils.graph_transform_utils import _pack_kwargs, _unpack_kwargs, com
 from atorch.utils.version import torch_version
 
 try:
-    if torch_version() <= (2, 0, 0):
+    if torch_version() <= (2, 0, 0):  # type: ignore
         from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import CheckpointWrapper as TorchWrapper
     else:
         from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import ActivationWrapper as TorchWrapper

--- a/atorch/atorch/modules/distributed_modules/mappings.py
+++ b/atorch/atorch/modules/distributed_modules/mappings.py
@@ -14,7 +14,7 @@ from atorch.modules.distributed_modules.utils import (
 )
 from atorch.utils.version import torch_version
 
-if torch_version() <= (1, 12, 1):
+if torch_version() <= (1, 12, 1):  # type: ignore
     from torch.distributed import _all_gather_base as torch_all_gather_base
 else:
     from torch.distributed import all_gather_into_tensor as torch_all_gather_base

--- a/atorch/atorch/modules/transformer/layers.py
+++ b/atorch/atorch/modules/transformer/layers.py
@@ -89,7 +89,7 @@ except (ImportError, ModuleNotFoundError):
     flash_attn_1 = None
     has_legacy_fa1 = False
 
-if torch_version() >= (2, 0, 0):  # torch ops seems to differ from 1.x, support pt2.0+ only
+if torch_version() >= (2, 0, 0):  # type: ignore  # torch ops seems to differ from 1.x, support pt2.0+ only
     try:
         import flash_attn_2_cuda
 

--- a/atorch/atorch/tests/clip_grad_norm_test.py
+++ b/atorch/atorch/tests/clip_grad_norm_test.py
@@ -280,7 +280,7 @@ class TestClipGradNorm(unittest.TestCase):
 
 class TestFSDPNormUtils(unittest.TestCase):
     @unittest.skipIf(
-        not torch.cuda.is_available() or torch.cuda.device_count() < 2 or torch_version() < (2, 0, 0),
+        not torch.cuda.is_available() or torch.cuda.device_count() < 2 or torch_version() < (2, 0, 0),  # type: ignore
         "No gpu available for cuda tests, torch 2.0 needed for use_orig_param",
     )
     def test_fsdp_norm_utils(self):

--- a/atorch/atorch/tests/dim_planner_test.py
+++ b/atorch/atorch/tests/dim_planner_test.py
@@ -96,7 +96,7 @@ def run_dim_planner(num_nodes, num_devices_per_node, loss_func):
 
 
 class TestDimPlanner(unittest.TestCase):
-    @unittest.skipIf(not torch.cuda.is_available() or torch_version() < (2, 0, 0), "Test on GPU image")
+    @unittest.skipIf(not torch.cuda.is_available() or torch_version() < (2, 0, 0), "Test on GPU image")  # type: ignore
     def test_dim_planner(self):
         run_dim_planner(2, 4, my_loss_func)
 

--- a/atorch/atorch/tests/ds_3d_parallel_optimization_test.py
+++ b/atorch/atorch/tests/ds_3d_parallel_optimization_test.py
@@ -171,7 +171,7 @@ def run_ds_3d_parallel(rank, world_size):
 
 class TestDeepSpeed3DParallel(unittest.TestCase):
     @unittest.skipIf(
-        not torch.cuda.is_available() or torch.cuda.device_count() < 4 or torch_version() < (2, 0, 0),
+        not torch.cuda.is_available() or torch.cuda.device_count() < 4 or torch_version() < (2, 0, 0),  # type: ignore
         "Must have at least 4 GPUs for tensor + pipeline parallel test",
     )
     def test_ds_3d_parallel(self):

--- a/atorch/atorch/tests/ds_pipe_test.py
+++ b/atorch/atorch/tests/ds_pipe_test.py
@@ -65,7 +65,7 @@ def _weight_align(pipe_model, ref_model):
 
 class TestDeepspeedPipelne(unittest.TestCase):
     @unittest.skipIf(
-        not torch.cuda.is_available() or torch_version() < (2, 0, 0),
+        not torch.cuda.is_available() or torch_version() < (2, 0, 0),  # type: ignore
         "skip if no gpu, torch 2.0 needed for torch.device context manager.",
     )
     def test_meta_to_pipelinemodule(self):

--- a/atorch/atorch/tests/manual_tp_test.py
+++ b/atorch/atorch/tests/manual_tp_test.py
@@ -167,7 +167,7 @@ def _run_manual_tp(rank):
 
 class TestManualTP(unittest.TestCase):
     @unittest.skipIf(
-        torch.cuda.device_count() < 4 or torch_version() < (2, 0, 0),
+        torch.cuda.device_count() < 4 or torch_version() < (2, 0, 0),  # type: ignore
         "run with cpu or gpu_num >=4, torch 2.0 needed for torch.device context manager.",
     )
     def test_manual_tp(self):

--- a/atorch/atorch/tests/meta_init_test.py
+++ b/atorch/atorch/tests/meta_init_test.py
@@ -193,7 +193,8 @@ def _test_init_auto_accelerate(rank, world_size):
 
 class TestInitAutoAccelerate(unittest.TestCase):
     @unittest.skipIf(
-        torch.cuda.device_count() < 2 or torch_version() < (2, 0, 0), "run with gpu_num >=2 torch.version > 2.0"
+        torch.cuda.device_count() < 2 or torch_version() < (2, 0, 0),  # type: ignore
+        "run with gpu_num >=2 torch.version > 2.0",
     )
     def test_init_auto_accelerate(self):
         world_size = 2

--- a/atorch/atorch/tests/mixed_parallel_test.py
+++ b/atorch/atorch/tests/mixed_parallel_test.py
@@ -205,7 +205,7 @@ class TestMixedMLP(unittest.TestCase):
         return super().tearDown()
 
     @unittest.skipIf(
-        not torch.cuda.is_available() or torch.cuda.device_count() < 4 or torch_version() < (2, 0, 0),
+        not torch.cuda.is_available() or torch.cuda.device_count() < 4 or torch_version() < (2, 0, 0),  # type: ignore
         "Must have at least 2 GPUs for gpu pipeline test",
     )
     def test_pipe_ddp_train(self):

--- a/atorch/atorch/tests/model_context_test.py
+++ b/atorch/atorch/tests/model_context_test.py
@@ -185,7 +185,7 @@ def use_shm_dataloader_func():
     atorch.reset_distributed()
 
 
-@unittest.skipIf(torch_version() >= (2, 0, 0), "to be fixed")
+@unittest.skipIf(torch_version() >= (2, 0, 0), "to be fixed")  # type: ignore
 class ModelContextShmDataloaderTest(unittest.TestCase):
     @unittest.skipIf(torch.cuda.is_available(), "Skip on gpu as cpu test covers it.")
     def test_use_shm_dataloader(self):

--- a/atorch/atorch/tests/pipeline_test.py
+++ b/atorch/atorch/tests/pipeline_test.py
@@ -442,7 +442,7 @@ class TestPipeMLP(unittest.TestCase):
         os.environ["MASTER_PORT"] = ""
 
     @unittest.skipIf(
-        (not torch.cuda.is_available() or torch.cuda.device_count() < 2) or torch_version() < (2, 0, 0),
+        (not torch.cuda.is_available() or torch.cuda.device_count() < 2) or torch_version() < (2, 0, 0),  # type: ignore
         "Must have at least 2 GPUs for gpu pipeline test",
     )
     def test_gpu_train_c10d(self):
@@ -464,7 +464,7 @@ class TestPipeMLP(unittest.TestCase):
     @unittest.skipIf(
         (not torch.cuda.is_available() or torch.cuda.device_count() < 2)
         or not torch.cuda.is_bf16_supported()
-        or torch_version() < (2, 0, 0)
+        or torch_version() < (2, 0, 0)  # type: ignore
         or True,
         "Skip as it's blocking now",
     )
@@ -487,7 +487,7 @@ class TestPipeMLP(unittest.TestCase):
     @unittest.skipIf(
         (not torch.cuda.is_available() or torch.cuda.device_count() < 2)
         or not torch.cuda.is_bf16_supported()
-        or torch_version() < (2, 0, 0)
+        or torch_version() < (2, 0, 0)  # type: ignore
         or True,
         "Skip as it's blocking now",
     )
@@ -508,7 +508,7 @@ class TestPipeMLP(unittest.TestCase):
         os.environ["MASTER_PORT"] = ""
 
     @unittest.skipIf(
-        (not torch.cuda.is_available() or torch.cuda.device_count() < 2) or torch_version() < (2, 0, 0),
+        (not torch.cuda.is_available() or torch.cuda.device_count() < 2) or torch_version() < (2, 0, 0),  # type: ignore
         "Must have at least 2 GPUs for gpu pipeline test",
     )
     def test_gpu_save_load_c10d(self):

--- a/atorch/atorch/tests/test_modules/test_moe_ddp.py
+++ b/atorch/atorch/tests/test_modules/test_moe_ddp.py
@@ -103,7 +103,7 @@ class MoEDDPTestcase(unittest.TestCase):
         except FileNotFoundError:
             pass
 
-    @unittest.skipIf(torch_version() >= (2, 0, 0), "torch2.1.0.dev may changed DDP's attribute.")
+    @unittest.skipIf(torch_version() >= (2, 0, 0), "torch2.1.0.dev may changed DDP's attribute.")  # type: ignore
     @unittest.skipIf(
         not torch.cuda.is_available() or torch.cuda.device_count() < 4,
         "need 4 gpus for testcase, DP 2 x EP 2",

--- a/atorch/atorch/tests/trainer_test.py
+++ b/atorch/atorch/tests/trainer_test.py
@@ -92,7 +92,7 @@ def run_atorch_trainer(test_args):
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="Skip cpu ut, only run on gpu.")
-@pytest.mark.skipif(torch_version() < (2, 0, 0), reason="AtorchTrainer need torch2.0 .")
+@pytest.mark.skipif(torch_version() < (2, 0, 0), reason="AtorchTrainer need torch2.0 .")  # type: ignore
 @pytest.mark.parametrize("atorch_opt", ["fsdp", "ddp"])
 @pytest.mark.parametrize("save_load_by_streaming", [True, False])
 @pytest.mark.parametrize("use_atorch_dataloader", [True, False])

--- a/atorch/atorch/trainer/atorch_trainer.py
+++ b/atorch/atorch/trainer/atorch_trainer.py
@@ -154,7 +154,7 @@ class AtorchTrainer:
 
         self.atorch_fsdp = args.atorch_opt == "fsdp"
 
-        if self.atorch_fsdp and torch_version() < (2, 0, 0):
+        if self.atorch_fsdp and torch_version() < (2, 0, 0):  # type: ignore
             raise ValueError("Greater than version 2.0 of PyTorch is necessary for FSDP.")
 
         if args.save_load_by_streaming and not self.atorch_fsdp:

--- a/atorch/atorch/utils/grad_scaler.py
+++ b/atorch/atorch/utils/grad_scaler.py
@@ -6,7 +6,7 @@ from torch.cuda.amp import GradScaler
 from atorch.common.log_utils import default_logger as logger
 from atorch.utils.version import torch_version
 
-if torch_version() >= (1, 12, 0):
+if torch_version() >= (1, 12, 0):  # type: ignore
     from torch.distributed.fsdp.sharded_grad_scaler import ShardedGradScaler
 else:
     from fairscale.optim.grad_scaler import ShardedGradScaler


### PR DESCRIPTION
See issue https://github.com/intelligent-machine-learning/dlrover/issues/1027, we update atorch mypy version to v0.981 to solve the problem of "Positional-only parameters are only supported in Python 3.8 and greater" during pre-commit.