### PR TITLE
In Ascend NPU, stop workers together with its children processes

### DIFF
--- a/dlrover/python/elastic_agent/torch/training.py
+++ b/dlrover/python/elastic_agent/torch/training.py
@@ -783,11 +783,10 @@ class ElasticTrainingAgent(LocalElasticAgent):
                 stop all the children processes before shutdown the workers
                 """
                 if self._pcontext is not None:
-                    for pid in self._pcontext.pids():
-                        logger.info(f"kill process {pid} and its sub processes")
-                        if pid == 0:
-                            logger.info("skip invalid process 0")
-                            continue
+                    pc_pids = set(self._pcontext.pids().values())
+                    logger.info(f"try to kill child processes of %s", pc_pids)
+                    for pid in pc_pids:
+                        logger.info(f"kill child processes of process {pid}")
                         try:
                             pp = psutil.Process(pid)
                             cp = pp.children()

--- a/dlrover/python/elastic_agent/torch/training.py
+++ b/dlrover/python/elastic_agent/torch/training.py
@@ -784,11 +784,19 @@ class ElasticTrainingAgent(LocalElasticAgent):
                 """
                 if self._pcontext is not None:
                     for pid in self._pcontext.pids():
-                        pp = psutil.Process(pid)
-                        cp = pp.children()
-                        for proc in cp:
-                            logger.info(f"kill sub {proc.pid} of parent {pid}")
-                            os.kill(proc.pid, signal.SIGKILL)
+                        logger.info(f"kill process {pid} and its sub processes")
+                        if pid == 0:
+                            logger.info("skip invalid process 0")
+                            continue
+                        try:
+                            pp = psutil.Process(pid)
+                            cp = pp.children()
+                            for proc in cp:
+                                logger.info(f"kill sub {proc.pid} of parent {pid}")
+                                os.kill(proc.pid, signal.SIGKILL)
+                        except Exception as e:
+                            logger.info(f"Error when kill {pid}: {str(e)}")
+
                 self._shutdown(death_sig=signal.SIGKILL)
             else:
                 if version_less_than_240():

--- a/dlrover/python/tests/test_elastic_training_agent.py
+++ b/dlrover/python/tests/test_elastic_training_agent.py
@@ -426,9 +426,23 @@ class ElasticTrainingAgentRunTest(unittest.TestCase):
         # without timeout
         agent._stop_workers(None, is_restart=False, timeout=3)
 
+        # test Ascend NPU
+        self.config.accelerator = Accelerators.ASCEND_NPU
+        agent = ElasticTrainingAgent(
+            node_rank=0,
+            config=self.config,
+            entrypoint="echo",
+            spec=self.spec,
+            start_method=self.config.start_method,
+            log_dir=self.config.log_dir,
+        )
+
+        agent._stop_workers(None, is_restart=False, timeout=3)
+
         def sleep_10_seconds(*args, **kwargs):
             time.sleep(10)
 
+        self.config.accelerator = Accelerators.NVIDIA_GPU
         # with timeout
         with patch.object(
             LocalElasticAgent, "_stop_workers", side_effect=sleep_10_seconds


### PR DESCRIPTION
### What changes were proposed in this pull request?

Be adapt to Ascend NPU cases, to stop workers and make sure no remaining processes are using NPU

### Why are the changes needed?

In Ascend NPU, workers will fork many child processes, and we need to clear all of them

### Does this PR introduce any user-facing change?

NO

### How was this patch tested?

UT