### PR TITLE
Increase heartbeat timeout

### DIFF
--- a/dlrover/python/master/node/dist_job_manager.py
+++ b/dlrover/python/master/node/dist_job_manager.py
@@ -365,7 +365,7 @@ class DistributedJobManager(JobManager):
                     logger.warning(detail_trace_back)
             time.sleep(15)
 
-    def _get_dead_node_event(self, window_interval=300) -> List[NodeEvent]:
+    def _get_dead_node_event(self, window_interval=600) -> List[NodeEvent]:
         now = time.time()
         dead_events: List[NodeEvent] = []
         for _, nodes in self._job_nodes.items():

--- a/dlrover/python/tests/test_job_manager.py
+++ b/dlrover/python/tests/test_job_manager.py
@@ -281,13 +281,13 @@ class DistributedJobManagerTest(unittest.TestCase):
         ):
             node.status = NodeStatus.RUNNING
             now = datetime.now()
-            node.heartbeat_time = (now - timedelta(seconds=500)).timestamp()
+            node.heartbeat_time = (now - timedelta(seconds=1000)).timestamp()
             if index == 0:
-                node.create_time = now - timedelta(seconds=400)
-                node.start_time = now - timedelta(seconds=300)
-            else:
-                node.create_time = now - timedelta(seconds=700)
+                node.create_time = now - timedelta(seconds=800)
                 node.start_time = now - timedelta(seconds=600)
+            else:
+                node.create_time = now - timedelta(seconds=1400)
+                node.start_time = now - timedelta(seconds=1200)
         events = manager._get_dead_node_event()
         self.assertEqual(len(events), 2)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Increase the timeout from 5mins to 10mins.

### Why are the changes needed?

Training worker will exit in 5mins. So the heartbeat timeout should > 5mins.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

UT.
