### PR TITLE
Fix heart beat for concurency.

### DIFF
--- a/dlrover/python/elastic_agent/master_client.py
+++ b/dlrover/python/elastic_agent/master_client.py
@@ -70,10 +70,13 @@ class MasterClient(Singleton):
     _instance_lock = threading.Lock()
 
     def __init__(self, master_addr, node_id, node_type, timeout=5):
+        logger.info(
+            f"Build master client with master_addr: {master_addr}, "
+            f"node_id: {node_id}, node_type: {node_type}."
+        )
         self._timeout = timeout
         self._master_addr = master_addr
         self._channel = grpc.build_channel(master_addr)
-        logger.info("dlrover master addr is %s" % self._master_addr)
         self._stub = elastic_training_pb2_grpc.MasterStub(self._channel)
         self._node_id = node_id
         self._node_type = node_type

--- a/dlrover/python/master/node/dist_job_manager.py
+++ b/dlrover/python/master/node/dist_job_manager.py
@@ -381,6 +381,7 @@ class DistributedJobManager(JobManager):
                             f"node: {node.id}-{node.name} "
                             f"because heartbeat time < create/start time."
                         )
+                        node.heartbeat_time = 0
                         continue
 
                     event_node = copy.deepcopy(node)

--- a/dlrover/python/master/node/dist_job_manager.py
+++ b/dlrover/python/master/node/dist_job_manager.py
@@ -379,7 +379,8 @@ class DistributedJobManager(JobManager):
                         logger.warning(
                             f"Skip dead node judgement for "
                             f"node: {node.id}-{node.name} "
-                            f"because heartbeat time < create/start time."
+                            f"because heartbeat time < create/start time. "
+                            f"Reset heartbeat time to 0."
                         )
                         node.heartbeat_time = 0
                         continue

--- a/dlrover/python/master/node/dist_job_manager.py
+++ b/dlrover/python/master/node/dist_job_manager.py
@@ -368,6 +368,7 @@ class DistributedJobManager(JobManager):
                 if (
                     node.heartbeat_time > 0
                     and now - node.heartbeat_time > window_interval
+                    and node.heartbeat_time > node.start_time
                     and node.status == NodeStatus.RUNNING
                 ):
                     event_node = copy.deepcopy(node)

--- a/dlrover/python/master/node/dist_job_manager.py
+++ b/dlrover/python/master/node/dist_job_manager.py
@@ -860,9 +860,7 @@ class DistributedJobManager(JobManager):
             node = self._job_nodes[node_type][node_id]
             if node.heartbeat_time == 0:
                 logger.info(
-                    f"Start receiving heartbeat from node {node.name}"
-                    f"({node_id})"
-                )
+                    f"Start receiving heartbeat from node {node.name}")
             node.heartbeat_time = timestamp
 
 

--- a/dlrover/python/master/node/job_manager.py
+++ b/dlrover/python/master/node/job_manager.py
@@ -11,6 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import threading
 from abc import ABCMeta, abstractclassmethod
 from typing import Dict
 
@@ -50,6 +51,7 @@ class JobManager(metaclass=ABCMeta):
         self._error_monitor: ErrorMonitor = error_monitor
 
         self._job_nodes: Dict[str, Dict[int, Node]] = {}
+        self._job_nodes_lock = threading.Lock()
 
         self._training_node_configure = TrainingNodeConfigure()
 

--- a/dlrover/python/master/node/job_manager.py
+++ b/dlrover/python/master/node/job_manager.py
@@ -51,7 +51,6 @@ class JobManager(metaclass=ABCMeta):
         self._error_monitor: ErrorMonitor = error_monitor
 
         self._job_nodes: Dict[str, Dict[int, Node]] = {}
-        self._job_nodes_lock = threading.Lock()
 
         self._training_node_configure = TrainingNodeConfigure()
 

--- a/dlrover/python/master/node/job_manager.py
+++ b/dlrover/python/master/node/job_manager.py
@@ -11,7 +11,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import threading
 from abc import ABCMeta, abstractclassmethod
 from typing import Dict
 

--- a/dlrover/python/master/stats/stats_backend.py
+++ b/dlrover/python/master/stats/stats_backend.py
@@ -15,6 +15,8 @@ import json
 
 import yaml
 
+from dlrover.python.common.log import default_logger as logger
+
 
 def parse_json_file(file_path):
     data = None
@@ -43,7 +45,7 @@ class LocalFileStateBackend:
         elif self.file_path.endswith("yaml"):
             data = parse_yaml_file(self.file_path)
         else:
-            print("error")  # to do: logging
+            logger.eror("Invalid file format.")
         self.data = data
         return data
 

--- a/dlrover/python/tests/test_elastic_training_agent.py
+++ b/dlrover/python/tests/test_elastic_training_agent.py
@@ -315,7 +315,6 @@ class ElasticTrainingAgentRunTest(unittest.TestCase):
         s.bind(("", 10000))
         os.environ["HOST_PORTS"] = "10000"
         port = agent._get_free_port()
-        print(port)
         s.close()
         self.assertTrue(port != 10000)
 

--- a/dlrover/python/tests/test_elasticjob_scaler.py
+++ b/dlrover/python/tests/test_elasticjob_scaler.py
@@ -89,5 +89,4 @@ class ElasticJobScalerTest(unittest.TestCase):
             ],
             "psHosts": ["test-ps-0:2222", "test-ps-1:2222"],
         }
-        print(scaler_crd.spec.to_dict())
         self.assertDictEqual(scaler_crd.spec.to_dict(), expected_dict)

