### PR TITLE
Improve training port conflict avoid

### DIFF
--- a/dlrover/python/common/grpc.py
+++ b/dlrover/python/common/grpc.py
@@ -107,6 +107,8 @@ def find_free_port_in_set(ports):
 def find_free_port_for_hccl(start=60000) -> int:
     cur_start = start
     end = start + 10000
+    if end > 65000:
+        end = 65000
     logger.info(f"Try to find available port for hccl from {start}")
     while True:
         try:

--- a/dlrover/python/common/grpc.py
+++ b/dlrover/python/common/grpc.py
@@ -104,8 +104,9 @@ def find_free_port_in_set(ports):
     raise RuntimeError(f"Fail to find a free port in {ports}")
 
 
-def find_free_port_for_hccl(start=60000, end=70000) -> int:
+def find_free_port_for_hccl(start=60000) -> int:
     cur_start = start
+    end = start + 10000
     logger.info(f"Try to find available port for hccl from {start}")
     while True:
         try:

--- a/dlrover/python/elastic_agent/torch/training.py
+++ b/dlrover/python/elastic_agent/torch/training.py
@@ -138,6 +138,7 @@ class ElasticLaunchConfig(LaunchConfig):
     network_check: bool = False
     comm_perf_test: bool = False
     node_unit: int = 1
+    training_port: int = 60000
     auto_config: bool = False
     auto_tunning: bool = False
     exclude_straggler: bool = False
@@ -736,8 +737,11 @@ class ElasticTrainingAgent(LocalElasticAgent):
 
     def sync_training_ports(self):
         logger.info(f"Accelerator: {self._config.accelerator}")
-        if self._config.accelerator == Accelerators.ASCEND_NPU:
-            start_port = 60000
+        if (
+            self._config.accelerator == Accelerators.ASCEND_NPU
+            and self._config.training_port > 0
+        ):
+            start_port = self._config.training_port
             port = 0
             logger.info("synchronize worker training ports...")
             count = 0

--- a/dlrover/python/master/node/training_node.py
+++ b/dlrover/python/master/node/training_node.py
@@ -392,6 +392,9 @@ class TrainingNodeConfigure:
                     next_check_port=self._next_check_node_training_port,
                 )
             self._recv_node_training_ports[node_id] = port
+            logger.info(
+                f"recv ports from: {self._recv_node_training_ports.keys()}"
+            )
             if len(self._recv_node_training_ports) == self._n_node:
                 min_port = 0
                 max_port = 0

--- a/dlrover/trainer/tests/torch/elastic_run_test.py
+++ b/dlrover/trainer/tests/torch/elastic_run_test.py
@@ -64,6 +64,8 @@ class ElasticRunTest(unittest.TestCase):
             "4",
             "--nnodes",
             "4",
+            "--training_port",
+            "1000",
             "test.py",
             "--batch_size",
             "16",
@@ -75,5 +77,6 @@ class ElasticRunTest(unittest.TestCase):
         self.assertTrue(config.auto_tunning)
         self.assertEqual(config.node_unit, 4)
         self.assertEqual(config.rdzv_configs["node_unit"], 4)
+        self.assertEqual(config.training_port, 1000)
         self.assertEqual(cmd, "/usr/local/bin/python")
         self.assertListEqual(cmd_args, ["-u", "test.py", "--batch_size", "16"])

--- a/dlrover/trainer/torch/elastic_run.py
+++ b/dlrover/trainer/torch/elastic_run.py
@@ -183,6 +183,14 @@ def parse_args(args):
         choices=[Accelerators.NVIDIA_GPU, Accelerators.ASCEND_NPU],
         help="The type of accelerator chip of the machine.",
     )
+    parser.add_argument(
+        "--training_port",
+        "--training-port",
+        type=int,
+        action=env,
+        default=60000,
+        help="The start of training port.",
+    )
     return parser.parse_args(args)
 
 
@@ -312,6 +320,7 @@ def _elastic_config_from_args(
         args, "exclude_straggler", False
     )
     elastic_config.set_node_unit(getattr(args, "node_unit", 1))
+    elastic_config.training_port = getattr(args, "training_port", 60000)
     elastic_config.save_at_breakpoint = getattr(
         args, "save_at_breakpoint", False
     )
@@ -342,7 +351,6 @@ def _check_to_use_dlrover_run(master_addr, max_nodes, timeout=120):
 def run(args):
     master_handler = None
     master_addr = os.getenv(NodeEnv.DLROVER_MASTER_ADDR, "")
-    use_dlrover_launch = False
     node_rank = env_utils.get_node_rank()
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
     job_name = os.getenv(NodeEnv.JOB_NAME, f"standalone_{timestamp}")


### PR DESCRIPTION
### What changes were proposed in this pull request?

We can configure the start port of the training job.

### Why are the changes needed?

1. It is more efficient to configure the start training port when the users know the available port range.
2. We can disable the port conflict-avoiding function.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

Unit test.