### PR TITLE
set checkpoint config no_reentrant default as False

### DIFF
--- a/atorch/atorch/auto/opt_lib/checkpoint_optimization.py
+++ b/atorch/atorch/auto/opt_lib/checkpoint_optimization.py
@@ -1,4 +1,3 @@
-import inspect
 from collections.abc import MutableMapping
 from functools import partial
 from typing import Callable
@@ -140,19 +139,30 @@ class CheckpointOptimization(Optimization):
                         apply_activation_checkpointing, checkpoint_wrapper_fn=checkpoint_wrapper_fn
                     )
                 else:
-                    # check by signature of func
-                    params = inspect.signature(checkpoint_wrapper).parameters
-                    need_patch = params["checkpoint_impl"].default != CheckpointImpl.NO_REENTRANT
-
                     assert other_config is not None  # for mypy
-                    # default to `need_patch`
-                    no_reentrant = other_config.pop("no_reentrant", need_patch)
+                    # pytorch uses default None for use_reentrant parameter in checkpoint,
+                    # which is equivalent to reentrant. This parameter will become mandatory in torch 2.4.
+                    no_reentrant = other_config.pop("no_reentrant", None)
                     selective_offload = other_config.pop("selective_offload", None)
+                    if no_reentrant is None:
+                        # Used no_reentrant for checkpoint selective offload
+                        no_reentrant = selective_offload is not None
+                        logger.warning(
+                            "checkpoint config does not contains no_reentrant value, "
+                            "set no_reentrant=True as selective_offload is used"
+                            if selective_offload is not None
+                            else "set no_reentrant=False as default"
+                        )
+                    else:
+                        logger.info(f"checkpoint config contains no_reentrant={no_reentrant}")
                     checkpoint_impl = CheckpointImpl.NO_REENTRANT if no_reentrant else CheckpointImpl.REENTRANT
                     checkpoint_wrapper_fn_kwargs = {"checkpoint_impl": checkpoint_impl}
                     if selective_offload is not None:
                         if checkpoint_impl == CheckpointImpl.REENTRANT:
-                            raise ValueError("selective offloading don't support `CheckpointImpl.REENTRANT`")
+                            raise ValueError(
+                                "selective offloading don't support `CheckpointImpl.REENTRANT`, "
+                                "requires no_reentrant=False in checkpoint config"
+                            )
                         if "offload_args" not in selective_offload or "num_layers" not in selective_offload:
                             raise ValueError("`offload_args` or `num_layers` is not passed")
 

--- a/atorch/atorch/tests/common_tests/selective_checkpoint_test.py
+++ b/atorch/atorch/tests/common_tests/selective_checkpoint_test.py
@@ -41,10 +41,9 @@ def boot_test(rank, number_layers, pipes, mode):
         "use_orig_params": True,
     }
     if mode == "origin":
-        checkpoint_config = LlamaDecoderLayer
-    elif mode == "new":
         checkpoint_config = {
             "wrap_class": LlamaDecoderLayer,
+            "no_reentrant": True,
         }
     elif mode == "offload":
         checkpoint_config = {
@@ -123,7 +122,7 @@ class SelectiveCheckpointTest(unittest.TestCase):
             return result
 
         result = {}
-        for ckpt_mode in ["origin", "new", "offload"]:
+        for ckpt_mode in ["origin", "offload"]:
             result[ckpt_mode] = run_inner(ckpt_mode)
         for k in result:
             self.assertListEqual(result["origin"], result[k])

--- a/atorch/examples/auto_accelerate/README.md
+++ b/atorch/examples/auto_accelerate/README.md
@@ -12,7 +12,7 @@
 ## Usage
 
 ```
-train.py [-h] --model_type MODEL_TYPE [--datasize DATASIZE] [--epoch EPOCH] [--hidden_size HIDDEN_SIZE] [--head_num HEAD_NUM] [--layer_num LAYER_NUM] [--seq_length SEQ_LENGTH] [--batchsize BATCHSIZE] [--distributed] [--user_created_dataloader] [--load_strategy] [--optim_grouped_params] [--log_interval LOG_INTERVAL] [--use_fsdp] [--use_amp] [--use_checkpointing] [--use_module_replace]
+train.py [-h] --model_type MODEL_TYPE [--datasize DATASIZE] [--epoch EPOCH] [--hidden_size HIDDEN_SIZE] [--head_num HEAD_NUM] [--layer_num LAYER_NUM] [--seq_length SEQ_LENGTH] [--batchsize BATCHSIZE] [--distributed] [--user_created_dataloader] [--load_strategy] [--optim_grouped_params] [--log_interval LOG_INTERVAL] [--use_fsdp] [--use_amp] [--use_checkpointing] [--use_module_replace] [--use_fp8]
 ```
 
 model_type: toy, gpt2, or llama
@@ -40,6 +40,7 @@ Optional args:
 + use_amp: if set, add amp_native optimization method in load_strategy. Default False.
 + use_checkpointing: if set, add checkpoint optimization method in load_strategy. Default False.
 + use_module_replace: if set, add module_replace optimization method in load_strategy. Default False.
++ use_fp8: if set, use fp8 for nn.Linear op if gpu sm >= 8.9. Default False.
 
 To launch distributed training, such as 8 process per node training for llama,  run:
 

--- a/atorch/examples/auto_accelerate/train.py
+++ b/atorch/examples/auto_accelerate/train.py
@@ -123,7 +123,8 @@ def train(args):
         # checkpoint
         if args.use_checkpointing:
             checkpoint_modules = (get_module_type(model_type),)
-            strategy.append(("checkpoint", checkpoint_modules))
+            checkpoint_config = {"wrap_class": checkpoint_modules, "no_reentrant": True}
+            strategy.append(("checkpoint", checkpoint_config))
         # fp8
         if args.use_fp8:
             if model_type == ModelType.LLAMA:

--- a/atorch/examples/llama2/fsdp_llama2.py
+++ b/atorch/examples/llama2/fsdp_llama2.py
@@ -204,7 +204,8 @@ def main():
     elif args.precision == "bf16":
         strategy.append(("half", "bf16"))
     if args.gradient_checkpointing:
-        strategy.append(("checkpoint", (LlamaDecoderLayer,)))
+        checkpoint_config = {"wrap_class": (LlamaDecoderLayer,), "no_reentrant": True}
+        strategy.append(("checkpoint", checkpoint_config))
     if args.fp8:
         if args.peft_type is not None:
             logger.warning("fp8 ignored as fp8 for lora training is not implemented yet.")


### PR DESCRIPTION
### What changes were proposed in this pull request?
As pytorch keeps use_reentrant default as None, and will make it a mandate parameter in 2.4, ATorch also set no_reentrant default as False.

Please describe the changes you have made or proposed in this pull request.

### Why are the changes needed?

Explain the purpose or motivation behind these changes. What problem are you trying to solve?

### Does this PR introduce any user-facing change?

Specify whether this pull request introduces any changes that users will directly interact with or notice.

### How was this patch tested?

Detail the testing process you have undertaken to ensure the changes in this pull request are valid and working as intended.
