### PR TITLE
Optimize pending judgement: when all nodes pending

### DIFF
--- a/dlrover/python/master/node/dist_job_manager.py
+++ b/dlrover/python/master/node/dist_job_manager.py
@@ -233,7 +233,9 @@ class DistributedJobManager(JobManager):
             return True, JobExitReason.PENDING_TIMEOUT, msg
 
         # worker pending judgement:
-        if self._worker_manager.is_training_hang_by_pending():
+        if self._worker_manager.is_training_hang_by_pending(
+            self.get_worker_num()
+        ):
             msg = (
                 "Stop the training early because 1) there is node pending "
                 "2) alive worker number consistently less than the min "


### PR DESCRIPTION
### What changes were proposed in this pull request?

Pass the current total worker number to the function to cover the case: 'all nodes pending'.

### Why are the changes needed?

Need cover the following case when doing pending judgement:
All nodes pending at beginning(min nodes required is None).

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

UT and full training test.
