### PR TITLE
Job master does not wait for workers if there are exited workers.

### DIFF
--- a/dlrover/python/master/node/dist_job_manager.py
+++ b/dlrover/python/master/node/dist_job_manager.py
@@ -816,7 +816,7 @@ class DistributedJobManager(JobManager):
 
     def pend_without_workers(self):
         """Check whether to wait for evicted workers."""
-        if self._worker_manager.has_failed_worker():
+        if self._worker_manager.has_exited_worker():
             return False
         elif self._worker_manager.wait_worker_restart():
             return True

--- a/dlrover/python/master/node/worker.py
+++ b/dlrover/python/master/node/worker.py
@@ -264,10 +264,13 @@ class WorkerManager(TrainingNodeManager):
                     plan.merge(p)
         return plan
 
-    def has_failed_worker(self):
-        """Check whether there is failed worker except evicted workers."""
+    def has_exited_worker(self):
+        """Check whether there is exited worker except evicted workers."""
         for worker in self._nodes.values():
-            if worker.exit_reason == NodeExitReason.FATAL_ERROR:
+            if (
+                worker.exit_reason == NodeExitReason.FATAL_ERROR
+                or worker.status == NodeStatus.SUCCEEDED
+            ):
                 return True
         return False
 

--- a/dlrover/python/tests/test_worker_manager.py
+++ b/dlrover/python/tests/test_worker_manager.py
@@ -157,13 +157,17 @@ class WorkerManagerTest(unittest.TestCase):
         for node in worker_manager._nodes.values():
             node.status = NodeStatus.FAILED
             node.exit_reason = NodeExitReason.FATAL_ERROR
-        failed = worker_manager.has_exited_worker()
-        self.assertTrue(failed)
+        exited = worker_manager.has_exited_worker()
+        self.assertTrue(exited)
 
         for node in worker_manager._nodes.values():
             node.exit_reason = NodeExitReason.KILLED
-        failed = worker_manager.has_exited_worker()
-        self.assertFalse(failed)
+        exited = worker_manager.has_exited_worker()
+        self.assertFalse(exited)
+
+        worker_manager._nodes[0].status = NodeStatus.SUCCEEDED
+        exited = worker_manager.has_exited_worker()
+        self.assertTrue(exited)
 
         wait = worker_manager.wait_worker_restart()
         self.assertTrue(wait)

--- a/dlrover/python/tests/test_worker_manager.py
+++ b/dlrover/python/tests/test_worker_manager.py
@@ -157,12 +157,12 @@ class WorkerManagerTest(unittest.TestCase):
         for node in worker_manager._nodes.values():
             node.status = NodeStatus.FAILED
             node.exit_reason = NodeExitReason.FATAL_ERROR
-        failed = worker_manager.has_failed_worker()
+        failed = worker_manager.has_exited_worker()
         self.assertTrue(failed)
 
         for node in worker_manager._nodes.values():
             node.exit_reason = NodeExitReason.KILLED
-        failed = worker_manager.has_failed_worker()
+        failed = worker_manager.has_exited_worker()
         self.assertFalse(failed)
 
         wait = worker_manager.wait_worker_restart()


### PR DESCRIPTION
### What changes were proposed in this pull request?

The job master does not wait for workers if there are exited workers.

### Why are the changes needed?

Fix #1086 

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

UT.