### PR TITLE
Optimize heartbeat timeout judgement if worker already succeeded.

### DIFF
--- a/dlrover/python/common/grpc.py
+++ b/dlrover/python/common/grpc.py
@@ -509,3 +509,8 @@ class ElasticRunConfigRequest(Message):
 @dataclass
 class ElasticRunConfig(Message):
     configs: Dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class SucceededRequest(Message):
+    pass

--- a/dlrover/python/common/node.py
+++ b/dlrover/python/common/node.py
@@ -216,6 +216,7 @@ class Node(object):
         self.migrated = False
         self.unrecoverable_failure_msg = ""
         self.heartbeat_time = 0
+        self.succeeded = False
 
     def exited(self):
         return self.status in [
@@ -339,6 +340,12 @@ class Node(object):
             and self.status == NodeStatus.INITIAL
         ):
             return True
+
+    def set_as_succeeded(self):
+        self.succeeded = True
+
+    def is_succeeded(self):
+        return self.succeeded
 
     def __repr__(self):
         return (

--- a/dlrover/python/elastic_agent/master_client.py
+++ b/dlrover/python/elastic_agent/master_client.py
@@ -420,6 +420,11 @@ class MasterClient(Singleton):
         response: grpc.ElasticRunConfig = self._get(request)
         return response.configs
 
+    def report_succeeded(self):
+        request = grpc.SucceededRequest()
+        response = self._report(request)
+        return response.success
+
     @classmethod
     def singleton_instance(cls, *args, **kwargs):
         if not cls._instance:

--- a/dlrover/python/elastic_agent/torch/training.py
+++ b/dlrover/python/elastic_agent/torch/training.py
@@ -850,6 +850,8 @@ class ElasticTrainingAgent(LocalElasticAgent):
                     logger.info("Async saver stopped.")
                 except Exception as e:
                     logger.warning(f"Unexpected exception when ending: {e}")
+                finally:
+                    self._client.report_succeeded()
 
                 return run_result
             elif state in {WorkerState.UNHEALTHY, WorkerState.FAILED}:

--- a/dlrover/python/master/node/dist_job_manager.py
+++ b/dlrover/python/master/node/dist_job_manager.py
@@ -1138,9 +1138,11 @@ class DistributedJobManager(JobManager):
 
     def update_succeeded_node(self, node_id, node_type):
         with self._lock:
-            if node_type in self._job_nodes:
-                if node_id in self._job_nodes[node_type]:
-                    self._job_nodes[node_type][node_id].set_as_succeeded()
+            if (
+                node_type in self._job_nodes
+                and node_id in self._job_nodes[node_type]
+            ):
+                self._job_nodes[node_type][node_id].set_as_succeeded()
 
 
 def create_job_manager(args: JobArgs, speed_monitor) -> DistributedJobManager:

--- a/dlrover/python/master/node/dist_job_manager.py
+++ b/dlrover/python/master/node/dist_job_manager.py
@@ -470,6 +470,7 @@ class DistributedJobManager(JobManager):
                     and node.start_time
                     and node.create_time
                     and node.status == NodeStatus.RUNNING
+                    and not node.is_succeeded()
                 ):
                     if (
                         node.heartbeat_time <= node.start_time.timestamp()
@@ -1134,6 +1135,12 @@ class DistributedJobManager(JobManager):
 
     def update_node_required_info_callback(self):
         self._worker_manager.update_node_required_info(self._nodes_required)
+
+    def update_succeeded_node(self, node_id, node_type):
+        with self._lock:
+            if node_type in self._job_nodes:
+                if node_id in self._job_nodes[node_type]:
+                    self._job_nodes[node_type][node_id].set_as_succeeded()
 
 
 def create_job_manager(args: JobArgs, speed_monitor) -> DistributedJobManager:

--- a/dlrover/python/master/node/dist_job_manager.py
+++ b/dlrover/python/master/node/dist_job_manager.py
@@ -1138,11 +1138,7 @@ class DistributedJobManager(JobManager):
 
     def update_succeeded_node(self, node_id, node_type):
         with self._lock:
-            if (
-                node_type in self._job_nodes
-                and node_id in self._job_nodes[node_type]
-            ):
-                self._job_nodes[node_type][node_id].set_as_succeeded()
+            super().update_succeeded_node(node_id, node_type)
 
 
 def create_job_manager(args: JobArgs, speed_monitor) -> DistributedJobManager:

--- a/dlrover/python/master/node/job_manager.py
+++ b/dlrover/python/master/node/job_manager.py
@@ -233,6 +233,8 @@ class JobManager(metaclass=ABCMeta):
         return self._training_node_config.get_elastic_run_configs()
 
     def update_succeeded_node(self, node_id, node_type):
-        if node_type in self._job_nodes:
-            if node_id in self._job_nodes[node_type]:
-                self._job_nodes[node_type][node_id].set_as_succeeded()
+        if (
+            node_type in self._job_nodes
+            and node_id in self._job_nodes[node_type]
+        ):
+            self._job_nodes[node_type][node_id].set_as_succeeded()

--- a/dlrover/python/master/node/job_manager.py
+++ b/dlrover/python/master/node/job_manager.py
@@ -237,4 +237,5 @@ class JobManager(metaclass=ABCMeta):
             node_type in self._job_nodes
             and node_id in self._job_nodes[node_type]
         ):
