### PR TITLE
Keep conflict processing when env set

### DIFF
--- a/dlrover/python/common/grpc.py
+++ b/dlrover/python/common/grpc.py
@@ -107,10 +107,11 @@ def find_free_port_in_set(ports):
 def find_free_port_for_hccl(
     start=AscendConstants.HCCL_PORT_START_DEFAULT,
 ) -> int:
+    max_port = 65500
     cur_start = start
     end = start + 10000
-    if end > 65000:
-        end = 65000
+    if end > max_port:
+        end = max_port
     logger.info(f"Try to find available port for hccl from {start}")
     checking_port = 0
     while True:

--- a/dlrover/python/tests/test_elastic_training_agent.py
+++ b/dlrover/python/tests/test_elastic_training_agent.py
@@ -363,10 +363,28 @@ class ElasticTrainingAgentRunTest(unittest.TestCase):
             start_method=self.config.start_method,
             log_dir=self.config.log_dir,
         )
-        agent.sync_training_ports()
+        agent.sync_training_ports(1)
         self.assertEqual(
             os.environ[AscendConstants.HCCL_PORT_START],
             str(AscendConstants.HCCL_PORT_START_DEFAULT),
+        )
+
+    def test_sync_node_port_with_env(self):
+        os.environ[AscendConstants.HCCL_PORT_START] = "65000"
+        self.config.accelerator = Accelerators.ASCEND_NPU
+        agent = ElasticTrainingAgent(
+            node_rank=0,
+            config=self.config,
+            entrypoint="echo",
+            spec=self.spec,
+            start_method=self.config.start_method,
+            log_dir=self.config.log_dir,
+        )
+
+        agent.sync_training_ports(1)
+        self.assertEqual(
+            os.environ[AscendConstants.HCCL_PORT_START],
+            str(65000),
         )
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. Use default env's port as start port.
2. Update max port to 65500.
3. Optimize ut for higher efficiency.

### Why are the changes needed?

Keep conflict processing when env has already been set.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

UT.