### PR TITLE
Resolve pending and insufficient nodes issue.

### DIFF
--- a/dlrover/python/common/constants.py
+++ b/dlrover/python/common/constants.py
@@ -108,6 +108,7 @@ class JobExitReason(object):
     UNKNOWN_ERROR = "UnknownError"
     HANG_ERROR = "HangError"
     RDZV_TIMEOUT_ERROR = "RdzvTimeout"
+    PENDING_TIMEOUT = "PendingTimeout"
 
 
 class CustomMetricKeys:

--- a/dlrover/python/common/constants.py
+++ b/dlrover/python/common/constants.py
@@ -284,6 +284,7 @@ class TrainingExceptionLevel(object):
     NODE_ERROR = "node_error"
     WARNING = "warning"
     INFO = "info"
+    ERROR = "error"
 
 
 class ConfigPath(object):

--- a/dlrover/python/common/constants.py
+++ b/dlrover/python/common/constants.py
@@ -109,6 +109,7 @@ class JobExitReason(object):
     HANG_ERROR = "HangError"
     RDZV_TIMEOUT_ERROR = "RdzvTimeout"
     PENDING_TIMEOUT = "PendingTimeout"
+    UNCOMPLETED_TIMEOUT = "UncompletedTimeout"
 
 
 class CustomMetricKeys:

--- a/dlrover/python/master/dist_master.py
+++ b/dlrover/python/master/dist_master.py
@@ -294,15 +294,17 @@ class DistributedJobMaster(JobMaster):
         logger.info("Master stopped")
 
     def request_stop(self, success, reason, msg=""):
-        logger.info(
-            f"Request to stop. Success: {success}, reason: {reason}, "
-            f"msg: {msg}."
-        )
         self._stop_requested = True
         self._exit_reason = reason
         if success:
             self._exit_code = 0
-            logger.info(msg)
+            logger.info(
+                f"Request to stop. Success: {success}, reason: {reason}, "
+                f"msg: {msg}."
+            )
         else:
             self._exit_code = 1
-            logger.error(msg)
+            logger.error(
+                f"Request to stop. Success: {success}, reason: {reason}, "
+                f"msg: {msg}."
+            )

--- a/dlrover/python/master/dist_master.py
+++ b/dlrover/python/master/dist_master.py
@@ -217,9 +217,9 @@ class DistributedJobMaster(JobMaster):
             while True:
                 if self._stop_requested:
                     break
-                msg = self.job_manager.early_stop()
-                if msg:
-                    self.request_stop(False, msg)
+                should_stop, reason, msg = self.job_manager.should_early_stop()
+                if should_stop:
+                    self.request_stop(False, reason, msg)
                     continue
                 self.job_manager.clear_exited_nodes()
                 if self.job_manager and self.job_manager.all_workers_exited():

--- a/dlrover/python/master/dist_master.py
+++ b/dlrover/python/master/dist_master.py
@@ -294,6 +294,10 @@ class DistributedJobMaster(JobMaster):
         logger.info("Master stopped")
 
     def request_stop(self, success, reason, msg=""):
+        logger.info(
+            f"Request to stop. Success: {success}, reason: {reason}, "
+            f"msg: {msg}."
+        )
         self._stop_requested = True
         self._exit_reason = reason
         if success:

--- a/dlrover/python/master/master.py
+++ b/dlrover/python/master/master.py
@@ -11,22 +11,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from abc import ABCMeta, abstractclassmethod
+from abc import ABCMeta, abstractmethod
 
 
 class JobMaster(metaclass=ABCMeta):
-    @abstractclassmethod
+    @abstractmethod
     def prepare(self):
         pass
 
-    @abstractclassmethod
+    @abstractmethod
     def run(self):
         pass
 
-    @abstractclassmethod
+    @abstractmethod
     def stop(self):
         pass
 
-    @abstractclassmethod
-    def request_stop(self):
+    @abstractmethod
+    def request_stop(self, success, reason, msg=""):
         pass

--- a/dlrover/python/master/monitor/error_monitor.py
+++ b/dlrover/python/master/monitor/error_monitor.py
@@ -56,6 +56,8 @@ class SimpleErrorMonitor(ErrorMonitor):
             logger.error(f"Rendezvous fails with reason {error_data}")
         elif level == TrainingExceptionLevel.WARNING:
             logger.warning(error_data)
