### PR TITLE
Sse rdzv timeout as insufficient timeout

### DIFF
--- a/dlrover/python/common/constants.py
+++ b/dlrover/python/common/constants.py
@@ -310,6 +310,10 @@ class CheckpointConstant(object):
     SAVE_TIMEOUT = 600
 
 
+class RdzvConstant(object):
+    JOIN_TIMEOUT = 600
+
+
 class Accelerators(object):
     NVIDIA_GPU = "nvidia.com/gpu"
     ASCEND_NPU = "ascend-npu"

--- a/dlrover/python/common/constants.py
+++ b/dlrover/python/common/constants.py
@@ -310,8 +310,10 @@ class CheckpointConstant(object):
     SAVE_TIMEOUT = 600
 
 
-class RdzvConstant(object):
-    JOIN_TIMEOUT = 600
+class JobConstant(object):
+    RDZV_JOIN_TIMEOUT_DEFAULT = 600
+    INSUFFICIENT_NODE_TIMEOUT_DEFAULT_MIN = 600
+    INSUFFICIENT_NODE_TIMEOUT_DEFAULT_MAX = 1800
 
 
 class Accelerators(object):

--- a/dlrover/python/common/constants.py
+++ b/dlrover/python/common/constants.py
@@ -313,7 +313,7 @@ class CheckpointConstant(object):
 class JobConstant(object):
     RDZV_JOIN_TIMEOUT_DEFAULT = 600
     INSUFFICIENT_NODE_TIMEOUT_DEFAULT_MIN = 600
-    INSUFFICIENT_NODE_TIMEOUT_DEFAULT_MAX = 1800
+    INSUFFICIENT_NODE_TIMEOUT_DEFAULT_MAX = 3600
 
 
 class Accelerators(object):

--- a/dlrover/python/common/grpc.py
+++ b/dlrover/python/common/grpc.py
@@ -349,6 +349,7 @@ class RendezvousParams(Message):
     max_nodes: int = 0
     waiting_timeout: int = 0
     node_unit: int = 0
+    join_timeout: int = 0
 
 
 @dataclass

--- a/dlrover/python/elastic_agent/master_client.py
+++ b/dlrover/python/elastic_agent/master_client.py
@@ -360,13 +360,14 @@ class MasterClient(Singleton):
         return result.nodes
 
     def report_rdzv_params(
-        self, min_nodes, max_nodes, waiting_timeout, node_unit
+        self, min_nodes, max_nodes, waiting_timeout, node_unit, joint_timeout
     ):
         message = grpc.RendezvousParams(
             min_nodes,
             max_nodes,
             waiting_timeout,
             node_unit,
+            joint_timeout,
         )
         response = self._report(message)
         return response.success

--- a/dlrover/python/elastic_agent/torch/training.py
+++ b/dlrover/python/elastic_agent/torch/training.py
@@ -65,6 +65,7 @@ from dlrover.python.common.constants import (
     NodeEnv,
     NodeErrorMessage,
     NodeStatus,
+    RdzvConstant,
     RendezvousName,
     TrainingExceptionLevel,
 )
@@ -225,7 +226,9 @@ class MasterRendezvousHandler(RendezvousHandler):
         self._node_rank = node_rank
         self._rdzv_params = rdzv_params
         self._local_world_size = local_world_size
-        self.join_timeout = int(rdzv_params.get("join_timeout", 600))
+        self.join_timeout = int(
+            rdzv_params.get("join_timeout", RdzvConstant.JOIN_TIMEOUT)
+        )
         self.pend_timeout = float(rdzv_params.get("pend_timeout", "inf"))
         self._client = MasterClient.singleton_instance()
         self._store = MasterKVStore(self._name, timedelta(seconds=60))
@@ -236,6 +239,7 @@ class MasterRendezvousHandler(RendezvousHandler):
             rdzv_params.max_nodes,
             lastcall_timeout,
             node_unit,
+            self.join_timeout,
         )
 
     def get_backend(self) -> str:

