### PR TITLE
Add signal timeout for 'stop_workers'

### DIFF
--- a/dlrover/python/elastic_agent/torch/training.py
+++ b/dlrover/python/elastic_agent/torch/training.py
@@ -541,6 +541,7 @@ class ElasticTrainingAgent(LocalElasticAgent):
         return workers
 
     def _initialize_workers(self, worker_group):
+        logger.info("Start initializing training workers.")
         start_pending = 0
         pend_timeout = float(
             self._config.rdzv_configs.get("pend_timeout", "inf")

--- a/dlrover/python/elastic_agent/torch/training.py
+++ b/dlrover/python/elastic_agent/torch/training.py
@@ -571,12 +571,26 @@ class ElasticTrainingAgent(LocalElasticAgent):
                 break
 
     @prof
-    def _stop_workers(self, worker_group: WorkerGroup) -> None:
-        if self._config.accelerator == Accelerators.ASCEND_NPU:
-            logger.info("stop workers via SIGKILL")
-            self._shutdown(death_sig=signal.SIGKILL)
-        else:
-            super()._stop_workers(worker_group)
+    def _stop_workers(self, worker_group: WorkerGroup, timeout=300) -> None:
+        try:
+            signal.signal(signal.SIGALRM, self._stop_timeout_handler)
+            signal.alarm(timeout)
+
+            if self._config.accelerator == Accelerators.ASCEND_NPU:
+                logger.info("stop workers via SIGKILL")
+                self._shutdown(death_sig=signal.SIGKILL)
+            else:
+                super()._stop_workers(worker_group)
+
+            signal.alarm(0)
+        except TimeoutError as te:
+            logger.error(str(te))
+            raise
+        finally:
+            signal.alarm(0)
+
+    def _stop_timeout_handler(self, signum, frame):
+        raise TimeoutError("Timed out waiting for stopping workers.")
 
     def _invoke_run(self, role: str = DEFAULT_ROLE) -> RunResult:
         # sync hccl port for NPU

--- a/dlrover/python/tests/test_elastic_training_agent.py
+++ b/dlrover/python/tests/test_elastic_training_agent.py
@@ -258,8 +258,8 @@ class ElasticTrainingAgentRunTest(unittest.TestCase):
             rdzv_handler=self.rdzv_handler,
             max_restarts=self.config.max_restarts,
             monitor_interval=self.config.monitor_interval,
-            # redirects=self.config.redirects,
-            # tee=self.config.tee,
+            redirects=self.config.redirects,
+            tee=self.config.tee,
             master_addr=master_addr,
             local_addr=self.config.local_addr,
         )


### PR DESCRIPTION
### What changes were proposed in this pull request?

Will raise error(pod failover) if the 'stop_workers' timeout.

### Why are the changes needed?

'stop_workers' may hang if there is hardware issue.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

UT.
