### PR TITLE
Fix issue in ckpt saver.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,7 @@ name: CI
 
 on:
   pull_request:
+  workflow_dispatch:
   push:
     branches: [master]
 

--- a/dlrover/python/elastic_agent/torch/ckpt_saver.py
+++ b/dlrover/python/elastic_agent/torch/ckpt_saver.py
@@ -999,6 +999,28 @@ class TempDirCheckpointSaver(AsyncCheckpointSaver):
     by users.
     """
 
+    def __init__(
+        self,
+        checkpoint_dir,
+        storage_meta: ClassMeta,
+        local_shard_num=1,
+        global_shard_num=1,
+        save_timeout=CheckpointConstant.SAVE_TIMEOUT,
+    ) -> None:
+        super().__init__(
+            checkpoint_dir,
+            storage_meta,
+            local_shard_num,
+            global_shard_num,
+            save_timeout,
+        )
+
+        if self._node_rank == 0:
+            # remove the history temp path if exists
+            self.storage.safe_rmtree(
+                os.path.join(self.checkpoint_dir, self._STAGE_DIR)
+            )
+
     def save_step_checkpoint(self, step):
         """
         Save the checkpoint of a step into the storage.

--- a/dlrover/python/elastic_agent/torch/ckpt_saver.py
+++ b/dlrover/python/elastic_agent/torch/ckpt_saver.py
@@ -785,6 +785,12 @@ class AsyncCheckpointSaver(metaclass=ABCMeta):
                     )
                     return False
 
+    def _remove_sub_dir_of_target_path(self, path):
+        for entry in os.listdir(path):
+            full_path = os.path.join(path, entry)
+            if os.path.isdir(full_path):
+                self.storage.safe_rmtree(full_path)
+
     @classmethod
     def reset(cls):
         """Reset the shared memory of all shards."""
@@ -1017,7 +1023,7 @@ class TempDirCheckpointSaver(AsyncCheckpointSaver):
 
         if self._node_rank == 0:
             # remove the history temp path if exists
-            self.storage.safe_rmtree(
+            self._remove_sub_dir_of_target_path(
                 os.path.join(self.checkpoint_dir, self._STAGE_DIR)
             )
 

--- a/dlrover/python/elastic_agent/torch/ckpt_saver.py
+++ b/dlrover/python/elastic_agent/torch/ckpt_saver.py
@@ -414,7 +414,7 @@ class AsyncCheckpointSaver(metaclass=ABCMeta):
         )
         self._master_client = None
 
-        logger.info("AsyncSaver initialized.")
+        logger.info(f"AsyncSaver({self.__class__.__name__}) initialized.")
 
     def __del__(self):
         self.close()

--- a/dlrover/python/elastic_agent/torch/ckpt_saver.py
+++ b/dlrover/python/elastic_agent/torch/ckpt_saver.py
@@ -777,15 +777,16 @@ class AsyncCheckpointSaver(metaclass=ABCMeta):
                 if elapsed_time > timeout:
                     logger.info(
                         "It is timeout to sync checkpoint "
-                        "bacause some nodes may fail."
+                        "because some nodes may fail."
                     )
                     return False
 
     def _remove_sub_dir_of_target_path(self, path):
-        for entry in os.listdir(path):
-            full_path = os.path.join(path, entry)
-            if os.path.isdir(full_path):
-                self.storage.safe_rmtree(full_path)
+        if os.path.exists(path):
+            for entry in os.listdir(path):
+                full_path = os.path.join(path, entry)
+                if os.path.isdir(full_path):
+                    self.storage.safe_rmtree(full_path)
 
     @classmethod
     def reset(cls):

--- a/dlrover/python/elastic_agent/torch/ckpt_saver.py
+++ b/dlrover/python/elastic_agent/torch/ckpt_saver.py
@@ -414,10 +414,6 @@ class AsyncCheckpointSaver(metaclass=ABCMeta):
         )
         self._master_client = None
 
-        # remove the history temp path if exists
-        self.storage.safe_rmtree(
-            os.path.join(self.checkpoint_dir, self._STAGE_DIR)
-        )
         logger.info("AsyncSaver initialized.")
 
     def __del__(self):

--- a/dlrover/python/tests/test_ckpt_saver.py
+++ b/dlrover/python/tests/test_ckpt_saver.py
@@ -157,6 +157,22 @@ class CheckpointSaverTest(unittest.TestCase):
             id(AsyncCheckpointSaver._saver_instance._master_client),
         )
 
+        # test
+        test_path = "/tmp/test_ckpt"
+        AsyncCheckpointSaver._saver_instance.checkpoint_dir = test_path
+        os.makedirs(test_path, exist_ok=True)
+        os.makedirs(os.path.join(test_path, "td1"), exist_ok=True)
+        with open(
+            os.path.join(test_path, "tf1"), "w", encoding="utf-8"
+        ) as file:
+            file.write("test")
+        AsyncCheckpointSaver._saver_instance._remove_sub_dir_of_target_path(
+            test_path
+        )
+        self.assertTrue(os.path.exists(test_path))
+        self.assertTrue(os.path.exists(os.path.join(test_path, "tf1")))
+        self.assertFalse(os.path.exists(os.path.join(test_path, "td1")))
+
     def test_close_saver(self):
         saver = DdpCheckpointSaver("test_ckpt", self.storage.get_class_meta())
         try:

--- a/dlrover/trainer/torch/flash_checkpoint/engine.py
+++ b/dlrover/trainer/torch/flash_checkpoint/engine.py
@@ -174,7 +174,7 @@ class CheckpointEngine(metaclass=ABCMeta):
         self.storage = storage
         self._save_timeout = save_timeout
         self._local_rank = env_utils.get_local_rank()
-        self._cached_step = 0
+        self._cached_step = -1
         self._restart_count = env_utils.get_torch_restart_count()
 
         # init saver


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. Move the 'cleaning' operation into ```TempDirCkptSaver```.
2. Optimize the operation: cleaning the sub directory(clean the 'step' path only) if necessary.
3. 'cached_step' start from -1 to support step 0 saving.

### Why are the changes needed?

1. ```CommonDirCkptSaver``` no need for temp directory cleaning.
2. Support step 0 saving.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

UT.