+        elif level == TrainingExceptionLevel.ERROR:
+            logger.error(error_data)
         return False
 
     def _handle_process_error(
@@ -95,6 +97,8 @@ class K8sJobErrorMonitor(ErrorMonitor):
             logger.error(f"Rendezvous fails with reason {error_data}")
         elif level == TrainingExceptionLevel.WARNING:
             logger.warning(error_data)
+        elif level == TrainingExceptionLevel.ERROR:
+            logger.error(error_data)
         return False
 
     def _handle_process_error(

--- a/dlrover/python/master/node/dist_job_manager.py
+++ b/dlrover/python/master/node/dist_job_manager.py
@@ -21,12 +21,13 @@ from typing import Dict, List, Optional
 
 from dlrover.python.common.constants import (
     DistributionStrategy,
+    JobExitReason,
     NodeEventType,
     NodeExitReason,
     NodeResourceLimit,
     NodeStatus,
     NodeType,
-    TrainingExceptionLevel, JobExitReason,
+    TrainingExceptionLevel,
 )
 from dlrover.python.common.global_context import Context
 from dlrover.python.common.grpc import ParallelConfig
@@ -215,8 +216,9 @@ class DistributedJobManager(JobManager):
 
     def should_early_stop(self):
         # ps pending judgement: any ps pod pending timeout
-        timeout_ps_nodes = (self._ps_manager
-                            .get_pending_timeout_oom_recovered_node())
+        timeout_ps_nodes = (
+            self._ps_manager.get_pending_timeout_oom_recovered_node()
+        )
         if len(timeout_ps_nodes) > 0:
             msg = (
                 "Stop the training early because oom recovered node pending "
@@ -225,7 +227,6 @@ class DistributedJobManager(JobManager):
             return True, JobExitReason.PENDING_TIMEOUT, msg
 
         # worker pending judgement:
-
         if self._worker_manager.is_training_hang_by_pending():
             msg = (
                 "Stop the training early because 1) there is node pending "
@@ -234,7 +235,8 @@ class DistributedJobManager(JobManager):
             )
             return True, JobExitReason.PENDING_TIMEOUT, msg
 
-        if self._worker_manager.is_training_hang_by_unsufficient_worker():
+        # insufficient worker judgement
+        if self._worker_manager.is_training_hang_by_insufficient_worker():
             msg = (
                 "Stop the training early because there isn't enough node to "
                 "keep training."

--- a/dlrover/python/master/node/dist_job_manager.py
+++ b/dlrover/python/master/node/dist_job_manager.py
@@ -26,7 +26,7 @@ from dlrover.python.common.constants import (
     NodeResourceLimit,
     NodeStatus,
     NodeType,
-    TrainingExceptionLevel,
+    TrainingExceptionLevel, JobExitReason,
 )
 from dlrover.python.common.global_context import Context
 from dlrover.python.common.grpc import ParallelConfig
@@ -213,7 +213,7 @@ class DistributedJobManager(JobManager):
     def get_worker_num(self):
         return self._job_resource.worker_num
 
-    def early_stop(self):
+    def should_early_stop(self):
         nodes = self._ps_manager.get_pending_timeout_oom_recovered_node()
         msg = ""
         if len(nodes) > 0:
@@ -221,7 +221,8 @@ class DistributedJobManager(JobManager):
                 "Stop the training early because "
                 "OOM recoverd pod pends too long."
             )
-        return msg
+            return True, JobExitReason.PENDING_TIMEOUT, msg
+        return False, "", ""
 
     def _adjust_worker_for_estimator(self):
         if self._job_args.distribution_strategy == DistributionStrategy.PS:

--- a/dlrover/python/master/node/dist_job_manager.py
+++ b/dlrover/python/master/node/dist_job_manager.py
@@ -221,8 +221,8 @@ class DistributedJobManager(JobManager):
         )
         if len(timeout_ps_nodes) > 0:
             msg = (
-                "Stop the training early because oom recovered node pending "
-                "timeout."
+                "Stop the training early because the nodes recovered from OOM "
+                "are pending too long and have timed out."
             )
             return True, JobExitReason.PENDING_TIMEOUT, msg
 
@@ -230,8 +230,8 @@ class DistributedJobManager(JobManager):
         if self._worker_manager.is_training_hang_by_pending():
             msg = (
                 "Stop the training early because 1) there is node pending "
-                "2) alive worker number consistently lower than the min "
-                "training nodes requires 3) time last exceed limit."
+                "2) alive worker number consistently less than the min "
+                "training nodes required 3) pending time last exceed limit."
             )
             return True, JobExitReason.PENDING_TIMEOUT, msg
 

--- a/dlrover/python/master/node/dist_job_manager.py
+++ b/dlrover/python/master/node/dist_job_manager.py
@@ -224,6 +224,12 @@ class DistributedJobManager(JobManager):
                 "Stop the training early because the nodes recovered from OOM "
                 "are pending too long and have timed out."
             )
+            self._error_monitor.process_error(
+                timeout_ps_nodes[0],
+                0,
+                msg,
+                level=TrainingExceptionLevel.ERROR,
+            )
             return True, JobExitReason.PENDING_TIMEOUT, msg
 
         # worker pending judgement:
@@ -233,6 +239,9 @@ class DistributedJobManager(JobManager):
                 "2) alive worker number consistently less than the min "
                 "training nodes required 3) pending time last exceed limit."
             )
