### PR TITLE
Skip TestLLama2Util on cpu

### DIFF
--- a/atorch/atorch/tests/rl_tests/rl_llama_model_util_test.py
+++ b/atorch/atorch/tests/rl_tests/rl_llama_model_util_test.py
@@ -9,6 +9,7 @@ from transformers.models.llama.modeling_llama import LlamaDecoderLayer
 from atorch.rl.model_utils.llama2_utils import get_llama2_params_offsets, move_weight_to_continuous_buffer
 
 
+@unittest.skipIf(not torch.cuda.is_available(), "Maybe failed on cpu")
 class TestLLama2Util(unittest.TestCase):
     def test_get_param_offset(self):
         config = LlamaConfig()


### PR DESCRIPTION
unittests of TestLLama2Util execute on gpu only
