### PR TITLE
add more network check log

### DIFF
--- a/dlrover/trainer/tests/torch/node_check_test.py
+++ b/dlrover/trainer/tests/torch/node_check_test.py
@@ -14,11 +14,12 @@
 import json
 import os
 import unittest
+from datetime import timedelta
 
 from dlrover.trainer.torch.node_check.ascend_npu import main as npu_main
 from dlrover.trainer.torch.node_check.nvidia_gpu import main as gpu_main
 from dlrover.trainer.torch.node_check.nvidia_gpu import set_nccl_env
-from dlrover.trainer.torch.node_check.utils import mock_error
+from dlrover.trainer.torch.node_check.utils import mock_error, get_network_check_timeout
 
 
 class TestNetworkCheckScript(unittest.TestCase):
@@ -75,3 +76,12 @@ class TestNetworkCheckScript(unittest.TestCase):
         ] = "NCCL_DEBUG=INFO,NCCL_SOCKET_IFNAME=eth0,NCCL_IB_GID_INDEX=3"
         set_nccl_env()
         self.assertEqual(os.environ["NCCL_SOCKET_IFNAME"], "eth0")
+
+    def test_get_network_check_timeout(self):
+        os.environ.setdefault("NETWORK_CHECK_TIMEOUT", "10")
+        timeout = get_network_check_timeout()
+        self.assertEqual(timeout, timedelta(seconds=10),f"want timeout: {timedelta(seconds=10)}, but got: {timeout}")
+
+        del os.environ["NETWORK_CHECK_TIMEOUT"]
+        timeout = get_network_check_timeout()
+        self.assertEqual(timeout, timedelta(seconds=180), f"want timeout: {timedelta(seconds=180)}, but got: {timeout}")

--- a/dlrover/trainer/tests/torch/node_check_test.py
+++ b/dlrover/trainer/tests/torch/node_check_test.py
@@ -19,7 +19,10 @@ from datetime import timedelta
 from dlrover.trainer.torch.node_check.ascend_npu import main as npu_main
 from dlrover.trainer.torch.node_check.nvidia_gpu import main as gpu_main
 from dlrover.trainer.torch.node_check.nvidia_gpu import set_nccl_env
-from dlrover.trainer.torch.node_check.utils import mock_error, get_network_check_timeout
+from dlrover.trainer.torch.node_check.utils import (
+    get_network_check_timeout,
+    mock_error,
+)
 
 
 class TestNetworkCheckScript(unittest.TestCase):
@@ -80,8 +83,16 @@ class TestNetworkCheckScript(unittest.TestCase):
     def test_get_network_check_timeout(self):
         os.environ.setdefault("NETWORK_CHECK_TIMEOUT", "10")
         timeout = get_network_check_timeout()
-        self.assertEqual(timeout, timedelta(seconds=10),f"want timeout: {timedelta(seconds=10)}, but got: {timeout}")
+        self.assertEqual(
+            timeout,
+            timedelta(seconds=10),
+            f"want timeout: {timedelta(seconds=10)}, but got: {timeout}",
+        )
 
         del os.environ["NETWORK_CHECK_TIMEOUT"]
         timeout = get_network_check_timeout()
-        self.assertEqual(timeout, timedelta(seconds=180), f"want timeout: {timedelta(seconds=180)}, but got: {timeout}")
+        self.assertEqual(
+            timeout,
+            timedelta(seconds=180),
+            f"want timeout: {timedelta(seconds=180)}, but got: {timeout}",
+        )

--- a/dlrover/trainer/torch/node_check/ascend_npu.py
+++ b/dlrover/trainer/torch/node_check/ascend_npu.py
@@ -23,7 +23,7 @@ try:
 except Exception:
     torch_npu = None
 
-from .utils import bm_allgather, matmul, record_execution_time
+from .utils import bm_allgather, matmul, record_execution_time, init_process_group, get_network_check_timeout
 
 
 @record_execution_time
@@ -36,7 +36,7 @@ def main():
         if "Ascend" in device:
             protocol = "hccl"
 
-    dist.init_process_group(protocol, timeout=timedelta(seconds=180))
+    init_process_group(protocol, timeout=get_network_check_timeout())
 
     if use_cuda:
         local_rank = int(os.environ["LOCAL_RANK"])

--- a/dlrover/trainer/torch/node_check/ascend_npu.py
+++ b/dlrover/trainer/torch/node_check/ascend_npu.py
@@ -12,7 +12,6 @@
 # limitations under the License.
 
 import os
-from datetime import timedelta
 
 import torch
 import torch.distributed as dist
@@ -23,7 +22,13 @@ try:
 except Exception:
     torch_npu = None
 
-from .utils import bm_allgather, matmul, record_execution_time, init_process_group, get_network_check_timeout
+from .utils import (
+    bm_allgather,
+    get_network_check_timeout,
+    init_process_group,
+    matmul,
+    record_execution_time,
+)
 
 
 @record_execution_time

--- a/dlrover/trainer/torch/node_check/nvidia_gpu.py
+++ b/dlrover/trainer/torch/node_check/nvidia_gpu.py
@@ -12,12 +12,17 @@
 # limitations under the License.
 
 import os
-from datetime import timedelta
 
 import torch
 import torch.distributed as dist
 
-from .utils import bm_allreduce, matmul, record_execution_time, init_process_group, get_network_check_timeout
+from .utils import (
+    bm_allreduce,
+    get_network_check_timeout,
+    init_process_group,
+    matmul,
+    record_execution_time,
+)
 
 
 def set_nccl_env():