--- a/dlrover/python/elastic_agent/torch/training.py
+++ b/dlrover/python/elastic_agent/torch/training.py
@@ -62,10 +62,10 @@ from dlrover.python.common.constants import (
     Accelerators,
     AscendConstants,
     ConfigPath,
+    JobConstant,
     NodeEnv,
     NodeErrorMessage,
     NodeStatus,
-    RdzvConstant,
     RendezvousName,
     TrainingExceptionLevel,
 )
@@ -227,7 +227,9 @@ class MasterRendezvousHandler(RendezvousHandler):
         self._rdzv_params = rdzv_params
         self._local_world_size = local_world_size
         self.join_timeout = int(
-            rdzv_params.get("join_timeout", RdzvConstant.JOIN_TIMEOUT)
+            rdzv_params.get(
+                "join_timeout", JobConstant.RDZV_JOIN_TIMEOUT_DEFAULT
+            )
         )
         self.pend_timeout = float(rdzv_params.get("pend_timeout", "inf"))
         self._client = MasterClient.singleton_instance()

--- a/dlrover/python/master/node/job_manager.py
+++ b/dlrover/python/master/node/job_manager.py
@@ -51,7 +51,7 @@ class JobManager(metaclass=ABCMeta):
         self._error_monitor: ErrorMonitor = error_monitor
 
         self._job_nodes: Dict[str, Dict[int, Node]] = {}
-        self._nodes_required = (0, 0)
+        self._nodes_required = (0, 0, 0)
 
         self._training_node_configure = TrainingNodeConfigure()
 
@@ -201,22 +201,24 @@ class JobManager(metaclass=ABCMeta):
             node_id, port
         )
 
-    def update_node_required_info(self, min_required, max_required):
+    def update_node_required_info(self, min_required, max_required, timeout):
         """
         Update the nodes min/max requirements.
 
         Args:
             min_required(int): Minimum number of nodes for training.
             max_required(int): Maximum number of nodes for training.
+            timeout(int): Required timeout in seconds.
         """
 
         if 0 < min_required <= max_required and max_required > 0:
-            self._nodes_required = (min_required, max_required)
+            self._nodes_required = (min_required, max_required, timeout)
             self.update_node_required_info_callback()
         else:
             logger.warning(
-                f"Invalid min_required: {min_required} "
-                f"and max_required: {max_required}."
+                f"Invalid required info, min_required: {min_required}, "
+                f"max_required: {max_required}, "
+                f"required_timeout: {timeout}."
             )
 
     def update_node_required_info_callback(self):

