### PR TITLE
Fix user-agent issue.

### DIFF
--- a/dlrover/python/scheduler/kubernetes.py
+++ b/dlrover/python/scheduler/kubernetes.py
@@ -147,10 +147,12 @@ class k8sClient(Singleton):
             )
 
         self.client = client.CoreV1Api()
+        self.setup_user_agent()
         self.api_instance = client.CustomObjectsApi()
-        self.api_client = client.ApiClient()
-        self.api_client.user_agent = USER_AGENT
         self._namespace = namespace
+
+    def setup_user_agent(self):
+        self.client.api_client.user_agent = USER_AGENT
 
     @retry_k8s_request
     def list_namespaced_pod(self, label_selector):

--- a/dlrover/python/scheduler/kubernetes.py
+++ b/dlrover/python/scheduler/kubernetes.py
@@ -154,6 +154,10 @@ class k8sClient(Singleton):
     def setup_user_agent(self):
         self.client.api_client.user_agent = USER_AGENT
 
+    @property
+    def api_client(self):
+        return self.client.api_client
+
     @retry_k8s_request
     def list_namespaced_pod(self, label_selector):
         """List the pods in the namespace with the label selector.

--- a/dlrover/python/tests/test_k8s_utils.py
+++ b/dlrover/python/tests/test_k8s_utils.py
@@ -110,7 +110,7 @@ class KubernetesTest(unittest.TestCase):
         self.assertEqual(svc.spec.ports[0].name, "http")
 
     def test_client(self):
-        client = k8sClient.singleton_instance("default")
-        succeed = client.cordon_node("test-node-0")
+        k8s_client = k8sClient.singleton_instance("default")
+        succeed = k8s_client.cordon_node("test-node-0")
         self.assertFalse(succeed)
-        self.assertEqual(client.api_client.user_agent, USER_AGENT)
+        self.assertEqual(k8s_client.client.api_client.user_agent, USER_AGENT)

--- a/dlrover/python/tests/test_k8s_utils.py
+++ b/dlrover/python/tests/test_k8s_utils.py
@@ -114,3 +114,4 @@ class KubernetesTest(unittest.TestCase):
         succeed = k8s_client.cordon_node("test-node-0")
         self.assertFalse(succeed)
         self.assertEqual(k8s_client.client.api_client.user_agent, USER_AGENT)
+        self.assertEqual(k8s_client.api_client.user_agent, USER_AGENT)


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. Remove 'api_client' field(not used) in 'k8sClient' class.
2. Update the user-agent for the 'api_client' of kubernetes client(not dlrover's k8s client).

### Why are the changes needed?

Use specified user-agent.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

UT.
