### PR TITLE
Support action timeout processing.

### DIFF
--- a/dlrover/python/elastic_agent/monitor/training.py
+++ b/dlrover/python/elastic_agent/monitor/training.py
@@ -79,7 +79,7 @@ class TorchTrainingMonitor(Singleton):
     TORCH_ACTION_TIMEOUT_SECS = 300
     TORCH_ACTION_TIMEOUT_TIMES = 3
 
-    def __init__(self, metrics_path, agent):
+    def __init__(self, metrics_path, agent=None):
         self._resource_monitor = ResourceMonitor.singleton_instance()
         self._master_client = MasterClient.singleton_instance()
         self._group_rank = env_utils.get_node_rank()
@@ -153,6 +153,9 @@ class TorchTrainingMonitor(Singleton):
             time.sleep(15)
 
     def _is_action_hang(self) -> bool:
+        if self._agent is None:
+            return False
+
         now = time.time()
         last_action_time = self._agent.get_action_time()
         if not last_action_time:

--- a/dlrover/python/elastic_agent/torch/training.py
+++ b/dlrover/python/elastic_agent/torch/training.py
@@ -714,15 +714,11 @@ class ElasticTrainingAgent(LocalElasticAgent):
         )
 
     def _restart_workers(self, worker_group: WorkerGroup):
-        self._set_action_time()
-
         self._restart_count += 1
         self._remaining_restarts -= 1
         # release the shared memory lock before starting workers.
         AsyncCheckpointSaver.reset()
         super()._restart_workers(worker_group)
-
-        self._log_and_reset_action_time("Restart workers")
 
     def _membership_changed(self, role, rdzv_handler: RendezvousHandler):
         # Timeout may happen when to query TCPStore.

--- a/dlrover/python/tests/test_agent_monitor.py
+++ b/dlrover/python/tests/test_agent_monitor.py
@@ -18,10 +18,6 @@ import unittest
 from datetime import datetime, timedelta
 from unittest.mock import patch
 
-from elastic_agent.torch.training import (
-    ElasticLaunchConfig,
-    ElasticTrainingAgent,
-)
 from torch.distributed.elastic.agent.server import WorkerSpec
 from torch.distributed.launcher import LaunchConfig
 
@@ -40,6 +36,10 @@ from dlrover.python.elastic_agent.monitor.training import (
     TFTrainingReporter,
     TorchTrainingMonitor,
     is_tf_chief,
+)
+from dlrover.python.elastic_agent.torch.training import (
+    ElasticLaunchConfig,
+    ElasticTrainingAgent,
 )
 from dlrover.python.tests.test_utils import start_local_master
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. Add new logic in torch-training-monitor to judge 'is action timeout'.
2. Add time setting around 'stop' action to record cost.
3. Will raise error(pod failover) if there is action timeout.

### Why are the changes needed?

Explain the purpose or motivation behind these changes. What problem are you trying to solve?

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

UT.