+            self._error_monitor.process_error(
+                None, 0, msg, level=TrainingExceptionLevel.ERROR
+            )
             return True, JobExitReason.PENDING_TIMEOUT, msg
 
         # insufficient worker judgement
@@ -240,6 +249,9 @@ class DistributedJobManager(JobManager):
             msg = (
                 "Stop the training early because there isn't enough node to "
                 "keep training."
+            )
+            self._error_monitor.process_error(
+                None, 0, msg, level=TrainingExceptionLevel.ERROR
             )
             return True, JobExitReason.UNCOMPLETED_TIMEOUT, msg
 

--- a/dlrover/python/master/node/dist_job_manager.py
+++ b/dlrover/python/master/node/dist_job_manager.py
@@ -214,14 +214,23 @@ class DistributedJobManager(JobManager):
         return self._job_resource.worker_num
 
     def should_early_stop(self):
-        nodes = self._ps_manager.get_pending_timeout_oom_recovered_node()
-        msg = ""
-        if len(nodes) > 0:
+        # ps pending judgement: any ps pod pending timeout
+        timeout_ps_nodes = (self._ps_manager
+                            .get_pending_timeout_oom_recovered_node())
+        if len(timeout_ps_nodes) > 0:
             msg = (
-                "Stop the training early because "
-                "OOM recoverd pod pends too long."
+                "Stop the training early because recovered pod pending "
+                "timeout."
             )
             return True, JobExitReason.PENDING_TIMEOUT, msg
+
+        # worker pending judgement:
+        # condition1: exist pending
+        # condition2: alive nodes number < min nodes -> training can't start
+        # condition3: condition1+condition2 last for a certain time
+        # TODO
+
+        # no need to early stop
         return False, "", ""
 
     def _adjust_worker_for_estimator(self):

--- a/dlrover/python/master/node/event_callback.py
+++ b/dlrover/python/master/node/event_callback.py
@@ -300,13 +300,17 @@ class AllReduceNodeHandlingCallback(NodeEventCallback):
         stop_node = False
         if node.exit_reason == NodeExitReason.FATAL_ERROR:
             if not _dlrover_ctx.relaunch_always:
-                logger.info(f"Need to stop job for node: {node.name} "
-                            "has fatal error.")
+                logger.info(
+                    f"Need to stop job for node: {node.name} "
+                    "has fatal error."
+                )
                 stop_node = True
         if node.relaunch_count >= node.max_relaunch_count:
-            logger.info("Need to stop job for node relaunching "
-                        f"count: {node.relaunch_count} "
-                        f"over limit: {node.max_relaunch_count}.")
+            logger.info(
+                "Need to stop job for node relaunching "
+                f"count: {node.relaunch_count} "
+                f"over limit: {node.max_relaunch_count}."
+            )
             self._available_worker_num -= 1
             stop_node = True
 

--- a/dlrover/python/master/node/event_callback.py
+++ b/dlrover/python/master/node/event_callback.py
@@ -300,8 +300,13 @@ class AllReduceNodeHandlingCallback(NodeEventCallback):
         stop_node = False
         if node.exit_reason == NodeExitReason.FATAL_ERROR:
             if not _dlrover_ctx.relaunch_always:
+                logger.info(f"Need to stop job for node: {node.name} "
+                            "has fatal error.")
                 stop_node = True
         if node.relaunch_count >= node.max_relaunch_count:
+            logger.info("Need to stop job for node relaunching "
+                        f"count: {node.relaunch_count} "
+                        f"over limit: {node.max_relaunch_count}.")
             self._available_worker_num -= 1
             stop_node = True
 

--- a/dlrover/python/master/node/job_manager.py
+++ b/dlrover/python/master/node/job_manager.py
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from abc import ABCMeta, abstractclassmethod
+from abc import ABCMeta, abstractmethod
 from typing import Dict
 
 from dlrover.python.common.node import Node
