### PR TITLE
Fix rdzv updating in concurrency

### DIFF
--- a/dlrover/python/master/servicer.py
+++ b/dlrover/python/master/servicer.py
@@ -552,7 +552,7 @@ class MasterServicer(elastic_training_pb2_grpc.MasterServicer):
         for manager in self._rdzv_managers.values():
             manager.update_rdzv_params(
                 min_nodes=message.min_nodes,
-                max_ndoes=message.max_nodes,
+                max_nodes=message.max_nodes,
                 waiting_timeout=message.waiting_timeout,
                 node_unit=message.node_unit,
             )

--- a/dlrover/python/tests/test_rdzv_manager.py
+++ b/dlrover/python/tests/test_rdzv_manager.py
@@ -212,7 +212,8 @@ class ElasticTrainingRendezvousManagerTest(unittest.TestCase):
             for i in range(300):
                 futures = [
                     executor.submit(
-                        rdzv_manager._check_rdzv_completed,
+                        rdzv_manager.get_comm_world,
+                        i,
                     )
                 ]
                 for future in as_completed(futures):

--- a/dlrover/python/tests/test_rdzv_manager.py
+++ b/dlrover/python/tests/test_rdzv_manager.py
@@ -14,6 +14,7 @@
 import datetime
 import time
 import unittest
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from dlrover.python.common.constants import NetworkFailureReason
 from dlrover.python.common.node import Node
@@ -184,6 +185,48 @@ class ElasticTrainingRendezvousManagerTest(unittest.TestCase):
 
         rdzv_manager._rdzv_params.min_nodes = 0
         self.assertEqual(rdzv_manager._get_lacking_ranks(), [])
+
+    def test_multi_updating_waiting_nodes(self):
+        rdzv_manager = ElasticTrainingRendezvousManager()
+
+        join_num = 1000
+        with ThreadPoolExecutor(max_workers=4) as executor:
+            for i in range(join_num):
+                executor.submit(
+                    rdzv_manager.join_rendezvous,
+                    i,
+                    i,
+                    8,
+                )
+
+        remove_num = 900
+        with ThreadPoolExecutor(max_workers=4) as executor:
+            for i in range(remove_num):
+                node = Node("worker", i, name=f"worker-{i}", rank_index=i)
+                executor.submit(
+                    rdzv_manager.remove_alive_node,
+                    node,
+                )
+
+        with ThreadPoolExecutor(max_workers=4) as executor:
+            for i in range(300):
+                futures = [
+                    executor.submit(
+                        rdzv_manager._check_rdzv_completed,
+                    )
+                ]
+                for future in as_completed(futures):
+                    try:
+                        future.result()
+                    except Exception:
+                        self.fail()
+
+        time.sleep(5)
+        self.assertEqual(
+            len(rdzv_manager._waiting_nodes.keys()), join_num - remove_num
+        )
+        for i in rdzv_manager._waiting_nodes.keys():
+            self.assertTrue(900 <= i <= 999)
 
 
 class NetworkCheckRendezvousManagerTest(unittest.TestCase):

--- a/dlrover/trainer/torch/node_check/nvidia_gpu.py
+++ b/dlrover/trainer/torch/node_check/nvidia_gpu.py
@@ -47,7 +47,6 @@ def main():
     t = matmul(use_cuda)
     shape = 1 << 24
     t += bm_allreduce(shape, use_cuda)
-    local_rank = int(os.environ["LOCAL_RANK"])
     dist.destroy_process_group()
     return t
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. Add lock when writing ```waiting_nodes```.
2. Rank 0 should also be considered during remove.

### Why are the changes needed?

To fixed incorrect waiting nodes object updating under concurrency.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

UT.
