### PR TITLE
Fix heartbeat when there is node relaunched.

### DIFF
--- a/dlrover/python/common/node.py
+++ b/dlrover/python/common/node.py
@@ -270,6 +270,7 @@ class Node(object):
         new_node.start_time = None
         new_node.create_time = None
         new_node.finish_time = None
+        new_node.heartbeat_time = 0
         new_node.is_released = False
         new_node.relaunchable = True
         new_node.init_time = time.time()

--- a/dlrover/python/master/node/dist_job_manager.py
+++ b/dlrover/python/master/node/dist_job_manager.py
@@ -385,7 +385,7 @@ class DistributedJobManager(JobManager):
                             f"Skip dead node judgement for "
                             f"node: {node.id}-{node.name} "
                             f"because heartbeat time < create/start time. "
-                            f"Reset heartbeat time to 0."
+                            f"Current nodes: {self._get_nodes_time_info()}."
                         )
                         continue
 
@@ -414,6 +414,27 @@ class DistributedJobManager(JobManager):
                         f"started at: {node.start_time}."
                     )
         return dead_events
+
+    def _get_nodes_time_info(self):
+        result = {}
+        for _, nodes in self._job_nodes.items():
+            for _, node in nodes.items():
+                if node.heartbeat_time == 0:
+                    heartbeat_time = 0
+                else:
+                    heartbeat_time = datetime.fromtimestamp(
+                        node.heartbeat_time
+                    )
+                result_dict = {
+                    "name": node.name,
+                    "type": node.type,
+                    "create": node.create_time,
+                    "start": node.start_time,
+                    "heartbeat": heartbeat_time,
+                }
+                result[node.id] = result_dict
+
+        return result
 
     def _monitor_scale_plan_crd(self):
         """Monitor the Scaler CRD from users to adjust the job resource"""

--- a/dlrover/python/tests/test_job_manager.py
+++ b/dlrover/python/tests/test_job_manager.py
@@ -291,6 +291,10 @@ class DistributedJobManagerTest(unittest.TestCase):
         events = manager._get_dead_node_event()
         self.assertEqual(len(events), 2)
 
+        nodes_time_info = manager._get_nodes_time_info()
+        self.assertIsNotNone(nodes_time_info)
+        self.assertEqual(len(nodes_time_info), 3)
+
     def test_relaunch_training_master(self):
         params = MockK8sPSJobArgs()
         params.initilize()


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. When new node is relaunched, the new node object should reset the heartbeat to 0.
2. Optimize the logging.

### Why are the changes needed?

Fix heartbeat issue when there is node relaunched.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

UT and full training test.
