### PR TITLE
Sort the ranks of nodes by the switches.

### DIFF
--- a/dlrover/python/common/grpc.py
+++ b/dlrover/python/common/grpc.py
@@ -326,22 +326,27 @@ class RendezvousRequest(Message):
     rdzv_name: str = ""
 
 
+@dataclass
 class CommWorldRequest(RendezvousRequest):
     pass
 
 
+@dataclass
 class JoinRendezvousRequest(RendezvousRequest):
-    pass
+    node_ip: str = ""  # The IP of node where the pod is located.
 
 
+@dataclass
 class WaitingNodeNumRequest(RendezvousRequest):
     pass
 
 
+@dataclass
 class NetworkReadyRequest(Message):
     pass
 
 
+@dataclass
 class StragglerExistRequest(Message):
     pass
 

--- a/dlrover/python/elastic_agent/master_client.py
+++ b/dlrover/python/elastic_agent/master_client.py
@@ -77,10 +77,9 @@ class MasterClient(Singleton):
         self._stub = elastic_training_pb2_grpc.MasterStub(self._channel)
         self._node_id = node_id
         self._node_type = node_type
-        self._host = os.getenv("POD_IP", "localhost")
+        self._node_ip = os.getenv("NODE_IP", "")
         self._worker_local_process_id = int(os.getenv("LOCAL_RANK", 0))
         self._ddp_server_port = self.find_free_port()
-        self._host_name = os.getenv("POD_NAME", "")
 
     def __del__(self):
         if self._channel:
@@ -314,6 +313,7 @@ class MasterClient(Singleton):
             node_id=node_rank,
             local_world_size=local_world_size,
             rdzv_name=rdzv_name,
+            node_ip=self._node_ip,
         )
         result: grpc.RendezvousState = self._get(request)
         return result.round

--- a/dlrover/python/master/elastic_training/net_topology.py
+++ b/dlrover/python/master/elastic_training/net_topology.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 
 from abc import ABCMeta, abstractmethod
+from collections import OrderedDict
 from dataclasses import dataclass
 from typing import Dict, List, Tuple
 
@@ -64,7 +65,7 @@ class DpTopologySorter(TopologySorter):
             asw_nodes.setdefault(meta.asw, [])
             asw_nodes[meta.asw].append(meta)
 
-        sorted_nodes: Dict[int, NodeTopologyMeta] = {}
+        sorted_nodes: Dict[int, NodeTopologyMeta] = OrderedDict()
         asw0_nodes = asw_nodes.pop(rank0_asw, [])
         for node_meta in asw0_nodes:
             sorted_nodes[node_meta.node_rank] = node_meta

--- a/dlrover/python/master/elastic_training/net_topology.py
+++ b/dlrover/python/master/elastic_training/net_topology.py
@@ -1,0 +1,75 @@
+# Copyright 2024 The DLRover Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from abc import ABCMeta, abstractmethod
+from dataclasses import dataclass
+from typing import Dict, List, Tuple
+
+
+@dataclass
+class NodeTopologyMeta(object):
+    node_rank: int = 0
+    process_num: int = 0
+    node_ip: str = ""
+    asw: str = ""
+    psw: str = ""
+
+
+class TopologyQuerier(metaclass=ABCMeta):
+    @abstractmethod
+    def query(self, node_ip) -> Tuple[str, str]:
+        """Query the asw and psw id of a node by the IP."""
+        pass
+
+
+class TopologySorter(metaclass=ABCMeta):
+    @abstractmethod
+    def sort(
+        self, nodes: Dict[int, NodeTopologyMeta]
+    ) -> Dict[int, NodeTopologyMeta]:
+        """Query the asw and psw id of a node by the IP."""
+        pass
+
+
+class DefaultTopologyQuerier(TopologyQuerier):
+    def query(self, node_ip) -> Tuple[str, str]:
+        return "", ""
+
+
+class DpTopologySorter(TopologySorter):
+    """
+    The sorter places the nodes under an asw (access switch) together in
+    the list of nodes. In allreduce communication, the communication packets
+    between nodes with continous ranks under an asw will not pass the psw.
+
+    """
+
+    def sort(
+        self, nodes: Dict[int, NodeTopologyMeta]
+    ) -> Dict[int, NodeTopologyMeta]:
+        asw_nodes: Dict[str, List[NodeTopologyMeta]] = {}
+        rank0_node = next(iter(nodes.values()))
+        rank0_asw = rank0_node.asw
+        for _, meta in nodes.items():
+            asw_nodes.setdefault(meta.asw, [])
+            asw_nodes[meta.asw].append(meta)
+
+        sorted_nodes: Dict[int, NodeTopologyMeta] = {}
+        asw0_nodes = asw_nodes.pop(rank0_asw, [])
+        for node_meta in asw0_nodes:
+            sorted_nodes[node_meta.node_rank] = node_meta
+
+        for node_metas in asw_nodes.values():
+            for node_meta in node_metas:
+                sorted_nodes[node_meta.node_rank] = node_meta
+        return sorted_nodes

