### PR TITLE
Fix master client setup in ckpt saver.

### DIFF
--- a/dlrover/python/elastic_agent/torch/training.py
+++ b/dlrover/python/elastic_agent/torch/training.py
@@ -555,9 +555,6 @@ class ElasticTrainingAgent(LocalElasticAgent):
                 # We need to register handler after starting workers because
                 # the PContext start_worker will overwrite the handler.
                 AsyncCheckpointSaver.register_signal_handler()
-
-                # need master client to report unexpected failures in saver
-                AsyncCheckpointSaver.register_master_client(self._client)
             except RendezvousOutSyncError:
                 if start_pending == 0:
                     start_pending = time.time()

--- a/dlrover/python/tests/test_ckpt_saver.py
+++ b/dlrover/python/tests/test_ckpt_saver.py
@@ -286,7 +286,9 @@ class CheckpointSaverTest(unittest.TestCase):
         master, addr = start_local_master()
         MasterClient._instance = build_master_client(addr)
 
+        self.assertIsNone(saver._master_client)
         self.assertIsNotNone(saver.get_master_client())
+        self.assertIsNotNone(saver._master_client)
         saver._report_failure_to_master("test-error")
 
 

--- a/dlrover/python/tests/test_ckpt_saver.py
+++ b/dlrover/python/tests/test_ckpt_saver.py
@@ -289,6 +289,10 @@ class CheckpointSaverTest(unittest.TestCase):
         self.assertIsNone(saver._master_client)
         self.assertIsNotNone(saver.get_master_client())
         self.assertIsNotNone(saver._master_client)
+        self.assertEqual(id(MasterClient._instance), id(saver._master_client))
+        self.assertEqual(
+            id(MasterClient._instance), id(saver.get_master_client())
+        )
         saver._report_failure_to_master("test-error")
 
 

--- a/dlrover/python/tests/test_ckpt_saver.py
+++ b/dlrover/python/tests/test_ckpt_saver.py
@@ -147,7 +147,7 @@ class CheckpointSaverTest(unittest.TestCase):
         MasterClient._instance = build_master_client(addr)
         master_client = MasterClient.singleton_instance()
         self.assertIsNotNone(master_client)
-        AsyncCheckpointSaver.register_master_client(master_client)
+        AsyncCheckpointSaver.get_master_client(master_client)
         self.assertIsNotNone(
             AsyncCheckpointSaver._saver_instance._master_client
         )
@@ -285,9 +285,8 @@ class CheckpointSaverTest(unittest.TestCase):
         saver = DdpCheckpointSaver("test_ckpt", self.storage.get_class_meta())
         master, addr = start_local_master()
         MasterClient._instance = build_master_client(addr)
-        master_client = MasterClient.singleton_instance()
-        saver.setup_master_client(master_client)
 
+        self.assertIsNotNone(saver.get_master_client())
         saver._report_failure_to_master("test-error")
 
 

--- a/dlrover/python/tests/test_ckpt_saver.py
+++ b/dlrover/python/tests/test_ckpt_saver.py
@@ -142,14 +142,19 @@ class CheckpointSaverTest(unittest.TestCase):
 
         # test setup master client
         self.assertIsNone(AsyncCheckpointSaver._saver_instance._master_client)
-
         master, addr = start_local_master()
         MasterClient._instance = build_master_client(addr)
         master_client = MasterClient.singleton_instance()
         self.assertIsNotNone(master_client)
-        AsyncCheckpointSaver.get_master_client(master_client)
+        self.assertIsNotNone(
+            AsyncCheckpointSaver._saver_instance.get_master_client()
+        )
         self.assertIsNotNone(
             AsyncCheckpointSaver._saver_instance._master_client
+        )
+        self.assertEqual(
+            id(master_client),
+            id(AsyncCheckpointSaver._saver_instance._master_client),
         )
 
     def test_close_saver(self):


### PR DESCRIPTION
### What changes were proposed in this pull request?

Just use ```singleton_instance``` to get the client object in ckpt saver.

### Why are the changes needed?

Fix master-client retrieving in ckpt saver.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

UT
