### PR TITLE
Ignore pod deleted event if pod failover is already done by k8s

### DIFF
--- a/dlrover/python/common/constants.py
+++ b/dlrover/python/common/constants.py
@@ -79,8 +79,12 @@ class NodeStatus(object):
 
 
 class NodeEventType(object):
+    """Notice: the type here is equal to the pod event type by k8s"""
+
+    ADDED = "ADDED"
     MODIFIED = "MODIFIED"
     DELETED = "DELETED"
+    ERROR = "ERROR"
 
 
 class NodeExitReason(object):

--- a/dlrover/python/master/watcher/k8s_watcher.py
+++ b/dlrover/python/master/watcher/k8s_watcher.py
@@ -20,10 +20,10 @@ from dlrover.python.common.constants import (
     ElasticJobApi,
     ElasticJobLabel,
     ExitCode,
+    NodeEventType,
     NodeExitReason,
     NodeStatus,
     NodeType,
-    NodeEventType,
     ScalePlanLabel,
 )
 from dlrover.python.common.log import default_logger as logger
@@ -110,11 +110,14 @@ def _convert_pod_event_to_node_event(event, pod_list):
     # the deleted pod have already been successfully recovered
     if evt_type == NodeEventType.DELETED:
         pod_labels = _get_pod_unique_labels(job_name, pod_type, rank)
-        any_existed_running_pod = any(k8s_util.is_target_labels_equal(
-            pod_labels, pod.metadata.labels) for pod in pod_list)
+        any_existed_running_pod = any(
+            k8s_util.is_target_labels_equal(pod_labels, pod.metadata.labels)
+            for pod in pod_list
+        )
         if any_existed_running_pod:
-            logger.info(f"Skip deleted event for pod with labels :"
-                        f" {pod_labels}.")
+            logger.info(
+                f"Skip deleted event for pod with labels :" f" {pod_labels}."
+            )
             return None
 
     restart = _verify_restarting_training(evt_obj)
@@ -198,8 +201,7 @@ class PodWatcher(NodeWatcher):
                 timeout_seconds=60,
             )
             for event in stream:
-                node_event = _convert_pod_event_to_node_event(
-                    event, pod_list)
+                node_event = _convert_pod_event_to_node_event(event, pod_list)
                 if not node_event:
                     continue
                 yield node_event

--- a/dlrover/python/tests/test_k8s_util.py
+++ b/dlrover/python/tests/test_k8s_util.py
@@ -17,8 +17,13 @@ import dlrover.python.util.k8s_util as ku
 from dlrover.python.common.constants import ElasticJobLabel, NodeType
 
 
