### PR TITLE
Remove empty.proto in the elastic_training.proto

### DIFF
--- a/dlrover/proto/elastic_training.proto
+++ b/dlrover/proto/elastic_training.proto
@@ -2,8 +2,6 @@ syntax = "proto3";
 
 package elastic;
 
-import "google/protobuf/empty.proto";
-
 enum TaskType {
   NONE = 0;
   TRAINING = 1;

--- a/dlrover/trainer/torch/elastic_run.py
+++ b/dlrover/trainer/torch/elastic_run.py
@@ -300,6 +300,10 @@ def _elastic_config_from_args(
         args, "save_at_breakpoint", False
     )
     elastic_config.auto_configure_params()
+    elastic_config.rdzv_backend = "dlrover-master"
+    elastic_config.rdzv_endpoint = ""
+    join_timeout = elastic_config.rdzv_configs.get("join_timeout", 600)
+    elastic_config.rdzv_configs["timeout"] = join_timeout
     return elastic_config, cmd, cmd_args
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Remove empty.proto in the elastic_training.proto because there is no uasge of  empty.proto.

### Why are the changes needed?

Simplify codes.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

UT.