@@ -53,117 +53,125 @@ class JobManager(metaclass=ABCMeta):
 
         self._training_node_configure = TrainingNodeConfigure()
 
-    @abstractclassmethod
+    @abstractmethod
     def start(self):
         pass
 
-    @abstractclassmethod
+    @abstractmethod
     def add_node_event_callback(self, node_event_callback):
         pass
 
-    @abstractclassmethod
+    @abstractmethod
     def update_node_resource_usage(
         self, node_type, node_id, cpu, memory, gpu_stats=[]
     ):
         pass
 
-    @abstractclassmethod
+    @abstractmethod
     def close_job(self):
         pass
 
-    @abstractclassmethod
+    @abstractmethod
     def all_workers_exited(self):
         return False
 
-    @abstractclassmethod
+    @abstractmethod
     def all_workers_failed(self):
         return False
 
-    @abstractclassmethod
+    @abstractmethod
     def all_workers_deleted(self):
         return False
 
-    @abstractclassmethod
+    @abstractmethod
     def all_critical_node_completed(self):
         return False
 
-    @abstractclassmethod
+    @abstractmethod
     def remove_worker(self, worker_id):
         pass
 
-    @abstractclassmethod
+    @abstractmethod
     def get_running_nodes(self):
         pass
 
-    @abstractclassmethod
+    @abstractmethod
     def get_running_workers(self):
         pass
 
-    @abstractclassmethod
+    @abstractmethod
     def post_ps_ready(self):
         pass
 
-    @abstractclassmethod
+    @abstractmethod
     def stop(self):
         pass
 
     def update_node_service_addr(self, node_type, node_id, service_addr):
         pass
 
-    @abstractclassmethod
+    @abstractmethod
     def get_cur_cluster_ps(self):
         pass
 
-    @abstractclassmethod
+    @abstractmethod
     def get_next_cluster_ps(self):
         pass
 
-    @abstractclassmethod
+    @abstractmethod
     def ready_for_new_ps_cluster(self):
         pass
 
-    @abstractclassmethod
+    @abstractmethod
     def has_ps_failure(self):
         pass
 
-    @abstractclassmethod
+    @abstractmethod
     def remove_training_nodes(self):
         """Remove all PS and workers"""
         pass
 
-    @abstractclassmethod
+    @abstractmethod
     def start_auto_scaling(self):
         pass
 
-    @abstractclassmethod
+    @abstractmethod
     def all_running_node_hanged(self):
         pass
 
-    @abstractclassmethod
+    @abstractmethod
     def remove_not_joined_rdzv_workers(self, worker_ranks):
         pass
 
-    @abstractclassmethod
+    @abstractmethod
     def pend_without_workers(self):
         pass
 
-    @abstractclassmethod
+    @abstractmethod
     def update_allreduce_node_unit(self, node_unit):
         pass
 
-    @abstractclassmethod
-    def early_stop(self):
+    @abstractmethod
+    def should_early_stop(self):
+        """
+        Should the job be stopped early?
+
+        Returns:
+            result(bool): True if the job should be stopped early.
+            reason: The short reason(constant) of the job being stopped.
+            msg: The long reason of the job being stopped.
+        """
         pass
 
-    @abstractclassmethod
+    @abstractmethod
     def get_opt_strategy(self):
         pass
 
-    @abstractclassmethod
+    @abstractmethod
     def update_node_paral_config(self, node_type, node_id, paral_config):
         pass
 
-    @abstractclassmethod
+    @abstractmethod
     def verify_restarting_worker_training(self, node_type, node_id):
         """
         Verify the necessity of restarting the training process
@@ -174,14 +182,14 @@ class JobManager(metaclass=ABCMeta):
         """
         pass
 
-    @abstractclassmethod
+    @abstractmethod
     def handle_training_failure(
         self, node_type, node_id, restart_count=-1, error_data="", level=""
     ):
         """Process the training failure reported by the node."""
         pass
 
-    @abstractclassmethod
+    @abstractmethod
     def collect_node_heart_beat(self, node_type, node_id, timestamp):
         """Collect the heart beat message of nodes."""
         pass

--- a/dlrover/python/master/node/job_manager.py
+++ b/dlrover/python/master/node/job_manager.py
@@ -50,6 +50,7 @@ class JobManager(metaclass=ABCMeta):
         self._error_monitor: ErrorMonitor = error_monitor
 
         self._job_nodes: Dict[str, Dict[int, Node]] = {}
