### PR TITLE
torch version compatible

### DIFF
--- a/dlrover/trainer/torch/utils.py
+++ b/dlrover/trainer/torch/utils.py
@@ -16,4 +16,4 @@ from packaging.version import Version
 
 
 def version_less_than_230():
-    return Version(torch.__version__) < Version("2.3.0")
+    return Version(torch.__version__) <= Version("2.2.2")


### PR DESCRIPTION
### What changes were proposed in this pull request?

torch version judge from 2.3.0 to 2.2.2

### Why are the changes needed?

there are some torch is build from source and version like `2.3.0a0+6ddf5cf85e.nv24.4`,`Version(2.3.0a0+6ddf5cf85e.nv24.4)<Version(2.3.0)`,but it is torch 2.3

### Does this PR introduce any user-facing change?

no
### How was this patch tested?

test with torch version=2.3.0a0+6ddf5cf85e.nv24.4