### PR TITLE
Skip memory limitation for gpu type node relaunch operation.

### DIFF
--- a/dlrover/python/common/node.py
+++ b/dlrover/python/common/node.py
@@ -363,6 +363,16 @@ class Node(object):
     def is_node_check_failed(self):
         return self.reported_status == NodeEventType.NODE_CHECK_FAILED
 
+    def is_resource_scalable(self):
+        """
+        This is a temp implement:
+            resource is not scalable if resource has gpu
+        """
+
+        if self.config_resource.gpu_num > 0:
+            return False
+        return True
+
     def __repr__(self):
         return (
             f"name:{self.name};"

--- a/dlrover/python/master/node/dist_job_manager.py
+++ b/dlrover/python/master/node/dist_job_manager.py
@@ -866,20 +866,21 @@ class DistributedJobManager(JobManager):
                 msg = "Disable relaunch"
             elif node.exit_reason == NodeExitReason.OOM:
                 mem = node.config_resource.memory
-                if mem >= NodeResourceLimit.MAX_MEMORY:
+                if (
+                    node.is_resource_scalable()
+                    and mem >= NodeResourceLimit.MAX_MEMORY
+                ):
                     should_relaunch = False
                     logger.warning(
-                        "The memory of worker %s is beyond the limit %s MB.",
-                        mem,
-                        NodeResourceLimit.MAX_MEMORY,
+                        f"The memory of node {mem} is beyond the limit "
+                        f"{NodeResourceLimit.MAX_MEMORY} MB."
                     )
                     msg = f"{mem} beyond {NodeResourceLimit.MAX_MEMORY}"
                 elif node.relaunch_count >= node.max_relaunch_count:
                     should_relaunch = False
                     logger.warning(
-                        "The relaunched count %s is beyond the maximum %s.",
-                        node.relaunch_count,
-                        node.max_relaunch_count,
+                        f"The relaunched count {node.relaunch_count} is "
+                        f"beyond the maximum {node.max_relaunch_count}."
                     )
                     msg = (
                         f"Relaunched {node.relaunch_count} "

--- a/dlrover/python/master/node/training_node.py
+++ b/dlrover/python/master/node/training_node.py
@@ -284,7 +284,7 @@ class TrainingNodeManager(object):
         return plan
 
     def reduce_pending_node_resource(self):
-        """Cut down CPU cores of pendding PS Pods"""
+        """Cut down CPU cores of pending PS Pods"""
         plan = ScalePlan()
 
         # Avoid dictionary changed size during iteration.

--- a/dlrover/python/master/resource/job.py
+++ b/dlrover/python/master/resource/job.py
@@ -536,7 +536,7 @@ class AllreduceJobResourceOptimizer(JobResourceOptimizer):
         pass
 
     def get_job_resource_plan(self) -> ResourcePlan:
-        """Check wether there are free nodes in the cluster."""
+        """Check whether there are free nodes in the cluster."""
         plan = ResourcePlan()
         worker_config = copy.deepcopy(self._original_worker_resource)
         max_node_num = self._original_worker_resource.count
@@ -554,7 +554,14 @@ class AllreduceJobResourceOptimizer(JobResourceOptimizer):
 
     def adjust_oom_resource(self, node: Node):
         """Adjust the resource configuration for OOM nodes"""
-        node.config_resource.memory *= 2
+
+        if node.config_resource.memory > NodeResourceLimit.MAX_MEMORY:
+            # no memory extension if the current value > the default max
+            pass
+        else:
+            node.config_resource.memory = min(
+                node.config_resource.memory * 2, NodeResourceLimit.MAX_MEMORY
+            )
 
     def get_config_resource(self):
         job_config = JobResource()

--- a/dlrover/python/tests/test_node.py
+++ b/dlrover/python/tests/test_node.py
@@ -31,6 +31,7 @@ class NodeTest(unittest.TestCase):
         node.relaunch_count = 3
         node.config_resource.gpu_num = 1
         is_unrecoverable = node.is_unrecoverable_failure()
+        self.assertFalse(node.is_resource_scalable())
         self.assertEqual(is_unrecoverable, True)
         self.assertEqual("exhausted" in node.unrecoverable_failure_msg, True)
 
@@ -48,6 +49,7 @@ class NodeTest(unittest.TestCase):
         node.config_resource.memory = NodeResourceLimit.MAX_MEMORY
         node.exit_reason = NodeExitReason.OOM
         is_unrecoverable = node.is_unrecoverable_failure()
+        self.assertTrue(node.is_resource_scalable())
         self.assertEqual(is_unrecoverable, True)
         self.assertEqual("oom" in node.unrecoverable_failure_msg, True)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. Skip the memory limitation judgement if node has gpu resource in relaunch operation.
2. Add a default limitation for memory adjustment for 'oom case' under torch training. 

### Why are the changes needed?

There is a memory limitation to avoid invalid resource scaling(out of quota)  under tensorflow training case. This limitation should not be involved in torch training for now for all the gpu type trainings nowadays are not scalable.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

UT.
