### PR TITLE
Fix empty node issue after master failover

### DIFF
--- a/dlrover/python/master/node/dist_job_manager.py
+++ b/dlrover/python/master/node/dist_job_manager.py
@@ -1004,7 +1004,7 @@ class DistributedJobManager(JobManager):
             return
         if (
             node_type not in self._job_nodes
-            or node_id in self._job_nodes[node_type]
+            or node_id not in self._job_nodes[node_type]
         ):
             logger.warning(
                 "Skip updating node resource usage for node "

--- a/dlrover/python/master/node/dist_job_manager.py
+++ b/dlrover/python/master/node/dist_job_manager.py
@@ -576,7 +576,10 @@ class DistributedJobManager(JobManager):
                 exist_nodes[node_type].append(node_id)
 
                 # for nodes not in current 'job_nodes' obj, re add it
-                if node_id not in self._job_nodes[node_type] and node.status != NodeStatus.DELETED:
+                if (
+                    node_id not in self._job_nodes[node_type]
+                    and node.status != NodeStatus.DELETED
+                ):
                     logger.info(
                         f"Node {node_type} {node.id} with status {node.status}"
                         " is re added without the event"
@@ -994,14 +997,19 @@ class DistributedJobManager(JobManager):
         self, node_type, node_id, cpu, memory, gpu_stats=[]
     ):
         if not self._job_nodes:
-            logger.warning("Skip updating node resource usage for job_nodes "
-                           "hasn't been initialized.")
+            logger.warning(
+                "Skip updating node resource usage for job_nodes "
+                "hasn't been initialized."
+            )
             return
-        if (node_type not in self._job_nodes
-                or node_id in self._job_nodes[node_type]
+        if (
+            node_type not in self._job_nodes
+            or node_id in self._job_nodes[node_type]
         ):
-            logger.warning("Skip updating node resource usage for node "
-                           f"{node_type}-{node_id} can not be found.")
+            logger.warning(
+                "Skip updating node resource usage for node "
+                f"{node_type}-{node_id} can not be found."
+            )
             return
         node = self._job_nodes[node_type][node_id]
         node.update_resource_usage(cpu, memory, gpu_stats)

--- a/dlrover/python/master/scaler/pod_scaler.py
+++ b/dlrover/python/master/scaler/pod_scaler.py
@@ -472,12 +472,9 @@ class PodScaler(Scaler):
         env.append(V1EnvVar(name=NodeEnv.JOB_NAME, value=self._job_name))
         env.append(V1EnvVar(name=NodeEnv.JOB_UID, value=self._job_uid))
 
-        # At the cost of increased performance overhead, these provide greater
-        # stability in concurrent scenarios. (need grpcio version>=1.58)
         # A history background: https://chromium.googlesource.com/external/
         # github.com/grpc/grpc/+/refs/tags/v1.19.0-pre1/doc/fork_support.md
-        env.append(V1EnvVar(name=NodeEnv.GRPC_ENABLE_FORK, value="true"))
-        env.append(V1EnvVar(name=NodeEnv.GRPC_POLL_STRATEGY, value="poll"))
+        env.append(V1EnvVar(name=NodeEnv.GRPC_ENABLE_FORK, value="false"))
 
         worker_num = self._config_worker_num
         if worker_num == 0:

--- a/dlrover/python/tests/test_job_manager.py
+++ b/dlrover/python/tests/test_job_manager.py
@@ -416,6 +416,7 @@ class DistributedJobManagerTest(unittest.TestCase):
         params.initilize()
         manager = create_job_manager(params, SpeedMonitor())
         manager._init_nodes()
+        self.assertFalse(4 in manager._job_nodes[NodeType.WORKER])
         for node in manager._job_nodes[NodeType.PS].values():
             node.status = NodeStatus.PENDING
         nodes = []
@@ -428,9 +429,19 @@ class DistributedJobManagerTest(unittest.TestCase):
                 max_relaunch_count=1,
             )
             nodes.append(node)
+        nodes.append(
+            Node(
+                node_type=NodeType.WORKER,
+                node_id=4,
+                status=NodeStatus.RUNNING,
+                config_resource=NodeResource(1, 4096),
+                max_relaunch_count=1,
+            )
+        )
         manager._process_list_nodes(nodes)
         ps_ids = list(manager._job_nodes[NodeType.PS].keys())
         self.assertListEqual(ps_ids, [0, 1, 2])
+        self.assertTrue(4 in manager._job_nodes[NodeType.WORKER])
 
     @patch.object(DistributedJobManager, "_process_event")
     def test_process_list_nodes_for_empty_case(self, mock_method):


### PR DESCRIPTION
### What changes were proposed in this pull request?

Re add relaunch worker node info back to ```job_nodes``` in ```JobManager``` during 'list' operation.

### Why are the changes needed?

Fix empty node issue after master failover.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

UT and training(with worker failover + master failover).
