### PR TITLE
Don't release the lock of shared memory before restarting workers.

### DIFF
--- a/dlrover/python/elastic_agent/torch/ckpt_saver.py
+++ b/dlrover/python/elastic_agent/torch/ckpt_saver.py
@@ -527,8 +527,6 @@ class AsyncCheckpointSaver(metaclass=ABCMeta):
 
     def reset_shared_memory(self):
         self._stop_commit = True
-        for lock in self._shm_locks:
-            lock.release()
         for shm_handler in self._shm_handlers:
             shm_handler.reset()
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Don't release the lock of shared memory in the `reset()` method.

### Why are the changes needed?

`Segment fault` will happen if the saver is saving the checkpoint from the shared memory to the storage and the training process is writing the shared memory.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

UT.