+        self._nodes_required = (0, 0)
 
         self._training_node_configure = TrainingNodeConfigure()
 
@@ -198,3 +199,13 @@ class JobManager(metaclass=ABCMeta):
         return self._training_node_configure.sync_node_training_port(
             node_id, port
         )
+
+    def update_node_required_info(self, min_required, max_required):
+        if min_required > 0 and max_required > 0 and max_required > min_required:
+            self._nodes_required = (min_required, max_required)
+            self.update_node_required_info_callback()
+
+    def update_node_required_info_callback(self):
+        """Callback when 'update_node_required_info' is invoked."""
+
+        pass

--- a/dlrover/python/master/node/job_manager.py
+++ b/dlrover/python/master/node/job_manager.py
@@ -201,7 +201,11 @@ class JobManager(metaclass=ABCMeta):
         )
 
     def update_node_required_info(self, min_required, max_required):
-        if min_required > 0 and max_required > 0 and max_required > min_required:
+        if (
+            min_required > 0
+            and max_required > 0
+            and max_required > min_required
+        ):
             self._nodes_required = (min_required, max_required)
             self.update_node_required_info_callback()
 

--- a/dlrover/python/master/node/job_manager.py
+++ b/dlrover/python/master/node/job_manager.py
@@ -14,6 +14,7 @@
 from abc import ABCMeta, abstractmethod
 from typing import Dict
 
+from dlrover.python.common.log import default_logger as logger
 from dlrover.python.common.node import Node
 from dlrover.python.master.hyperparams.simple_strategy_generator import (
     SimpleStrategyGenerator,
@@ -201,13 +202,22 @@ class JobManager(metaclass=ABCMeta):
         )
 
     def update_node_required_info(self, min_required, max_required):
-        if (
-            min_required > 0
-            and max_required > 0
-            and max_required > min_required
-        ):
+        """
+        Update the nodes min/max requirements.
+
+        Args:
+            min_required(int): Minimum number of nodes for training.
+            max_required(int): Maximum number of nodes for training.
+        """
+
+        if 0 < min_required <= max_required and max_required > 0:
             self._nodes_required = (min_required, max_required)
             self.update_node_required_info_callback()
+        else:
+            logger.warning(
+                f"Invalid min_required: {min_required} "
+                f"and max_required: {max_required}."
+            )
 
     def update_node_required_info_callback(self):
         """Callback when 'update_node_required_info' is invoked."""

--- a/dlrover/python/master/node/local_job_manager.py
+++ b/dlrover/python/master/node/local_job_manager.py
@@ -47,7 +47,7 @@ class LocalJobManager(JobManager):
                 status=NodeStatus.RUNNING,
             )
 
-    def early_stop(self):
+    def should_early_stop(self):
         return False
 
     def add_node_event_callback(self, node_event_callback):

--- a/dlrover/python/master/node/worker.py
+++ b/dlrover/python/master/node/worker.py
@@ -348,7 +348,7 @@ class WorkerManager(TrainingNodeManager):
         # with condition 1 + 2
         if (
             len(pending_nodes) == 0
-            or len(running_nodes) > self._nodes_required[0]
+            or len(running_nodes) >= self._nodes_required[0]
         ):
             return False
 

--- a/dlrover/python/master/servicer.py
+++ b/dlrover/python/master/servicer.py
@@ -555,6 +555,9 @@ class MasterServicer(elastic_training_pb2_grpc.MasterServicer):
                 waiting_timeout=message.waiting_timeout,
                 node_unit=message.node_unit,
             )
+
+        self._job_manager.update_node_required_info(
+            message.min_nodes, message.max_nodes)
         return True
 
     def _report_failure(self, node_type, node_id, message: grpc.NodeFailure):

--- a/dlrover/python/master/servicer.py
+++ b/dlrover/python/master/servicer.py
@@ -557,7 +557,8 @@ class MasterServicer(elastic_training_pb2_grpc.MasterServicer):
             )
 
         self._job_manager.update_node_required_info(
-            message.min_nodes, message.max_nodes)
+            message.min_nodes, message.max_nodes
+        )
         return True
 
     def _report_failure(self, node_type, node_id, message: grpc.NodeFailure):

--- a/dlrover/python/master/watcher/k8s_watcher.py
+++ b/dlrover/python/master/watcher/k8s_watcher.py
@@ -118,7 +118,7 @@ def _convert_pod_event_to_node_event(event, k8s_client):
         pod_labels_selector = k8s_util.gen_k8s_label_selector_from_dict(
             _get_pod_unique_labels(job_name, pod_type, rank)
         )
