### PR TITLE
Tune up the sleep interval to query the new rdzv.

### DIFF
--- a/dlrover/python/elastic_agent/torch/training.py
+++ b/dlrover/python/elastic_agent/torch/training.py
@@ -527,6 +527,9 @@ class ElasticTrainingAgent(LocalElasticAgent):
 
     def _initialize_workers(self, worker_group):
         start_pending = 0
+        pend_timeout = float(
+            self._config.rdzv_configs.get("pend_timeout", "inf")
+        )
         while True:
             try:
                 if self._config.network_check:
@@ -543,6 +546,8 @@ class ElasticTrainingAgent(LocalElasticAgent):
                         "agents to join the network-check rendezvous."
                     )
                 time.sleep(_DEFAULT_INTERVAL)
+                if time.time() - start_pending > pend_timeout:
+                    raise TimeoutError("Timeout to wait for new nodes.")
             else:
                 logger.info("Finish initializing workers.")
                 break

--- a/dlrover/python/elastic_agent/torch/training.py
+++ b/dlrover/python/elastic_agent/torch/training.py
@@ -266,11 +266,11 @@ class MasterRendezvousHandler(RendezvousHandler):
                 if self._node_rank in world:
                     break
                 else:
-                    logger.info(
-                        "The node is not in the world "
-                        "and waits for more nodes."
-                    )
                     if start_pending == 0:
+                        logger.info(
+                            "The node is not in the world "
+                            "and waits for more nodes."
+                        )
                         start_pending = time.time()
                     time.sleep(_DEFAULT_INTERVAL)
                     start_join = time.time()
@@ -526,6 +526,7 @@ class ElasticTrainingAgent(LocalElasticAgent):
         return workers
 
     def _initialize_workers(self, worker_group):
+        start_pending = 0
         while True:
             try:
                 if self._config.network_check:
@@ -535,12 +536,15 @@ class ElasticTrainingAgent(LocalElasticAgent):
                 # the PContext start_worker will overwrite the handler.
                 AsyncCheckpointSaver.register_signal_handler()
             except RendezvousOutSyncError:
-                logger.info(
-                    "Exit elastic-training rendezvous when there are "
-                    "agents to join the network-check rendezvous."
-                )
+                if start_pending == 0:
+                    start_pending = time.time()
+                    logger.info(
+                        "Exit elastic-training rendezvous when there are "
+                        "agents to join the network-check rendezvous."
+                    )
                 time.sleep(_DEFAULT_INTERVAL)
             else:
+                logger.info("Finish initializing workers.")
                 break
 
     @prof

--- a/dlrover/python/elastic_agent/torch/training.py
+++ b/dlrover/python/elastic_agent/torch/training.py
@@ -84,7 +84,7 @@ except (ModuleNotFoundError, ImportError):  # noqa: F841
 __all__ = ["launch_agent"]
 
 
-_DEFAULT_INTERVAL = 5
+_DEFAULT_INTERVAL = 15
 
 
 def _set_paral_config():
@@ -286,7 +286,7 @@ class MasterRendezvousHandler(RendezvousHandler):
                     err_msg, level=TrainingExceptionLevel.RDZV_ERROR
                 )
                 raise TimeoutError(err_msg)
-            time.sleep(3)
+            time.sleep(_DEFAULT_INTERVAL)
         rank = list(world.keys()).index(self._node_rank)
         world_size = len(world)
         logger.info(
@@ -539,6 +539,7 @@ class ElasticTrainingAgent(LocalElasticAgent):
                     "Exit elastic-training rendezvous when there are "
                     "agents to join the network-check rendezvous."
                 )
+                time.sleep(_DEFAULT_INTERVAL)
             else:
                 break
 

--- a/dlrover/python/tests/test_elastic_training_agent.py
+++ b/dlrover/python/tests/test_elastic_training_agent.py
@@ -191,7 +191,7 @@ class ElasticTrainingAgentTest(unittest.TestCase):
         )
         agent._config.network_check = False
         agent._config.rdzv_configs = {"pend_timeout": 0}
-        
+
         def _mock_rendezvous(self, *args):
             raise RendezvousOutSyncError("test")
 

--- a/dlrover/python/tests/test_elastic_training_agent.py
+++ b/dlrover/python/tests/test_elastic_training_agent.py
@@ -179,6 +179,26 @@ class ElasticTrainingAgentTest(unittest.TestCase):
         local_ip = _get_local_ip()
         self.assertEqual(local_ip, "127.0.0.1")
 
+    def test_initialize_worker(self):
+        node_id = 1
+        agent = ElasticTrainingAgent(
+            node_rank=node_id,
+            config=self.config,
+            entrypoint="python",
+            spec=self.spec,
+            start_method=self.config.start_method,
+            log_dir=self.config.log_dir,
+        )
+        agent._config.network_check = False
+        agent._config.rdzv_configs = {"pend_timeout": 0}
+        
+        def _mock_rendezvous(self, *args):
+            raise RendezvousOutSyncError("test")
+
+        agent._rendezvous = _mock_rendezvous
+        with self.assertRaises(TimeoutError):
+            agent._initialize_workers(agent._worker_group)
+
 
 class ElasticTrainingAgentRunTest(unittest.TestCase):
     def setUp(self) -> None:


### PR DESCRIPTION
### What changes were proposed in this pull request?

Tune up the sleep interval to 15s to query the new rdzv. 

### Why are the changes needed?

There are too much logs to wait for nodes.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

UT.