--- a/dlrover/trainer/torch/node_check/nvidia_gpu.py
+++ b/dlrover/trainer/torch/node_check/nvidia_gpu.py
@@ -17,7 +17,7 @@ from datetime import timedelta
 import torch
 import torch.distributed as dist
 
-from .utils import bm_allreduce, matmul, record_execution_time
+from .utils import bm_allreduce, matmul, record_execution_time, init_process_group, get_network_check_timeout
 
 
 def set_nccl_env():
@@ -34,7 +34,7 @@ def main():
     use_cuda = torch.cuda.is_available()
     protocol = "nccl" if use_cuda else "gloo"
 
-    dist.init_process_group(protocol, timeout=timedelta(seconds=180))
+    init_process_group(protocol, timeout=get_network_check_timeout())
     if use_cuda:
         local_rank = int(os.environ["LOCAL_RANK"])
         torch.cuda.set_device(local_rank)

--- a/dlrover/trainer/torch/node_check/utils.py
+++ b/dlrover/trainer/torch/node_check/utils.py
@@ -14,6 +14,7 @@
 import json
 import os
 import time
+from datetime import timedelta
 
 import torch
 import torch.distributed as dist
@@ -34,10 +35,13 @@ def record_execution_time(func):
 
 def log_execution_time(func):
     def wrapper(*args, **kwargs):
-        t = func(*args, **kwargs)
-        t = round(t, 3)
         local_rank = int(os.environ["LOCAL_RANK"])
         func_name = func.__name__
+        logger.info(
+            f"Begin execute {func_name} on local rank {local_rank}"
+        )
+        t = func(*args, **kwargs)
+        t = round(t, 3)
         logger.info(
             f"Time to execute {func_name} on local rank {local_rank} is {t}s."
         )
@@ -52,6 +56,23 @@ def mock_error():
         local_rank = int(os.environ["LOCAL_RANK"])
         if err_rank == local_rank:
             raise ValueError("Mock network error!")
+
+
+@log_execution_time
+def init_process_group(protocol: str, timeout: timedelta = timedelta(seconds=180)):
+    start = time.time()
+    dist.init_process_group(protocol, timeout=timeout)
+    elapsed_time = time.time() - start
+    return elapsed_time
+
+
+def get_network_check_timeout() -> timedelta:
+    default_timeout_seconds = 180
+    timeout = int(os.environ.get("NETWORK_CHECK_TIMEOUT", default_timeout_seconds))
+    if timeout <= 0:
+        timeout = default_timeout_seconds
+
+    return timedelta(seconds=timeout)
 
 
 @log_execution_time
@@ -111,6 +132,7 @@ def bm_allreduce(shape, use_gpu):
     return elapsed_time
 
 
+@log_execution_time
 def _execute_nccl_comm(comm_op, *args):
     local_rank = int(os.environ["LOCAL_RANK"])
     # warm up
@@ -132,6 +154,7 @@ def _execute_nccl_comm(comm_op, *args):
     return elapsed_time
 
 
+@log_execution_time
 def _execute_cpu_comm(comm_op, *args):
     # warm up
     for _ in range(10):
@@ -164,6 +187,7 @@ def matmul(use_cuda, round_num=10):
     return elapsed_time
 
 
+@log_execution_time
 def _execute_gpu_matmul(tensor1, tensor2, round_num):
     start = torch.cuda.Event(enable_timing=True)
     end = torch.cuda.Event(enable_timing=True)
@@ -178,6 +202,7 @@ def _execute_gpu_matmul(tensor1, tensor2, round_num):
     return elapsed_time
 
 
+@log_execution_time
 def _execute_cpu_matmul(tensor1, tensor2, round_num):
     start = time.time()
     for _ in range(round_num):

--- a/dlrover/trainer/torch/node_check/utils.py
+++ b/dlrover/trainer/torch/node_check/utils.py
@@ -37,9 +37,7 @@ def log_execution_time(func):
     def wrapper(*args, **kwargs):
         local_rank = int(os.environ["LOCAL_RANK"])
         func_name = func.__name__
-        logger.info(
-            f"Begin execute {func_name} on local rank {local_rank}"
-        )
+        logger.info(f"Begin execute {func_name} on local rank {local_rank}")
         t = func(*args, **kwargs)
         t = round(t, 3)
         logger.info(
@@ -59,7 +57,9 @@ def mock_error():
 
 
 @log_execution_time
-def init_process_group(protocol: str, timeout: timedelta = timedelta(seconds=180)):
+def init_process_group(
+    protocol: str, timeout: timedelta = timedelta(seconds=180)
+):
     start = time.time()
     dist.init_process_group(protocol, timeout=timeout)
     elapsed_time = time.time() - start
@@ -68,7 +68,9 @@ def init_process_group(protocol: str, timeout: timedelta = timedelta(seconds=180
 
 def get_network_check_timeout() -> timedelta:
     default_timeout_seconds = 180
-    timeout = int(os.environ.get("NETWORK_CHECK_TIMEOUT", default_timeout_seconds))
+    timeout = int(
+        os.environ.get("NETWORK_CHECK_TIMEOUT", default_timeout_seconds)
+    )
     if timeout <= 0:
         timeout = default_timeout_seconds
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

add more output log for torch `network-check`

add env: "NETWORK_CHECK_TIMEOUT" for `network-check` collective communications.
default value is 180 seconds if not set env "NETWORK_CHECK_TIMEOUT".

### Why are the changes needed?

There may be blocking or delay when EDL agent starts the network-check script. In order to locate the problem more conveniently, more logs are added.

### Does this PR introduce any user-facing change?

Specify whether this pull request introduces any changes that users will directly interact with or notice.

### How was this patch tested?

Detail the testing process you have undertaken to ensure the changes in this pull request are valid and working as intended.