-        logger.info(
+        logger.debug(
             f"Recheck running pod with labels: {pod_labels_selector} "
             f"for {evt_type} event."
         )

--- a/dlrover/python/tests/test_error_monitor.py
+++ b/dlrover/python/tests/test_error_monitor.py
@@ -38,3 +38,10 @@ class ErrorLogMonitorTest(unittest.TestCase):
             level=TrainingExceptionLevel.NODE_ERROR,
         )
         self.assertTrue(relaunched)
+
+        err_monitor.process_error(
+            node=None,
+            restart_count=0,
+            error_data="test",
+            level=TrainingExceptionLevel.ERROR,
+        )

--- a/dlrover/python/tests/test_job_manager.py
+++ b/dlrover/python/tests/test_job_manager.py
@@ -495,7 +495,7 @@ class DistributedJobManagerTest(unittest.TestCase):
             node.status = NodeStatus.PENDING
             node.is_recovered_oom = True
             node.create_time = datetime.now()
-        msg = manager.early_stop()
+        msg = manager.should_early_stop()
         self.assertTrue(msg == "")
 
         manager._remove_exited_node = True
@@ -507,14 +507,14 @@ class DistributedJobManagerTest(unittest.TestCase):
             node.status = NodeStatus.PENDING
             node.create_time = datetime.now() + timedelta(days=-1)
             node.is_recovered_oom = True
-        msg = manager.early_stop()
+        msg = manager.should_early_stop()
         self.assertFalse(msg == "")
 
         for node in manager._job_nodes[NodeType.PS].values():
             node.status = NodeStatus.RUNNING
             node.create_time = datetime.now() + timedelta(days=-1)
             node.is_recovered_oom = True
-        msg = manager.early_stop()
+        msg = manager.should_early_stop()
         self.assertTrue(msg == "")
 
     def test_when_node_not_init(self):

--- a/dlrover/python/tests/test_job_manager.py
+++ b/dlrover/python/tests/test_job_manager.py
@@ -529,7 +529,9 @@ class DistributedJobManagerTest(unittest.TestCase):
         manager = create_job_manager(params, SpeedMonitor())
         manager._init_nodes()
 
-        manager._worker_manager.is_training_hang_by_pending = mock.MagicMock(return_value=True)
+        manager._worker_manager.is_training_hang_by_pending = mock.MagicMock(
+            return_value=True
+        )
         result, reason, msg = manager.should_early_stop()
         self.assertTrue(result)
         self.assertEqual(reason, JobExitReason.PENDING_TIMEOUT)
@@ -541,8 +543,9 @@ class DistributedJobManagerTest(unittest.TestCase):
         manager = create_job_manager(params, SpeedMonitor())
         manager._init_nodes()
 
-        manager._worker_manager.is_training_hang_by_insufficient_worker = mock.MagicMock(
-            return_value=True)
+        manager._worker_manager.is_training_hang_by_insufficient_worker = (
+            mock.MagicMock(return_value=True)
+        )
         result, reason, msg = manager.should_early_stop()
         self.assertTrue(result)
         self.assertEqual(reason, JobExitReason.UNCOMPLETED_TIMEOUT)

--- a/dlrover/python/tests/test_job_manager.py
+++ b/dlrover/python/tests/test_job_manager.py
@@ -486,7 +486,7 @@ class DistributedJobManagerTest(unittest.TestCase):
         hang = manager.all_running_node_hanged()
         self.assertFalse(hang)
 
-    def test_early_stop(self):
+    def test_early_stop_part1(self):
         params = MockK8sPSJobArgs()
         params.initilize()
         manager = create_job_manager(params, SpeedMonitor())
@@ -495,8 +495,10 @@ class DistributedJobManagerTest(unittest.TestCase):
             node.status = NodeStatus.PENDING
             node.is_recovered_oom = True
             node.create_time = datetime.now()
-        msg = manager.should_early_stop()
-        self.assertTrue(msg == "")
+        result, reason, msg = manager.should_early_stop()
+        self.assertFalse(result)
+        self.assertFalse(reason)
+        self.assertFalse(msg)
 
         manager._remove_exited_node = True
         manager._job_nodes[NodeType.WORKER][0].status = NodeStatus.FAILED
@@ -507,15 +509,44 @@ class DistributedJobManagerTest(unittest.TestCase):
             node.status = NodeStatus.PENDING
             node.create_time = datetime.now() + timedelta(days=-1)
             node.is_recovered_oom = True