--- a/dlrover/python/tests/test_job_manager.py
+++ b/dlrover/python/tests/test_job_manager.py
@@ -276,11 +276,20 @@ class DistributedJobManagerTest(unittest.TestCase):
             node.status = NodeStatus.RUNNING
         events = manager._get_dead_node_event()
         self.assertEqual(len(events), 0)
-        for node in manager._job_nodes[NodeType.WORKER].values():
+        for index, node in enumerate(
+            manager._job_nodes[NodeType.WORKER].values()
+        ):
             node.status = NodeStatus.RUNNING
-            node.heartbeat_time = time.time() - 500
+            now = time.time()
+            node.heartbeat_time = now - 500
+            if index == 0:
+                node.create_time = now - 400
+                node.start_time = now - 300
+            else:
+                node.create_time = now - 700
+                node.start_time = now - 600
         events = manager._get_dead_node_event()
-        self.assertEqual(len(events), 3)
+        self.assertEqual(len(events), 2)
 
     def test_relaunch_training_master(self):
         params = MockK8sPSJobArgs()

--- a/dlrover/python/tests/test_job_manager.py
+++ b/dlrover/python/tests/test_job_manager.py
@@ -14,6 +14,7 @@
 import threading
 import time
 import unittest
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta
 from unittest import mock
 
@@ -58,6 +59,7 @@ from dlrover.python.master.resource.job import JobResource
 from dlrover.python.master.watcher.base_watcher import Node, NodeEvent
 from dlrover.python.scheduler.job import LocalJobArgs
 from dlrover.python.tests.test_utils import (
+    MockK8sAllreduceJobArgs,
     MockK8sPSJobArgs,
     create_task_manager,
     mock_k8s_client,
@@ -519,6 +521,36 @@ class DistributedJobManagerTest(unittest.TestCase):
         active_threads_name = [t.name for t in threading.enumerate()]
         self.assertIn("node_monitor", active_threads_name)
         self.assertIn("node_heart_beat_monitor", active_threads_name)
+        manager.stop()
+
+    def test_concurrency_heart_beat_collecting(self):
+        params = MockK8sAllreduceJobArgs()
+        worker_size = 10000
+        params.initilize(worker_size)
+        manager = create_job_manager(params, SpeedMonitor())
+        manager.start()
+
+        self.assertEqual(len(manager._job_nodes[NodeType.WORKER]), worker_size)
+        for i, node in manager._job_nodes[NodeType.WORKER].items():
+            self.assertEqual(node.id, i)
+            self.assertEqual(node.heartbeat_time, 0)
+        futures = []
+        with ThreadPoolExecutor(max_workers=100) as executor:
+            for i in range(worker_size):
+                futures.append(
+                    executor.submit(
+                        manager.collect_node_heart_beat, NodeType.WORKER, i, i
+                    )
+                )
+
+            for future in futures:
+                future.result()
+
+        self.assertEqual(len(futures), worker_size)
+        for i, node in manager._job_nodes[NodeType.WORKER].items():
+            self.assertEqual(node.id, i)
+            self.assertEqual(node.heartbeat_time, i)
+
         manager.stop()
 
 

--- a/dlrover/python/tests/test_sharding_client.py
+++ b/dlrover/python/tests/test_sharding_client.py
@@ -69,7 +69,6 @@ class DataShardClientTest(unittest.TestCase):
         for i in range(loop):
             shard = data_shard_service.fetch_shard()
             if i < 10 and i != 5:
-                print(f"i : {i}, shard : {shard.start}")
                 self.assertIsNotNone(shard)
                 data_shard_service.report_batch_done(task_ids=[i])
             elif i == 5:
@@ -103,7 +102,6 @@ class DataShardClientTest(unittest.TestCase):
         shuffled = False
         for i in range(len(indices)):
             if i != indices[i]:
-                print(i, indices[i])
                 shuffled = True
                 break
         self.assertFalse(shuffled)

--- a/dlrover/python/tests/test_task_manager.py
+++ b/dlrover/python/tests/test_task_manager.py
@@ -70,7 +70,6 @@ class TaskMangerTest(unittest.TestCase):
         checkpoint_str = checkpoint.to_json()
 
         checkpoint_dict = json.loads(checkpoint_str)
-        print(checkpoint_dict)
         self.assertDictEqual(
             checkpoint_dict,
             {

--- a/dlrover/python/tests/test_utils.py
+++ b/dlrover/python/tests/test_utils.py
@@ -114,9 +114,9 @@ class MockK8sAllreduceJobArgs(JobArgs):
             PlatformType.KUBERNETES, "default", "test"
         )
 
-    def initilize(self):
+    def initilize(self, worker_count=16):
         worker_resource = NodeGroupResource(
-            16, NodeResource(1, 4096, "a100", 8)
+            worker_count, NodeResource(1, 4096, "a100", 8)
         )
         self.node_args[NodeType.WORKER] = NodeArgs(
             worker_resource, True, 3, 0, ""

--- a/dlrover/python/util/state/store_mananger.py
+++ b/dlrover/python/util/state/store_mananger.py
@@ -62,7 +62,6 @@ class MemoryStoreManager(StoreManager):
     def build_store(self):
         if self.memory_store is None:
             self.memory_store = MemoryStore(self, self.jobname, "test")
-        print(self.memory_store)
         return self.memory_store
 
     @classmethod


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. Add lock for heart beat collecting and dead node event judgement.
2. Add one more condition: heartbeat_time is meaningful when 'heartbeat_time' > 'start_time'.
3. Remove 'print'.

### Why are the changes needed?

Multi worker call master to update heart beat may cause thread safe issue.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

UT(TODO).
