### PR TITLE
Optimize node status from pod phase.

### DIFF
--- a/dlrover/python/master/node/dist_job_manager.py
+++ b/dlrover/python/master/node/dist_job_manager.py
@@ -368,6 +368,7 @@ class DistributedJobManager(JobManager):
     def _get_dead_node_event(self, window_interval=600) -> List[NodeEvent]:
         now = time.time()
         dead_events: List[NodeEvent] = []
+        logger.debug(f"Current job nodes are: {self._job_nodes}.")
         for _, nodes in self._job_nodes.items():
             for _, node in nodes.items():
                 if (

--- a/dlrover/python/tests/test_k8s_watcher.py
+++ b/dlrover/python/tests/test_k8s_watcher.py
@@ -61,7 +61,9 @@ class PodWatcherTest(unittest.TestCase):
         self.k8s_client = mock_k8s_client()
 
     def test_list(self):
+        # set env
         os.environ[WITH_TO_DELETED] = "True"
+
         mock_k8s_client()
         pod_watcher = PodWatcher("test", "")
         nodes: List[Node] = pod_watcher.list()
@@ -85,6 +87,9 @@ class PodWatcherTest(unittest.TestCase):
         self.assertEqual(node.id, 99)
         self.assertEqual(node.type, NodeType.WORKER)
         self.assertEqual(node.status, NodeStatus.DELETED)
+
+        # reset env
+        os.environ.pop(WITH_TO_DELETED)
 
     def test_convert_pod_event_to_node_event(self):
         labels = _mock_pod_labels()

--- a/dlrover/python/tests/test_utils.py
+++ b/dlrover/python/tests/test_utils.py
@@ -36,6 +36,8 @@ from dlrover.python.master.shard.task_manager import TaskManager
 from dlrover.python.scheduler.job import JobArgs, LocalJobArgs, NodeArgs
 from dlrover.python.scheduler.kubernetes import k8sClient
 
+WITH_TO_DELETED = "WITH_TO_DELETED"
+
 
 def _is_local():
     return "dlrover/python/tests" in os.getcwd()
@@ -249,6 +251,17 @@ def mock_list_namespaced_pod(label_selector):
             }
             pod = create_pod(labels)
             pods.append(pod)
+
+    if os.getenv(WITH_TO_DELETED):
+        labels = {
+            ElasticJobLabel.APP_NAME: "test",
+            ElasticJobLabel.REPLICA_TYPE_KEY: NodeType.WORKER,
+            ElasticJobLabel.REPLICA_INDEX_KEY: str(99),
+            ElasticJobLabel.RANK_INDEX_KEY: str(99),
+            ElasticJobLabel.RELAUNCH_COUNT: "0",
+        }
+        pod = create_pod(labels, with_deletion_timestamp=True)
+        pods.append(pod)
 
     return client.V1PodList(
         items=pods, metadata=client.V1ListMeta(resource_version="12345678")


### PR DESCRIPTION
### What changes were proposed in this pull request?

Set to 'Deleted' status if the pod has 'deletion_timstamp' when listing pod from k8s.

### Why are the changes needed?

To prevent repeated worker heartbeat warning when pod deletion failed.

A example scene:
1. the heartbeat is working
2. a worker heartbeat lost and timeout
3. master relaunch the worker who lost heartbeat
4. master receive to_deleted event and update node status to deleted, but k8s failed to delete the pod(failure node)
5. master can still get pod info from k8s and the pod.status.phase is running but with deletion_timestamp
6. for the node status is based on the pod.status.phase, the node status rewrite to running again
7. master will always find that worker who lost heartbeat (never end until the pod is deleted manually)

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

UT.