+            logger.info(f"Node {node_id}({node_type}) to succeeded.")
             self._job_nodes[node_type][node_id].set_as_succeeded()

--- a/dlrover/python/master/node/job_manager.py
+++ b/dlrover/python/master/node/job_manager.py
@@ -231,3 +231,8 @@ class JobManager(metaclass=ABCMeta):
 
     def get_elastic_run_configs(self) -> Dict[str, str]:
         return self._training_node_config.get_elastic_run_configs()
+
+    def update_succeeded_node(self, node_id, node_type):
+        if node_type in self._job_nodes:
+            if node_id in self._job_nodes[node_type]:
+                self._job_nodes[node_type][node_id].set_as_succeeded()

--- a/dlrover/python/master/servicer.py
+++ b/dlrover/python/master/servicer.py
@@ -361,6 +361,8 @@ class MasterServicer(elastic_training_pb2_grpc.MasterServicer):
             success = self._sync_checkpoint(node_type, node_id, message)
         elif isinstance(message, grpc.DiagnosisReportData):
             success = self._report_worker_diagnosis_data(message)
+        elif isinstance(message, grpc.SucceededRequest):
+            success = self._report_succeeded(node_id, node_type)
 
         response.success = success
         return response
@@ -630,6 +632,10 @@ class MasterServicer(elastic_training_pb2_grpc.MasterServicer):
                 return False
             data_obj = data_cls.from_json(message.data_content)
             self._diagnosis_manager.collect_diagnosis_data(data_obj)
+        return True
+
+    def _report_succeeded(self, node_id, node_type):
+        self._job_manager.update_succeeded_node(node_id, node_type)
         return True
 
     def _sync_training_ports(

--- a/dlrover/python/tests/test_node.py
+++ b/dlrover/python/tests/test_node.py
@@ -46,3 +46,7 @@ class NodeTest(unittest.TestCase):
         is_unrecoverable = node.is_unrecoverable_failure()
         self.assertEqual(is_unrecoverable, True)
         self.assertEqual("oom" in node.unrecoverable_failure_msg, True)
+
+        self.assertFalse(node.is_succeeded())
+        node.set_as_succeeded()
+        self.assertTrue(node.is_succeeded())

--- a/dlrover/python/tests/test_servicer.py
+++ b/dlrover/python/tests/test_servicer.py
@@ -424,6 +424,10 @@ class MasterServicerTest(unittest.TestCase):
         )
         self.assertTrue(self.servicer._report_worker_diagnosis_data(request))
 
+    def test_report_succeeded(self):
+        self.assertTrue(self.servicer._report_succeeded(0, NodeType.WORKER))
+        self.assertTrue(self.servicer._report_succeeded(0, "test"))
+
 
 class MasterServicerForRayTest(unittest.TestCase):
     def setUp(self) -> None:


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. Add 'succeeded report' implement.
2. Add 'succeeded' flag for ```Node``` object.
3. Skip 'succeeded node' in 'noheartbeat' judgement.

### Why are the changes needed?

Won't trigger heartbeat timeout if agent already succeeded exit.

### Does this PR introduce any user-facing change?

Specify whether this pull request introduces any changes that users will directly interact with or notice.

### How was this patch tested?

Ut and training job.
