### PR TITLE
Update build_proto.sh to use pip3 instead of pip

### DIFF
--- a/scripts/build_proto.sh
+++ b/scripts/build_proto.sh
@@ -14,9 +14,9 @@
 
 set -e
 set -x
-PROTOBUF_VERSION_SRC=$(pip show protobuf | grep Version | cut -d' ' -f2)
-GRPCIO_VERSION_SRC=$(pip show grpcio | grep Version | cut -d' ' -f2)
-GRPCIO_TOOLS_VERSION_SRC=$(pip show grpcio-tools | grep Version | cut -d' ' -f2)
+PROTOBUF_VERSION_SRC=$(pip3 show protobuf | grep Version | cut -d' ' -f2)
+GRPCIO_VERSION_SRC=$(pip3 show grpcio | grep Version | cut -d' ' -f2)
+GRPCIO_TOOLS_VERSION_SRC=$(pip3 show grpcio-tools | grep Version | cut -d' ' -f2)
 PROTOS_DIR=dlrover/proto
 
 generate_proto_files() {
@@ -32,7 +32,7 @@ generate_proto_files() {
   cd "$protodir"
   for fn in $proto_files; do
     filename=$(basename "$fn" .proto)
-    python -m grpc_tools.protoc -I. -I"$base_dir" --python_out=. --grpc_python_out=. "$filename".proto
+    python3 -m grpc_tools.protoc -I. -I"$base_dir" --python_out=. --grpc_python_out=. "$filename".proto
     sed -i "s/import ${filename}_pb2/from \. import ${filename}_pb2/g" "$filename"_pb2_grpc.py
   done
   rm -rf ./*.proto
@@ -44,19 +44,13 @@ if [ "$(printf '%02d\n' "${CUR_PYTHON_VERSION}")" -le 36 ]; then
   PROTOBUF_VERSION="3.13.0"
   GRPCIO_VERSION="1.29.0"
   GRPCIO_TOOLS_VERSION="1.29.0"
-  pip install protobuf==$PROTOBUF_VERSION grpcio==$GRPCIO_VERSION grpcio-tools==$GRPCIO_TOOLS_VERSION
-  generate_proto_files protobuf_3_20_3
-elif [ "$(printf '%02d\n' "${CUR_PYTHON_VERSION}")" -ge 38 ]; then
-  PROTOBUF_VERSION="3.20.3"
-  GRPCIO_VERSION="1.34.1"
-  GRPCIO_TOOLS_VERSION="1.34.1"
-  pip install protobuf==$PROTOBUF_VERSION grpcio==$GRPCIO_VERSION grpcio-tools==$GRPCIO_TOOLS_VERSION
+  pip3 install protobuf==$PROTOBUF_VERSION grpcio==$GRPCIO_VERSION grpcio-tools==$GRPCIO_TOOLS_VERSION
   generate_proto_files protobuf_3_20_3
 elif [ "$(printf '%02d\n' "${CUR_PYTHON_VERSION}")" -ge 38 ]; then
   PROTOBUF_VERSION="4.25.3"
   GRPCIO_VERSION="1.62.1"
   GRPCIO_TOOLS_VERSION="1.58.0"
-  pip install protobuf==$PROTOBUF_VERSION grpcio==$GRPCIO_VERSION grpcio-tools==$GRPCIO_TOOLS_VERSION
+  pip3 install protobuf==$PROTOBUF_VERSION grpcio==$GRPCIO_VERSION grpcio-tools==$GRPCIO_TOOLS_VERSION
   generate_proto_files protobuf_4_25_3
-  pip install protobuf=="$PROTOBUF_VERSION_SRC" grpcio=="$GRPCIO_VERSION_SRC" grpcio-tools=="$GRPCIO_TOOLS_VERSION_SRC"
+  pip3 install protobuf=="$PROTOBUF_VERSION_SRC" grpcio=="$GRPCIO_VERSION_SRC" grpcio-tools=="$GRPCIO_TOOLS_VERSION_SRC"
 fi


### PR DESCRIPTION
### What changes were proposed in this pull request?

Update build_proto.sh to use pip3 instead of pip

### Why are the changes needed?

This update addresses an issue where environments with Python 2.7 could default to pip related to Python 2, leading to incorrect generation of protobuf files.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

Internal CI/CD execution.