--- a/dlrover/python/master/elastic_training/net_topology.py
+++ b/dlrover/python/master/elastic_training/net_topology.py
@@ -50,7 +50,7 @@ class DpTopologySorter(TopologySorter):
     """
     The sorter places the nodes under an asw (access switch) together in
     the list of nodes. In allreduce communication, the communication packets
-    between nodes with continous ranks under an asw will not pass the psw.
+    between nodes with continuous ranks under an asw will not pass the psw.
 
     """
 

--- a/dlrover/python/master/elastic_training/rdzv_manager.py
+++ b/dlrover/python/master/elastic_training/rdzv_manager.py
@@ -14,6 +14,7 @@
 import math
 import time
 from abc import ABCMeta, abstractmethod
+from collections import OrderedDict
 from threading import Lock
 from typing import Dict, List, Tuple
 
@@ -61,7 +62,7 @@ class RendezvousManager(metaclass=ABCMeta):
         self._released_workers = []
         # key is the node rank.
         self._waiting_nodes: Dict[int, NodeTopologyMeta] = {}
-        self._rdzv_nodes: Dict[int, NodeTopologyMeta] = {}
+        self._rdzv_nodes: Dict[int, NodeTopologyMeta] = OrderedDict()
         self._lastcall_time = 0
         self._rdzv_params = RendezvousParameters(0, 0)
         self._rdzv_round = 0

--- a/dlrover/python/master/elastic_training/rdzv_manager.py
+++ b/dlrover/python/master/elastic_training/rdzv_manager.py
@@ -326,9 +326,11 @@ class ElasticTrainingRendezvousManager(RendezvousManager):
                 rdzv_completed = self._check_rdzv_completed()
                 if rdzv_completed:
                     self._rdzv_round += 1
