### PR TITLE
optimize MODIFIED event with deletion info

### DIFF
--- a/dlrover/python/master/watcher/k8s_watcher.py
+++ b/dlrover/python/master/watcher/k8s_watcher.py
@@ -106,9 +106,15 @@ def _convert_pod_event_to_node_event(event, k8s_client):
     host_name = evt_obj.spec.node_name
     host_ip = evt_obj.status.host_ip
 
+    to_deleted_event = False
+    status = evt_obj.status.phase
+    if metadata.deletion_timestamp:
+        status = NodeStatus.DELETED
+        to_deleted_event = True
+
     # Skip deleted event of pod if the cluster has relaunched a new pod with
     # the same type and rank as the deleted pod.
-    if evt_type == NodeEventType.DELETED:
+    if evt_type == NodeEventType.DELETED or to_deleted_event:
         pod_labels_selector = k8s_util.gen_k8s_label_selector_from_dict(
             _get_pod_unique_labels(job_name, pod_type, rank)
         )
@@ -135,9 +141,6 @@ def _convert_pod_event_to_node_event(event, k8s_client):
         logger.info(f"{evt_obj.metadata.name} need to restart.")
 
     resource = _parse_container_resource(evt_obj.spec.containers[0])
-    status = evt_obj.status.phase
-    if metadata.deletion_timestamp:
-        status = NodeStatus.DELETED
 
     relaunch_count = int(metadata.labels[ElasticJobLabel.RELAUNCH_COUNT])
     node = Node(

--- a/dlrover/python/tests/test_k8s_watcher.py
+++ b/dlrover/python/tests/test_k8s_watcher.py
@@ -97,9 +97,25 @@ class PodWatcherTest(unittest.TestCase):
     ):
         # one of the mocked label must be the same with the one generated in
         # 'test_utils.py#mock_list_namespaced_pod'
+
+        # test DELETED event
         labels = _mock_pod_labels()
         pod = create_pod(labels)
         event_type = NodeEventType.DELETED
+        event = {"object": pod, "type": event_type}
+        self.assertIsNone(
+            _convert_pod_event_to_node_event(event, self.k8s_client)
+        )
+
+        # test MODIFIED event without deletion_timestamp
+        event_type = NodeEventType.MODIFIED
+        event = {"object": pod, "type": event_type}
+        self.assertIsNotNone(
+            _convert_pod_event_to_node_event(event, self.k8s_client)
+        )
+
+        # test MODIFIED event with deletion_timestamp
+        pod = create_pod(labels, True)
         event = {"object": pod, "type": event_type}
         self.assertIsNone(
             _convert_pod_event_to_node_event(event, self.k8s_client)

--- a/dlrover/python/tests/test_utils.py
+++ b/dlrover/python/tests/test_utils.py
@@ -137,7 +137,7 @@ class MockRayJobArgs(JobArgs):
         self.job_uuid = "11111"
 
 
-def create_pod(labels):
+def create_pod(labels, with_deletion_timestamp=False):
     status = client.V1PodStatus(
         container_statuses=[
             client.V1ContainerStatus(
@@ -177,6 +177,10 @@ def create_pod(labels):
         priority_class_name="high",
     )
 
+    deletion_timestamp = (
+        datetime.datetime.now() if with_deletion_timestamp else None
+    )
+
     pod = client.V1Pod(
         api_version="v1",
         kind="Pod",
@@ -185,6 +189,7 @@ def create_pod(labels):
             name="test-worker-0",
             labels=labels,
             creation_timestamp=datetime.datetime.now(),
+            deletion_timestamp=deletion_timestamp,
             annotations={},
         ),
         status=status,


### PR DESCRIPTION
### What changes were proposed in this pull request?

Keep optimizing watcher logic.

### Why are the changes needed?

To ignore redundant pod scaling, pod modified event also should be cared.

### Does this PR introduce any user-facing change?

Nope.

### How was this patch tested?

UT.
