### PR TITLE
Set the shm as the memory in the job of nanogpt.

### DIFF
--- a/examples/pytorch/nanogpt/elastic_job.yaml
+++ b/examples/pytorch/nanogpt/elastic_job.yaml
@@ -12,11 +12,18 @@ spec:
       template:
         spec:
           restartPolicy: Never
+          volumes:
+          - name: dshm
+            emptyDir:
+              medium: Memory
           containers:
             - name: main
               # yamllint disable-line rule:line-length
               image: registry.cn-hangzhou.aliyuncs.com/intell-ai/dlrover:pytorch-example
               imagePullPolicy: Always
+              volumeMounts:
+              - mountPath: /dev/shm
+                name: dshm
               command:
                 - /bin/bash
                 - -c
@@ -33,3 +40,4 @@ spec:
                   cpu: "4"
                   memory: 16Gi
                   # nvidia.com/gpu: 1 # optional
+          

--- a/examples/pytorch/nanogpt/elastic_job.yaml
+++ b/examples/pytorch/nanogpt/elastic_job.yaml
@@ -13,17 +13,17 @@ spec:
         spec:
           restartPolicy: Never
           volumes:
-          - name: dshm
-            emptyDir:
-              medium: Memory
+            - name: dshm
+              emptyDir:
+                medium: Memory
           containers:
             - name: main
               # yamllint disable-line rule:line-length
               image: registry.cn-hangzhou.aliyuncs.com/intell-ai/dlrover:pytorch-example
               imagePullPolicy: Always
               volumeMounts:
-              - mountPath: /dev/shm
-                name: dshm
+                - mountPath: /dev/shm
+                  name: dshm
               command:
                 - /bin/bash
                 - -c
@@ -40,4 +40,3 @@ spec:
                   cpu: "4"
                   memory: 16Gi
                   # nvidia.com/gpu: 1 # optional
-          


### PR DESCRIPTION
### What changes were proposed in this pull request?

Set the shm as the memory.

### Why are the changes needed?

The default shm of docker is only 64MB which is not enough to save the nanogpt checkpoint.

```Text
The worker fails with {0: ProcessFailure(local_rank=0, pid=54, exitcode=-7, error_file='<N/A>', error_file_data={'message': '<NONE>'}, message='Signal 7 (SIGBUS) received by PID 54', timestamp=1711419181)}
```

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

`kubectl -n dlrover apply -f examples/pytorch/nanogpt/elastic_job.yaml`