### PR TITLE
Skip empty error codes when check node failures

### DIFF
--- a/dlrover/python/diagnosis/inferencechain/inferenceoperator/check_failure_node_operator.py
+++ b/dlrover/python/diagnosis/inferencechain/inferenceoperator/check_failure_node_operator.py
@@ -73,6 +73,7 @@ class CheckFailureNodeOperator(InferenceOperator):
         # export FAILURE_NODE_ERRORS="error code is 12345# error code is
         # 23456# error code is 507035"
         error_codes = errors.split("#")
+        error_codes = [error_code.strip() for error_code in error_codes]
 
         collector = TrainingLogCollector(log_file, 5000)
         training_log = collector.collect_data()
@@ -92,7 +93,7 @@ class CheckFailureNodeOperator(InferenceOperator):
             if is_failure_node:
                 break
             for error in error_codes:
-                if error in log:
+                if len(error) > 0 and error in log:
                     is_failure_node = True
                     break
         if is_failure_node:

--- a/dlrover/python/tests/test_diagnosis_agent.py
+++ b/dlrover/python/tests/test_diagnosis_agent.py
@@ -91,7 +91,7 @@ class TestDiagnosisAgent(unittest.TestCase):
         action = agent.diagnose_training_failure(wc)
         self.assertEqual(action, DiagnoseAction.RELAUNCH_WORKER)
 
-        agent._errors = ""
+        agent._errors = " #"
         wc.remaining_failovers = 2
         action = agent.diagnose_training_failure(wc)
         self.assertEqual(action, DiagnoseAction.RESTART_WORKER)

--- a/dlrover/python/tests/test_diagnosis_agent.py
+++ b/dlrover/python/tests/test_diagnosis_agent.py
@@ -91,6 +91,11 @@ class TestDiagnosisAgent(unittest.TestCase):
         action = agent.diagnose_training_failure(wc)
         self.assertEqual(action, DiagnoseAction.RELAUNCH_WORKER)
 
+        agent._errors = ""
+        wc.remaining_failovers = 2
+        action = agent.diagnose_training_failure(wc)
+        self.assertEqual(action, DiagnoseAction.RESTART_WORKER)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### What changes were proposed in this pull request?

Check if error code is empty when detecting failure node.

### Why are the changes needed?

There is a bug when error code is empty.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

Unit test.