-        msg = manager.should_early_stop()
-        self.assertFalse(msg == "")
+        result, reason, msg = manager.should_early_stop()
+        self.assertTrue(result)
+        self.assertTrue(reason)
+        self.assertTrue(msg)
 
         for node in manager._job_nodes[NodeType.PS].values():
             node.status = NodeStatus.RUNNING
             node.create_time = datetime.now() + timedelta(days=-1)
             node.is_recovered_oom = True
-        msg = manager.should_early_stop()
-        self.assertTrue(msg == "")
+        result, reason, msg = manager.should_early_stop()
+        self.assertFalse(result)
+        self.assertFalse(reason)
+        self.assertFalse(msg)
+
+    def test_early_stop_part2(self):
+        params = MockK8sPSJobArgs()
+        params.initilize()
+        manager = create_job_manager(params, SpeedMonitor())
+        manager._init_nodes()
+
+        manager._worker_manager.is_training_hang_by_pending = mock.MagicMock(return_value=True)
+        result, reason, msg = manager.should_early_stop()
+        self.assertTrue(result)
+        self.assertEqual(reason, JobExitReason.PENDING_TIMEOUT)
+        self.assertTrue(msg)
+
+    def test_early_stop_part3(self):
+        params = MockK8sPSJobArgs()
+        params.initilize()
+        manager = create_job_manager(params, SpeedMonitor())
+        manager._init_nodes()
+
+        manager._worker_manager.is_training_hang_by_insufficient_worker = mock.MagicMock(
+            return_value=True)
+        result, reason, msg = manager.should_early_stop()
+        self.assertTrue(result)
+        self.assertEqual(reason, JobExitReason.UNCOMPLETED_TIMEOUT)
+        self.assertTrue(msg)
 
     def test_when_node_not_init(self):
         params = MockK8sPSJobArgs()

--- a/dlrover/python/tests/test_worker_manager.py
+++ b/dlrover/python/tests/test_worker_manager.py
@@ -11,6 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import time
 import unittest
 from datetime import datetime, timedelta
 
@@ -20,11 +21,14 @@ from dlrover.python.common.constants import (
     NodeType,
     PlatformType,
 )
+from dlrover.python.common.global_context import Context
 from dlrover.python.common.node import Node, NodeGroupResource, NodeResource
 from dlrover.python.master.node.worker import ChiefManager, WorkerManager
 from dlrover.python.master.resource.job import JobResource
 from dlrover.python.scheduler.factory import new_elastic_job
 from dlrover.python.tests.test_utils import mock_k8s_client
+
+_dlrover_ctx = Context.singleton_instance()
 
 
 class WorkerManagerTest(unittest.TestCase):
@@ -193,3 +197,122 @@ class WorkerManagerTest(unittest.TestCase):
         worker_manager._nodes[0].is_released = True
         reset = worker_manager.verify_restarting_training(0)
         self.assertFalse(reset)
