### PR TITLE
Copy tensor to the shared memory without grad.

### DIFF
--- a/dlrover/python/elastic_agent/torch/ckpt_saver.py
+++ b/dlrover/python/elastic_agent/torch/ckpt_saver.py
@@ -208,10 +208,11 @@ def _write_shared_memory(value: torch.Tensor, meta: TensorMeta, buffer):
     """
     if value.numel() == 0:
         return
-    shm_tensor = torch.frombuffer(
-        buffer, dtype=value.dtype, count=value.numel(), offset=meta.offset
-    ).reshape(value.shape)
-    shm_tensor.copy_(value)
+    with torch.no_grad():
+        shm_tensor = torch.frombuffer(
+            buffer, dtype=value.dtype, count=value.numel(), offset=meta.offset
+        ).reshape(value.shape)
+        shm_tensor.copy_(value)
 
 
 class SharedMemoryHandler(object):


### PR DESCRIPTION
### What changes were proposed in this pull request?

Copy tensor to the shared memory without grad.

### Why are the changes needed?

Avoid modifing the backward graph to compute gradients because the tensor in the shared memory does not need gradients.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

UT.