### PR TITLE
Optimize training ending

### DIFF
--- a/dlrover/python/elastic_agent/torch/training.py
+++ b/dlrover/python/elastic_agent/torch/training.py
@@ -653,11 +653,15 @@ class ElasticTrainingAgent(LocalElasticAgent):
                     f" Waiting {self._exit_barrier_timeout} seconds "
                     "for other agents to finish."
                 )
-                self._exit_barrier()
-                logger.info("Barrier exited.")
 
-                self._wait_async_saver()
-                logger.info("Async saver stopped.")
+                try:
+                    self._exit_barrier()
+                    logger.info("Barrier exited.")
+
+                    self._wait_async_saver()
+                    logger.info("Async saver stopped.")
+                except Exception as e:
+                    logger.warning(f"Unexpected exception when ending: {e}")
 
                 return run_result
             elif state in {WorkerState.UNHEALTHY, WorkerState.FAILED}:

--- a/dlrover/python/tests/test_elastic_training_agent.py
+++ b/dlrover/python/tests/test_elastic_training_agent.py
@@ -286,6 +286,20 @@ class ElasticTrainingAgentRunTest(unittest.TestCase):
         self.assertDictEqual(run_result.failures, {})
         self.assertEqual(run_result.state, WorkerState.SUCCEEDED)
 
+    def test_failure_ending_after_training(self):
+        agent = ElasticTrainingAgent(
+            node_rank=0,
+            config=self.config,
+            entrypoint="echo",
+            spec=self.spec,
+            start_method=self.config.start_method,
+            log_dir=self.config.log_dir,
+        )
+        agent._wait_async_saver = mock.MagicMock(side_effect=[Exception])
+        run_result = agent._invoke_run()
+        self.assertDictEqual(run_result.failures, {})
+        self.assertEqual(run_result.state, WorkerState.SUCCEEDED)
+
     def test_report_resource_with_step(self):
         with tempfile.TemporaryDirectory() as tmpdirname:
             config_file = os.path.join(tmpdirname, "runtime_metrics.json")


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add try-except after training finished.

### Why are the changes needed?

1. To avoid unexpected failure in post action after finished training cause unexpected failover.
2. Add logging for unexpected failure.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

UT.
