### PR TITLE
Fix duplicate pod relaunching for some cases(with internal k8s).

### DIFF
--- a/dlrover/python/master/node/job_manager.py
+++ b/dlrover/python/master/node/job_manager.py
@@ -27,6 +27,7 @@ from dlrover.python.master.node.training_node import (
 )
 from dlrover.python.master.resource.job import JobResource
 from dlrover.python.scheduler.job import JobArgs
+from dlrover.python.scheduler.kubernetes import k8sClient
 
 
 class JobManager(metaclass=ABCMeta):
@@ -42,6 +43,7 @@ class JobManager(metaclass=ABCMeta):
     ):
         self._job_resource = JobResource()
         self._job_args = job_args
+        self._k8s_client = k8sClient.singleton_instance(job_args.namespace)
         self._job_strategy_generator: SimpleStrategyGenerator = (
             SimpleStrategyGenerator(self._job_args.job_uuid)
         )

--- a/dlrover/python/master/watcher/k8s_watcher.py
+++ b/dlrover/python/master/watcher/k8s_watcher.py
@@ -20,7 +20,6 @@ from dlrover.python.common.constants import (
     ElasticJobApi,
     ElasticJobLabel,
     ExitCode,
-    NodeEventType,
     NodeExitReason,
     NodeStatus,
     NodeType,
@@ -35,7 +34,6 @@ from dlrover.python.scheduler.kubernetes import (
     convert_memory_to_mb,
     k8sClient,
 )
-from dlrover.python.util import k8s_util
 
 
 def _get_start_timestamp(pod_status_obj):
@@ -80,7 +78,7 @@ def _get_pod_exit_reason(pod):
             return NodeExitReason.UNKNOWN_ERROR
 
 
-def _convert_pod_event_to_node_event(event, k8s_client):
+def _convert_pod_event_to_node_event(event):
     evt_obj = event.get("object")
     evt_type = event.get("type")
     if not evt_obj or not evt_type:
@@ -92,7 +90,6 @@ def _convert_pod_event_to_node_event(event, k8s_client):
         return None
 
     metadata: client.V1ObjectMeta = evt_obj.metadata
-    job_name = metadata.labels[ElasticJobLabel.JOB_KEY]
 
     # Skip events of dlrover mater Pod
     pod_type = metadata.labels[ElasticJobLabel.REPLICA_TYPE_KEY]
@@ -105,35 +102,9 @@ def _convert_pod_event_to_node_event(event, k8s_client):
     host_name = evt_obj.spec.node_name
     host_ip = evt_obj.status.host_ip
 
-    to_deleted_event = False
     status = evt_obj.status.phase
     if metadata.deletion_timestamp:
         status = NodeStatus.DELETED
-        to_deleted_event = True
-
-    # Skip deleted event of pod if the cluster has relaunched a new pod with
-    # the same type and rank as the deleted pod.
-    if evt_type == NodeEventType.DELETED or to_deleted_event:
-        pod_labels_selector = k8s_util.gen_k8s_label_selector_from_dict(
-            _get_pod_unique_labels(job_name, pod_type, rank)
-        )
-        logger.debug(
-            f"Recheck running pod with labels: {pod_labels_selector} "
-            f"for {evt_type} event."
-        )
-        pods = k8s_client.list_namespaced_pod(pod_labels_selector)
-        if (
-            pods
-            and len(pods.items) > 0
-            and any(
-                pod.status.phase == NodeStatus.RUNNING for pod in pods.items
-            )
-        ):
-            logger.info(
-                f"Skip deleted event for pod : {pod_labels_selector} "
-                f"for same running pod already exists."
-            )
-            return None
 
     restart = _verify_restarting_training(evt_obj)
     if restart:
@@ -216,9 +187,7 @@ class PodWatcher(NodeWatcher):
             )
 
             for event in stream:
-                node_event = _convert_pod_event_to_node_event(
-                    event, self._k8s_client
-                )
+                node_event = _convert_pod_event_to_node_event(event)
                 if not node_event:
                     continue
                 yield node_event

--- a/dlrover/python/tests/test_job_manager.py
+++ b/dlrover/python/tests/test_job_manager.py
@@ -396,7 +396,7 @@ class DistributedJobManagerTest(unittest.TestCase):
             nodes.append(node)
         manager._process_list_nodes(nodes)
         ps_ids = list(manager._job_nodes[NodeType.PS].keys())
-        self.assertListEqual(ps_ids, [0, 1, 2, 3])
+        self.assertListEqual(ps_ids, [0, 1, 2])
 
     def test_create_allreduce_job_manager(self):
         params = MockK8sPSJobArgs()

--- a/dlrover/python/tests/test_k8s_watcher.py
+++ b/dlrover/python/tests/test_k8s_watcher.py
@@ -96,43 +96,12 @@ class PodWatcherTest(unittest.TestCase):
         pod = create_pod(labels)
         event_type = NodeEventType.MODIFIED
         event = {"object": pod, "type": event_type}
-        node_event: NodeEvent = _convert_pod_event_to_node_event(
-            event, self.k8s_client
-        )
+        node_event: NodeEvent = _convert_pod_event_to_node_event(event)
         self.assertEqual(node_event.event_type, event_type)
         self.assertEqual(node_event.node.id, 0)
         self.assertEqual(node_event.node.type, NodeType.WORKER)
         self.assertEqual(node_event.node.config_resource.cpu, 1)
         self.assertEqual(node_event.node.config_resource.memory, 10240)
-
-    def test_convert_pod_deleted_event_to_node_event_with_existed_running_pod(
-        self,
-    ):
-        # one of the mocked label must be the same with the one generated in
-        # 'test_utils.py#mock_list_namespaced_pod'
-
-        # test DELETED event
-        labels = _mock_pod_labels()
-        pod = create_pod(labels)
-        event_type = NodeEventType.DELETED
-        event = {"object": pod, "type": event_type}
-        self.assertIsNone(
-            _convert_pod_event_to_node_event(event, self.k8s_client)
-        )
-
-        # test MODIFIED event without deletion_timestamp
-        event_type = NodeEventType.MODIFIED
-        event = {"object": pod, "type": event_type}
-        self.assertIsNotNone(
-            _convert_pod_event_to_node_event(event, self.k8s_client)
-        )
-
-        # test MODIFIED event with deletion_timestamp
-        pod = create_pod(labels, True)
-        event = {"object": pod, "type": event_type}
-        self.assertIsNone(
-            _convert_pod_event_to_node_event(event, self.k8s_client)
-        )
 
     def test_get_pod_exit_reason(self):
         labels = _mock_pod_labels()


### PR DESCRIPTION
### What changes were proposed in this pull request?

Do judgement in 'process_event' instead of in 'k8s watcher'. Because there are 2 ways to trigger node event processing. Judgement in 'k8s watcher' is not enough.

### Why are the changes needed?

To fix duplicate pod relaunching for some cases(TKP).

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

UT.