-class KubernetesUtilTest(unittest.TestCase):
-    def test_kubernetes_label_selector_transformation(self):
+class K8sUtilTest(unittest.TestCase):
+    """
+    This is a test for testing util for k8s.(To distunguish with
+    'test_k8s_utils')
+    """
+
+    def test_k8s_label_selector_transformation(self):
         master_labels = {
             ElasticJobLabel.JOB_KEY: "ut-test",
             ElasticJobLabel.REPLICA_TYPE_KEY: NodeType.DLROVER_MASTER,
@@ -31,3 +36,21 @@ class KubernetesUtilTest(unittest.TestCase):
 
         dict_result = ku.gen_dict_from_k8s_label_selector(selector_result)
         self.assertEqual(master_labels, dict_result)
+
+    def test_is_target_labels_equal(self):
+        target_labels = {"k1": "1"}
+        source_labels = {"k1": "1", "k2": "v2", "k3": "v3"}
+        self.assertTrue(
+            ku.is_target_labels_equal(target_labels, source_labels))
+
+        target_labels = {"k1": "1", "k2": "v3"}
+        self.assertFalse(
+            ku.is_target_labels_equal(target_labels, source_labels))
+
+        target_labels = {"k2": "v2", "k1": "1"}
+        self.assertTrue(
+            ku.is_target_labels_equal(target_labels, source_labels))
+
+        target_labels = {"k2": "v2", "k1": 1}
+        self.assertTrue(
+            ku.is_target_labels_equal(target_labels, source_labels))

--- a/dlrover/python/tests/test_k8s_util.py
+++ b/dlrover/python/tests/test_k8s_util.py
@@ -41,16 +41,20 @@ class K8sUtilTest(unittest.TestCase):
         target_labels = {"k1": "1"}
         source_labels = {"k1": "1", "k2": "v2", "k3": "v3"}
         self.assertTrue(
-            ku.is_target_labels_equal(target_labels, source_labels))
+            ku.is_target_labels_equal(target_labels, source_labels)
+        )
 
         target_labels = {"k1": "1", "k2": "v3"}
         self.assertFalse(
-            ku.is_target_labels_equal(target_labels, source_labels))
+            ku.is_target_labels_equal(target_labels, source_labels)
+        )
 
         target_labels = {"k2": "v2", "k1": "1"}
         self.assertTrue(
-            ku.is_target_labels_equal(target_labels, source_labels))
+            ku.is_target_labels_equal(target_labels, source_labels)
+        )
 
         target_labels = {"k2": "v2", "k1": 1}
         self.assertTrue(
-            ku.is_target_labels_equal(target_labels, source_labels))
+            ku.is_target_labels_equal(target_labels, source_labels)
+        )

--- a/dlrover/python/tests/test_k8s_utils.py
+++ b/dlrover/python/tests/test_k8s_utils.py
@@ -26,6 +26,11 @@ from dlrover.python.tests.test_utils import create_pod, mock_k8s_client
 
 
 class KubernetesTest(unittest.TestCase):
+    """
+    This is a util for testing convenience.
+    (To distunguish with 'test_k8s_util')
+    """
+
     def setUp(self) -> None:
         mock_k8s_client()
 

--- a/dlrover/python/tests/test_k8s_watcher.py
+++ b/dlrover/python/tests/test_k8s_watcher.py
@@ -90,7 +90,7 @@ class PodWatcherTest(unittest.TestCase):
         self.assertEqual(node_event.node.config_resource.cpu, 1)
         self.assertEqual(node_event.node.config_resource.memory, 10240)
 
-    def test_convert_pod_deleted_event_to_node_event_with_duplicated_running_pod(
+    def test_convert_pod_deleted_event_to_node_event_with_existed_running_pod(
         self,
     ):
         # one of the mocked label must be the same with the one generated in

--- a/dlrover/python/util/k8s_util.py
+++ b/dlrover/python/util/k8s_util.py
@@ -31,3 +31,30 @@ def gen_dict_from_k8s_label_selector(label_selector):
         k: v
         for k, v in (item.split("=") for item in label_selector.split(","))
     }
+
+
+def is_target_labels_equal(target_labels: dict, source_labels: dict):
+    """
+    Whether the target labels exist in the labels source and are all equal.
+
+    Args:
+        target_labels (dict): Target labels.
+        source_labels (dict): Source labels.
+
+    e.g.
+    Return true if:
+    target_labels: {key1: value1, key2: value2}
+    source_labels: {key1: value1, key2: value2, key3: value3}
+
+    Return false if:
+    target_labels: {key1: value1, key2: value3}
+    source_labels: {key1: value1, key2: value2, key3: value3}
+    """
+
+    # all values to str for compatible
+    target_labels = {k: str(v) for k, v in target_labels.items()}
+    source_labels = {k: str(v) for k, v in source_labels.items()}
+
+    if all(target_labels[x] == source_labels[x] for x in target_labels):
+        return True
+    return False


### PR DESCRIPTION
### What changes were proposed in this pull request?

The creation failed pod might be retried by some k8s implementations. So DLRover should not recreate the pod under such circumstances.

### Why are the changes needed?

Ignore the delete event if the unique pod searched by labels is still running.

### Does this PR introduce any user-facing change?

Nope.

### How was this patch tested?

Unittest.
