### PR TITLE
optimize rdzv logic during node relaunching

### DIFF
--- a/dlrover/python/elastic_agent/sharding/client.py
+++ b/dlrover/python/elastic_agent/sharding/client.py
@@ -159,6 +159,9 @@ class ShardingClient(object):
                 task_ids = list(self._pending_tasks.keys())
             for task_id in task_ids:
                 if record_count > 0:
+                    if task_id not in self._pending_tasks:
+                        continue
+
                     task = self._pending_tasks[task_id]
                     task_record_count = task.shard.end - task.shard.start
 

--- a/dlrover/python/master/elastic_training/rdzv_manager.py
+++ b/dlrover/python/master/elastic_training/rdzv_manager.py
@@ -99,7 +99,6 @@ class RendezvousManager(metaclass=ABCMeta):
                 f"Remove exited worker {node.name} from "
                 f"{self._name} rendezvous."
             )
-            self._waiting_nodes.pop(node.rank_index, None)
             self._has_node_failed = True
 
     def update_rdzv_params(
@@ -213,6 +212,11 @@ class RendezvousManager(metaclass=ABCMeta):
             if not self._waiting_nodes:
                 self._start_rdzv_ts = time.time()
             if node_rank in self._waiting_nodes:
+                logger.info(
+                    f"Skip rdzv joining for node : {node_rank} "
+                    "because the target node is no longer in the "
+                    "waiting nodes list."
+                )
                 return self._rdzv_round
             asw, psw = self._topology_querier.query(node_ip)
             meta = NodeTopologyMeta(

--- a/dlrover/python/tests/test_rdzv_manager.py
+++ b/dlrover/python/tests/test_rdzv_manager.py
@@ -136,7 +136,7 @@ class ElasticTrainingRendezvousManagerTest(unittest.TestCase):
         rdzv_manager.add_alive_node(node_11)
         rdzv_manager.remove_alive_node(node_10)
         rdzv_manager.remove_alive_node(node_11)
-        self.assertEqual(len(rdzv_manager._waiting_nodes), 2)
+        self.assertEqual(len(rdzv_manager._waiting_nodes), 4)
 
         # Test the number of waiting nodes is equal or
         # bigger than the node unit.

--- a/dlrover/python/tests/test_rdzv_manager.py
+++ b/dlrover/python/tests/test_rdzv_manager.py
@@ -107,8 +107,7 @@ class ElasticTrainingRendezvousManagerTest(unittest.TestCase):
         min_nodes = 8
         max_nodes = 12
         node_unit = 4
-        rdzv_manager.update_rdzv_params(
-            min_nodes, max_nodes, 0.1, node_unit)
+        rdzv_manager.update_rdzv_params(min_nodes, max_nodes, 0.1, node_unit)
 
         test_loop = 10
         for i in range(test_loop):
@@ -121,8 +120,9 @@ class ElasticTrainingRendezvousManagerTest(unittest.TestCase):
         time.sleep(0.2)
         round, _, world = rdzv_manager.get_comm_world(1)
         self.assertEqual(round, 1)
-        self.assertEqual(len(rdzv_manager._waiting_nodes),
-                         test_loop - min_nodes)
+        self.assertEqual(
+            len(rdzv_manager._waiting_nodes), test_loop - min_nodes
+        )
         self.assertEqual(len(rdzv_manager._rdzv_nodes), min_nodes)
         self.assertListEqual(list(world.keys()), list(range(min_nodes)))
         round, _, world = rdzv_manager.get_comm_world(9)
@@ -133,10 +133,12 @@ class ElasticTrainingRendezvousManagerTest(unittest.TestCase):
         self.assertEqual(rdzv_manager.num_nodes_waiting(), 0)
         rdzv_manager.join_rendezvous(10, 8)
         rdzv_manager.join_rendezvous(11, 8)
-        self.assertEqual(len(rdzv_manager._waiting_nodes),
-                         rdzv_manager.num_nodes_waiting())
         self.assertEqual(
-            rdzv_manager.num_nodes_waiting(), test_loop + 2 - min_nodes)
+            len(rdzv_manager._waiting_nodes), rdzv_manager.num_nodes_waiting()
+        )
+        self.assertEqual(
+            rdzv_manager.num_nodes_waiting(), test_loop + 2 - min_nodes
+        )
         node_10 = Node("worker", 10, name="worker-10")
         node_11 = Node("worker", 11, name="worker-11")
 

--- a/dlrover/python/tests/test_rdzv_manager.py
+++ b/dlrover/python/tests/test_rdzv_manager.py
@@ -143,7 +143,7 @@ class ElasticTrainingRendezvousManagerTest(unittest.TestCase):
         for i in range(12, 16):
             rdzv_manager.join_rendezvous(i, 8)
         num = rdzv_manager.num_nodes_waiting()
-        self.assertEqual(num, 6)
+        self.assertEqual(num, 8)
         rdzv_manager.clear_waiting_nodes()
         num = rdzv_manager.num_nodes_waiting()
         self.assertEqual(num, 0)


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. Optimize the logic in rdzv manager.
2. Optimize sharding service.
3. Optimize list watch.

### Why are the changes needed?

1. We can't remove the node from waiting list for the pod event may be delayed. The 'waiting_nodes' list object should be oriented towards final consistency. Therefore, directly updating the implementation of the object through passive messages is incomplete.
2. Increase the robustness of sharding service.
3. Make sure watch object can be closed.

### Does this PR introduce any user-facing change?

Nope.

### How was this patch tested?

UT.
