### PR TITLE
Filter non training logs

### DIFF
--- a/dlrover/python/diagnosis/datacollector/training_log_collector.py
+++ b/dlrover/python/diagnosis/datacollector/training_log_collector.py
@@ -32,6 +32,15 @@ class TrainingLogCollector(DataCollector):
             return TrainingLog()
         byte_logs = read_last_n_lines(self._log_file, self._n_line)
         logs = [str(line) for line in byte_logs]
+        # only collect training logs
+        if len(logs) > 0:
+            training_start_line = 0
+            start_str = "DLRover agent started with:"
+            for i in range(len(logs)):
+                if start_str in logs[i]:
+                    training_start_line = i
+                    break
+            logs = logs[training_start_line:]
         training_log = TrainingLog(logs=logs)
         return training_log
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

When to read the training logs, DLrover only reads logs after the training is started.

### Why are the changes needed?

Avoid non-training log noises.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

Unit test.