### PR TITLE
Flash Checkpoint supports saving the checkpoint of moe optimizers.

### DIFF
--- a/dlrover/trainer/torch/flash_checkpoint/megatron_dist_ckpt.py
+++ b/dlrover/trainer/torch/flash_checkpoint/megatron_dist_ckpt.py
@@ -37,8 +37,8 @@ try:
         update_num_microbatches,
     )
     from megatron.core import mpu, tensor_parallel
-    from megatron.utils import print_rank_0, unwrap_model
     from megatron.optimizer.optimizer import ChainedOptimizer
+    from megatron.utils import print_rank_0, unwrap_model
 except ImportError:
     logger.warning("Please check the magatron.checkpointing exists.")
 
@@ -123,9 +123,7 @@ def save_checkpoint(
         and optimizer is not None
     ):
         if isinstance(optimizer, ChainedOptimizer):
-            dist_opter_state = get_chained_optimizer_parameter_state(
-                optimizer
-            )
+            dist_opter_state = get_chained_optimizer_parameter_state(optimizer)
         else:
             dist_opter_state = get_parameter_state(optimizer)
 
@@ -250,7 +248,7 @@ def get_parameter_state(dist_optimizer):
 def get_chained_optimizer_parameter_state(chained_optimizer):
     states = []
     for optimizer in chained_optimizer.chained_optimizers:
-        if hasattr(optimizer, 'get_parameter_state'):
+        if hasattr(optimizer, "get_parameter_state"):
             state_dict = get_parameter_state(optimizer)
             states.append(state_dict)
         else:
@@ -545,7 +543,7 @@ def load_chained_optimizer_parameter_state(chained_optimizer, states):
     from a list of states.
     """
     for idx, optimizer in enumerate(chained_optimizer.chained_optimizers):
-        if not hasattr(optimizer, 'load_parameter_state_from_state_dict'):
+        if not hasattr(optimizer, "load_parameter_state_from_state_dict"):
             continue
 
         state_dict = states[idx] if states else None


### PR DESCRIPTION
### What changes were proposed in this pull request?

The `save_checkpoint` in megatron_dist_ckpt.py can save the checkpoint of `ChainedOptimizer`.

### Why are the changes needed?

Fix #1030 

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

We can test it with the commit[ cb995d5](https://github.com/NVIDIA/Megatron-LM/commit/cb995d571faea19d01a1bf55ed0fd89523b9ce64) in Megatron-LM. I have tested it with 2 * A100 on a node.

```bash
dlrover-run --auto-config pretrain_gpt.py \
       --tensor-model-parallel-size 1 \
       --pipeline-model-parallel-size 1 \
       --sequence-parallel \
       --use-distributed-optimizer \
       --num-experts 2 \
       --expert-model-parallel-size 2 \
       --moe-grouped-gemm \
       --moe-router-load-balancing-type aux_loss  \
       --moe-router-topk 2 \
       --moe-aux-loss-coeff 1e-2 \
       --num-layers 48 \
       --hidden-size 1600 \
       --num-attention-heads 16 \
       --seq-length 1024 \
       --max-position-embeddings 1024 \
       --micro-batch-size 4 \
       --global-batch-size 8 \
       --train-iters 5000 \
       --lr-decay-iters 320000 \
       --save $CHECKPOINT_PATH \
       --load $CHECKPOINT_PATH \
       --data-path $DATA_PATH \
       --vocab-file $VOCAB_FILE \
       --merge-file $MERGE_FILE \
       --split 900,50,50 \
       --distributed-backend nccl \
       --lr 0.00015 \
       --min-lr 1.0e-5 \
       --lr-decay-style cosine \
       --weight-decay 1e-2 \
       --clip-grad 1.0 \
       --lr-warmup-fraction .01 \
       --log-interval 10 \
       --save-interval 50 \
       --eval-interval 1000 \
       --eval-iters 10 \
       --bf16
```