### PR TITLE
Polish the log of executing matmul ops.

### DIFF
--- a/dlrover/trainer/torch/node_check/utils.py
+++ b/dlrover/trainer/torch/node_check/utils.py
@@ -40,8 +40,9 @@ def log_execution_time(func):
         func(*args, **kwargs)
         t = round(time.time() - start, 2)
         local_rank = int(os.environ["LOCAL_RANK"])
+        func_name = func.__name__
         logger.info(
-            f"Time to execute {func} on local rank {local_rank} is {t}."
+            f"Time to execute {func_name} on local rank {local_rank} is {t}s."
         )
 
     return wrapper


### PR DESCRIPTION
### What changes were proposed in this pull request?

Polish the log of executing matmul ops.

### Why are the changes needed?

The log is not clear like

`Time to execute <function matmul at 0x7fc3ae448280> on local rank 0 is 0.01.`

### Does this PR introduce any user-facing change?

No.
### How was this patch tested?

UT.