--- a/dlrover/python/master/node/worker.py
+++ b/dlrover/python/master/node/worker.py
@@ -16,6 +16,7 @@ import time
 from typing import Dict, List, Tuple
 
 from dlrover.python.common.constants import (
+    JobConstant,
     NodeExitReason,
     NodeStatus,
     NodeType,
@@ -411,8 +412,12 @@ class WorkerManager(TrainingNodeManager):
         if not self.has_node_required_info():
             return False
 
-        # use 1.5 * rdzv-timeout as timeout
+        # use 1.5 * rdzv-timeout with min: 600 and max: as timeout
         timeout = int(self.get_nodes_timeout() * 1.5)
+        if timeout < JobConstant.INSUFFICIENT_NODE_TIMEOUT_DEFAULT_MIN:
+            timeout = JobConstant.INSUFFICIENT_NODE_TIMEOUT_DEFAULT_MIN
+        elif timeout > JobConstant.INSUFFICIENT_NODE_TIMEOUT_DEFAULT_MAX:
+            timeout = JobConstant.INSUFFICIENT_NODE_TIMEOUT_DEFAULT_MAX
         cur_nodes = list(self._nodes.values())
 
         # collect available nodes

--- a/dlrover/python/master/node/worker.py
+++ b/dlrover/python/master/node/worker.py
@@ -429,12 +429,16 @@ class WorkerManager(TrainingNodeManager):
         if len(available_nodes) < self.get_min_nodes_required():
             if self._last_insufficient_nodes_timestamp == 0:
                 self._last_insufficient_nodes_timestamp = int(now)
-                logger.warning(f"Job with insufficient nodes: {cur_nodes}.")
+                logger.warning(
+                    f"Job with insufficient nodes: {cur_nodes}. "
+                    f"Need at least: {self.get_min_nodes_required()}."
+                )
             else:
                 if now - self._last_insufficient_nodes_timestamp > timeout:
                     logger.warning(
                         f"Job with insufficient nodes: {cur_nodes} "
-                        f"lasts for more than {timeout}s."
+                        f"lasts for more than {timeout}s. "
+                        f"Need at least: {self.get_min_nodes_required()}."
                     )
                     return True
         else:

--- a/dlrover/python/master/node/worker.py
+++ b/dlrover/python/master/node/worker.py
@@ -398,6 +398,15 @@ class WorkerManager(TrainingNodeManager):
 
         return False
 
+    def _get_insufficient_timeout(self):
+        timeout = int(self.get_nodes_timeout() * 1.5)
+        if timeout < JobConstant.INSUFFICIENT_NODE_TIMEOUT_DEFAULT_MIN:
+            timeout = JobConstant.INSUFFICIENT_NODE_TIMEOUT_DEFAULT_MIN
+        elif timeout > JobConstant.INSUFFICIENT_NODE_TIMEOUT_DEFAULT_MAX:
+            timeout = JobConstant.INSUFFICIENT_NODE_TIMEOUT_DEFAULT_MAX
+
+        return timeout
+
     def is_training_hang_by_insufficient_worker(self) -> bool:
         """
         There is a small probability that due to unknown reason on the
@@ -413,11 +422,7 @@ class WorkerManager(TrainingNodeManager):
             return False
 
         # use 1.5 * rdzv-timeout with min: 600 and max: as timeout
-        timeout = int(self.get_nodes_timeout() * 1.5)
-        if timeout < JobConstant.INSUFFICIENT_NODE_TIMEOUT_DEFAULT_MIN:
-            timeout = JobConstant.INSUFFICIENT_NODE_TIMEOUT_DEFAULT_MIN
-        elif timeout > JobConstant.INSUFFICIENT_NODE_TIMEOUT_DEFAULT_MAX:
-            timeout = JobConstant.INSUFFICIENT_NODE_TIMEOUT_DEFAULT_MAX
+        timeout = self._get_insufficient_timeout()
         cur_nodes = list(self._nodes.values())
 
         # collect available nodes

--- a/dlrover/python/master/servicer.py
+++ b/dlrover/python/master/servicer.py
@@ -558,7 +558,7 @@ class MasterServicer(elastic_training_pb2_grpc.MasterServicer):
             )
 
         self._job_manager.update_node_required_info(
-            message.min_nodes, message.max_nodes
+            message.min_nodes, message.max_nodes, message.waiting_timeout
         )
         return True
 

--- a/dlrover/python/master/servicer.py
+++ b/dlrover/python/master/servicer.py
@@ -23,9 +23,9 @@ from dlrover.python.common import grpc
 from dlrover.python.common.constants import (
     GRPC,
     CustomMetricKeys,
+    JobConstant,
     NodeStatus,
     NodeType,
-    RdzvConstant,
     RendezvousName,
     TrainingExceptionLevel,
     TrainingLoopStatus,
@@ -560,7 +560,7 @@ class MasterServicer(elastic_training_pb2_grpc.MasterServicer):
 
         join_timeout = message.join_timeout
         if join_timeout == 0:  # Back compatibility
-            join_timeout = RdzvConstant.JOIN_TIMEOUT
+            join_timeout = JobConstant.RDZV_JOIN_TIMEOUT_DEFAULT
         self._job_manager.update_node_required_info(
             message.min_nodes, message.max_nodes, join_timeout
         )

--- a/dlrover/python/master/servicer.py
+++ b/dlrover/python/master/servicer.py
@@ -25,6 +25,7 @@ from dlrover.python.common.constants import (
     CustomMetricKeys,
     NodeStatus,
     NodeType,
+    RdzvConstant,
     RendezvousName,
     TrainingExceptionLevel,
     TrainingLoopStatus,
@@ -557,8 +558,11 @@ class MasterServicer(elastic_training_pb2_grpc.MasterServicer):
                 node_unit=message.node_unit,
             )
 
+        join_timeout = message.join_timeout
+        if join_timeout == 0:  # Back compatibility
+            join_timeout = RdzvConstant.JOIN_TIMEOUT
         self._job_manager.update_node_required_info(
-            message.min_nodes, message.max_nodes, message.waiting_timeout
+            message.min_nodes, message.max_nodes, join_timeout
         )
         return True
 

--- a/dlrover/python/tests/test_master.py
+++ b/dlrover/python/tests/test_master.py
@@ -137,7 +137,7 @@ class LocalJobMasterTest(unittest.TestCase):
         self.assertTrue(succeed)
 
     def test_rdzv_manager(self):
-        self.master_client.report_rdzv_params(1, 1, 360, 1)
+        self.master_client.report_rdzv_params(1, 1, 360, 1, 600)
         self.master_client.join_rendezvous(
             0, 8, RendezvousName.ELASTIC_TRAINING
         )

--- a/dlrover/python/tests/test_worker_manager.py
+++ b/dlrover/python/tests/test_worker_manager.py
@@ -208,7 +208,7 @@ class WorkerManagerTest(unittest.TestCase):
         )
         self.assertFalse(worker_manager.is_training_hang_by_pending(4))
 
-        worker_manager.update_node_required_info((4, 8))
+        worker_manager.update_node_required_info((4, 8, 600))
         self.assertFalse(worker_manager.is_training_hang_by_pending(4))
 
         mock_nodes = {}
@@ -302,7 +302,7 @@ class WorkerManagerTest(unittest.TestCase):
         # =============================================
         # condition: when node required is not updated
         # =============================================
-        worker_manager.update_node_required_info((0, 0))
+        worker_manager.update_node_required_info((0, 0, 600))
 
         # mock with 1 pending short time
         worker_num = 1

--- a/dlrover/python/tests/test_worker_manager.py
+++ b/dlrover/python/tests/test_worker_manager.py
@@ -374,9 +374,6 @@ class WorkerManagerTest(unittest.TestCase):
         )
 
     def test_is_training_hang_by_insufficient_worker(self):
-        # mock timeout 2 second(seconds_to_wait_pending_pod * 2)
-        _dlrover_ctx.seconds_to_wait_pending_pod = 1
-
         worker_manager = WorkerManager(
             self._job_nodes[NodeType.WORKER],
             self._job_resource,
@@ -388,7 +385,7 @@ class WorkerManagerTest(unittest.TestCase):
             worker_manager.is_training_hang_by_insufficient_worker()
         )
 
-        worker_manager.update_node_required_info((4, 8))
+        worker_manager.update_node_required_info((4, 8, 1))
         self.assertFalse(
             worker_manager.is_training_hang_by_insufficient_worker()
         )

--- a/dlrover/python/tests/test_worker_manager.py
+++ b/dlrover/python/tests/test_worker_manager.py
@@ -14,6 +14,7 @@
 import time
 import unittest
 from datetime import datetime, timedelta
+from unittest import mock
 
 from dlrover.python.common.constants import (
     NodeExitReason,
@@ -392,6 +393,9 @@ class WorkerManagerTest(unittest.TestCase):
 
         mock_nodes = {}
         is_insufficient = 0
+        worker_manager._get_insufficient_timeout = mock.MagicMock(
+            return_value=1
+        )
 
         # mock with 3 running + 1 pending
         for index in range(4):


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. Worker report 'join timeout' by ```report_rdzv_params```.
2. Master saves the 'join timeout' in worker manager.
3. Master base on the 'join timeout' to setup insufficient timeout.

For back compatibility(worker who don't report the join timeout):
Use the default 600s as the 'join timeout'.

For protection:
The timeout range is (600s, 3600s).

### Why are the changes needed?

Previously, we used the pending timeout period as the criterion for determining insufficiency. However, considering that users may configure the networking timeout period themselves, it is more scientific to directly use the networking timeout period for this configuration. 

The current definition of this timeout period is **1.5 times the networking timeout period**, which is used to avoid scenarios where **errors cannot be recovered within a complete round of the networking timeout period**.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

UT.