+
+    def test_is_training_hang_by_pending(self):
+        worker_manager = WorkerManager(
+            self._job_nodes[NodeType.WORKER],
+            self._job_resource,
+            3,
+            self._elastic_job.get_node_service_addr,
+            self._elastic_job.get_node_name,
+        )
+        self.assertFalse(worker_manager.is_training_hang_by_pending())
+
+        worker_manager.update_node_required_info((4, 8))
+        self.assertFalse(worker_manager.is_training_hang_by_pending())
+
+        node_size = len(worker_manager._nodes)
+        # mock with pending nodes with short time
+        index = node_size
+        pending_node = Node(
+            NodeType.WORKER,
+            index,
+            NodeResource(0, 0),
+            "test-" + str(index),
+            NodeStatus.PENDING,
+        )
+        pending_node.create_time = datetime.now() + timedelta(minutes=-1)
+        worker_manager._nodes[index] = pending_node
+        self.assertFalse(worker_manager.is_training_hang_by_pending())
+
+        # mock with pending nodes with long time
+        worker_manager._nodes[index].create_time = datetime.now() + timedelta(
+            minutes=-20
+        )
+        self.assertTrue(worker_manager.is_training_hang_by_pending())
+
+        # reset
+        worker_manager._nodes.pop(index)
+
+    def test_is_training_hang_by_insufficient_worker(self):
+        # mock timeout 2 second(seconds_to_wait_pending_pod * 2)
+        _dlrover_ctx.seconds_to_wait_pending_pod = 1
+
+        worker_manager = WorkerManager(
+            self._job_nodes[NodeType.WORKER],
+            self._job_resource,
+            3,
+            self._elastic_job.get_node_service_addr,
+            self._elastic_job.get_node_name,
+        )
+        self.assertFalse(
+            worker_manager.is_training_hang_by_insufficient_worker()
+        )
+
+        worker_manager.update_node_required_info((4, 8))
+        self.assertFalse(
+            worker_manager.is_training_hang_by_insufficient_worker()
+        )
+
+        mock_nodes = {}
+        is_insufficient = 0
+
+        # mock with 3 running + 1 pending
+        for index in range(4):
+            mock_node = Node(
+                NodeType.WORKER,
+                index,
+                NodeResource(0, 0),
+                "test-" + str(index),
+                NodeStatus.RUNNING,
+            )
+            if index == 0:
+                mock_node.status = NodeStatus.PENDING
+            mock_nodes[index] = mock_node
+        worker_manager._nodes = mock_nodes
+        for _ in range(5):
+            if worker_manager.is_training_hang_by_insufficient_worker():
+                is_insufficient += 1
+            time.sleep(1)
+        self.assertEqual(is_insufficient, 0)
+        mock_nodes.clear()
+        is_insufficient = 0
+
+        # mock with 3 running
+        for index in range(3):
+            mock_node = Node(
+                NodeType.WORKER,
+                index,
+                NodeResource(0, 0),
+                "test-" + str(index),
+                NodeStatus.RUNNING,
+            )
+            mock_nodes[index] = mock_node
+        worker_manager._nodes = mock_nodes
+        for _ in range(5):
+            if worker_manager.is_training_hang_by_insufficient_worker():
+                is_insufficient += 1
+            time.sleep(1)
+        self.assertTrue(is_insufficient >= 2)
+        mock_nodes.clear()
+        is_insufficient = 0
+
+        # mock with 3 running + 1 released
+        for index in range(4):
+            mock_node = Node(
+                NodeType.WORKER,
+                index,
+                NodeResource(0, 0),
+                "test-" + str(index),
+                NodeStatus.RUNNING,
+            )
+            if index == 0:
+                mock_node.status = NodeStatus.DELETED
+                mock_node.is_released = True
+            mock_nodes[index] = mock_node
+        worker_manager._nodes = mock_nodes
+        for _ in range(5):
+            if worker_manager.is_training_hang_by_insufficient_worker():
+                is_insufficient += 1
+            time.sleep(1)
+        self.assertTrue(is_insufficient >= 2)

--- a/dlrover/python/tests/test_worker_manager.py
+++ b/dlrover/python/tests/test_worker_manager.py
@@ -351,3 +351,6 @@ class WorkerManagerTest(unittest.TestCase):
                 is_insufficient += 1
             time.sleep(1)
         self.assertTrue(is_insufficient >= 2)
+
+        # reset
+        _dlrover_ctx.seconds_to_wait_pending_pod = 900

--- a/dlrover/python/tests/test_worker_manager.py
+++ b/dlrover/python/tests/test_worker_manager.py
@@ -268,6 +268,25 @@ class WorkerManagerTest(unittest.TestCase):
             mock_nodes[index] = mock_node
         worker_manager._nodes = mock_nodes
         self.assertFalse(worker_manager.is_training_hang_by_pending())
+        mock_nodes.clear()
+
+        # mock with 3 running + 1 initial long time
+        for index in range(4):
+            mock_node = Node(
+                NodeType.WORKER,
+                index,
+                NodeResource(0, 0),
+                "test-" + str(index),
+                NodeStatus.RUNNING,
+            )
+            if index == 0:
+                mock_node.status = NodeStatus.INITIAL
+                mock_node.create_time = datetime.now() + timedelta(minutes=-20)
+            else:
+                mock_node.create_time = datetime.now() + timedelta(minutes=-20)
+            mock_nodes[index] = mock_node
+        worker_manager._nodes = mock_nodes
+        self.assertTrue(worker_manager.is_training_hang_by_pending())
 
     def test_is_training_hang_by_insufficient_worker(self):
         # mock timeout 2 second(seconds_to_wait_pending_pod * 2)


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. Add 'pending nodes' judgement.
2. Add 'insufficient nodes' judgement.
3. Optimize 'should_early_stop' function.
4. Update annotations using.

### Why are the changes needed?

Job should early stop in the 2 following case:
1. Exist pending nodes cause training could not continue.
5. Insufficient nodes cause training could not continue.

Details of these 2 scenarios can be found in the comments in the code.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

UT for now. Need more training test later.