-                    self._rdzv_node = self._topology_sorter.sort(
+                    self._rdzv_nodes = self._topology_sorter.sort(
                         self._rdzv_nodes
                     )
+                    ranks = list(self._rdzv_nodes.keys())
+                    logger.info(f"Node ranks are {ranks}.")
             return self._rdzv_round, 0, self._rdzv_nodes
 
     def report_network_check_result(self, node_id, normal, elapsed_time):

--- a/dlrover/python/master/servicer.py
+++ b/dlrover/python/master/servicer.py
@@ -234,7 +234,7 @@ class MasterServicer(elastic_training_pb2_grpc.MasterServicer):
     def _join_rendezvous(self, request: grpc.JoinRendezvousRequest):
         rdzv_manager = self._rdzv_managers[request.rdzv_name]
         round = rdzv_manager.join_rendezvous(
-            request.node_id, request.node_ip, request.local_world_size
+            request.node_id, request.local_world_size, request.node_ip
         )
         if request.rdzv_name == RendezvousName.NETWORK_CHECK:
             # The waiting node in the training rdzv should clear if

--- a/dlrover/python/tests/test_net_topology.py
+++ b/dlrover/python/tests/test_net_topology.py
@@ -1,0 +1,51 @@
+# Copyright 2024 The DLRover Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from typing import Dict
+
+from dlrover.python.master.elastic_training.net_topology import (
+    DefaultTopologyQuerier,
+    DpTopologySorter,
+    NodeTopologyMeta,
+)
+
+
+class NetTopologyTest(unittest.TestCase):
+    def setUp(self) -> None:
+        pass
+
+    def test_dp_topology_sorter(self):
+        sw_querier = DefaultTopologyQuerier()
+        sorter = DpTopologySorter()
+        nodes: Dict[int, NodeTopologyMeta] = {}
+        node_num = 10
+        for i in range(node_num):
+            node_ip = f"192.168.0.{i}"
+            asw, psw = sw_querier.query(node_ip)
+            node = NodeTopologyMeta(
+                node_rank=i, process_num=8, node_ip=node_ip, asw=asw, psw=psw
+            )
+            nodes[i] = node
+        sorted_nodes = sorter.sort(nodes)
+        node_ranks = list(sorted_nodes.keys())
+        self.assertListEqual(node_ranks, list(range(node_num)))
+
+        for node in nodes.values():
+            asw_index = node.node_rank % 3
+            node.asw = f"asw-{asw_index}"
+
+        sorted_nodes = sorter.sort(nodes)
+        node_ranks = list(sorted_nodes.keys())
+        expected_ranks = [0, 3, 6, 9, 1, 4, 7, 2, 5, 8]
+        self.assertListEqual(node_ranks, expected_ranks)

--- a/dlrover/python/tests/test_rdzv_manager.py
+++ b/dlrover/python/tests/test_rdzv_manager.py
@@ -78,7 +78,7 @@ class ElasticTrainingRendezvousManagerTest(unittest.TestCase):
         self.assertEqual(round, 1)
         self.assertEqual(len(rdzv_manager._waiting_nodes), 0)
         self.assertEqual(len(rdzv_manager._rdzv_nodes), 3)
-        self.assertDictEqual(world, {0: 8, 1: 8, 2: 8})
+        self.assertListEqual(list(world.keys()), [0, 1, 2])
 
     def test_min_nodes(self):
         rdzv_manager = ElasticTrainingRendezvousManager()
@@ -100,7 +100,7 @@ class ElasticTrainingRendezvousManagerTest(unittest.TestCase):
         self.assertEqual(round, 1)
         self.assertEqual(len(rdzv_manager._waiting_nodes), 0)
         self.assertEqual(len(rdzv_manager._rdzv_nodes), 2)
-        self.assertDictEqual(world, {0: 8, 1: 8})
+        self.assertListEqual(list(world.keys()), [0, 1])
 
     def test_min_nodes_with_unit(self):
         rdzv_manager = ElasticTrainingRendezvousManager()
@@ -117,8 +117,7 @@ class ElasticTrainingRendezvousManagerTest(unittest.TestCase):
         self.assertEqual(round, 1)
         self.assertEqual(len(rdzv_manager._waiting_nodes), 2)
         self.assertEqual(len(rdzv_manager._rdzv_nodes), 8)
-        expected_world = {i: 8 for i in range(8)}
-        self.assertDictEqual(expected_world, world)
+        self.assertListEqual(list(world.keys()), list(range(8)))
         round, _, world = rdzv_manager.get_comm_world(9)
         self.assertEqual(round, 1)
         self.assertFalse(9 in world)
@@ -163,11 +162,11 @@ class NetworkCheckRendezvousManagerTest(unittest.TestCase):
         self.assertEqual(group, 0)
         self.assertEqual(len(rdzv_manager._waiting_nodes), 0)
         self.assertEqual(len(rdzv_manager._rdzv_nodes), 4)
-        self.assertDictEqual(world, {0: 8, 1: 8})
+        self.assertListEqual(list(world.keys()), [0, 1])
         self.assertEqual(group, 0)
         round, group, world = rdzv_manager.get_comm_world(2)
         self.assertEqual(round, 1)
-        self.assertDictEqual(world, {2: 8, 3: 8})
+        self.assertListEqual(list(world.keys()), [2, 3])
         self.assertEqual(group, 1)
         for i in range(3):
             rdzv_manager.report_network_check_result(i, True, 0.0)
@@ -178,10 +177,10 @@ class NetworkCheckRendezvousManagerTest(unittest.TestCase):
         self.assertEqual(round, 1)
         round, group, world = rdzv_manager.get_comm_world(0)
         self.assertEqual(round, 2)
-        self.assertDictEqual(world, {3: 8, 0: 8})
+        self.assertListEqual(list(world.keys()), [0, 3])
         round, group, world = rdzv_manager.get_comm_world(1)
         self.assertEqual(round, 2)
-        self.assertDictEqual(world, {1: 8, 2: 8})
+        self.assertListEqual(list(world.keys()), [1, 2])
         self.assertEqual(group, 1)
         success, _ = rdzv_manager.check_fault_node()
         self.assertFalse(success)
@@ -191,7 +190,7 @@ class NetworkCheckRendezvousManagerTest(unittest.TestCase):
         self.assertEqual(round, 2)
         round, group, world = rdzv_manager.get_comm_world(3)
         self.assertEqual(round, 3)
-        self.assertDictEqual(world, {2: 8, 3: 8})
+        self.assertListEqual(list(world.keys()), [2, 3])
         _, reason = rdzv_manager.check_fault_node()
         self.assertEqual(reason, NetworkFailureReason.WAITING_NODE)
         for i in range(3):
@@ -208,7 +207,7 @@ class NetworkCheckRendezvousManagerTest(unittest.TestCase):
         self.assertEqual(round, 0)
         round, _, world = rdzv_manager.get_comm_world(0)
         self.assertEqual(round, 1)
-        self.assertDictEqual(world, {0: 8})
+        self.assertListEqual(list(world.keys()), [0])
         rdzv_manager.report_network_check_result(0, True, 0.0)
         nodes, _ = rdzv_manager.check_fault_node()
         self.assertListEqual(nodes, [])
@@ -228,7 +227,7 @@ class NetworkCheckRendezvousManagerTest(unittest.TestCase):
         self.assertEqual(group, 0)
         round, group, world = rdzv_manager.get_comm_world(2)
         self.assertEqual(round, 1)
-        self.assertDictEqual(world, {2: 8, 3: 8})
+        self.assertListEqual(list(world.keys()), [2, 3])
         self.assertEqual(group, 1)
         for i in range(4):
             rdzv_manager.report_network_check_result(i, True, 5.0)
@@ -242,7 +241,7 @@ class NetworkCheckRendezvousManagerTest(unittest.TestCase):
         self.assertEqual(round, 1)
         round, group, world = rdzv_manager.get_comm_world(5)
         self.assertEqual(round, 2)
-        self.assertDictEqual(world, {0: 8, 5: 8})
+        self.assertListEqual(list(world.keys()), [0, 5])
 
         for i in [1, 2, 3, 4]:
             rdzv_manager.report_network_check_result(i, True, 5.0)
@@ -263,7 +262,7 @@ class NetworkCheckRendezvousManagerTest(unittest.TestCase):
         self.assertEqual(group, 0)
         round, group, world = rdzv_manager.get_comm_world(2)
         self.assertEqual(round, 1)
-        self.assertDictEqual(world, {2: 8, 3: 8, 4: 8})
+        self.assertListEqual(list(world.keys()), [2, 3, 4])
         self.assertEqual(group, 1)
         for i in range(2):
             rdzv_manager.report_network_check_result(i, True, 15.0)
@@ -277,7 +276,7 @@ class NetworkCheckRendezvousManagerTest(unittest.TestCase):
         self.assertEqual(round, 1)
         round, group, world = rdzv_manager.get_comm_world(1)
         self.assertEqual(round, 2)
-        self.assertDictEqual(world, {1: 8, 2: 8})
+        self.assertListEqual(list(world.keys()), [2, 1])
 
         for i in [1, 2]:
             rdzv_manager.report_network_check_result(i, True, 15.0)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Sort the ranks of nodes by the switches.

### Why are the changes needed?

In a DDP job, the communication packets between nodes with continuous ranks under an asw will not pass the psw.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

UT.