### PR TITLE
correct log and complete ut for error_monitor

### DIFF
--- a/dlrover/python/master/monitor/error_monitor.py
+++ b/dlrover/python/master/monitor/error_monitor.py
@@ -151,5 +151,5 @@ class K8sJobErrorMonitor(ErrorMonitor):
         if self.cordon_node_eanbled:
             succeed = self._k8s_client.cordon_node(node.host_name)
             if succeed:
-                logger.info(f"Node {node.name} is marked unschedulable.")
+                logger.info(f"Host {node.host_name} is marked unschedulable.")
         return True

--- a/dlrover/python/master/monitor/error_monitor.py
+++ b/dlrover/python/master/monitor/error_monitor.py
@@ -100,10 +100,10 @@ class SimpleErrorMonitor(ErrorMonitor):
 class K8sJobErrorMonitor(ErrorMonitor):
     """The monitor logs the error data."""
 
-    def __init__(self, namespace="", cordon_node_eanbled=False):
+    def __init__(self, namespace="", cordon_node_enabled=False):
         from dlrover.python.scheduler.kubernetes import k8sClient
 
-        self.cordon_node_eanbled = cordon_node_eanbled
+        self.cordon_node_enabled = cordon_node_enabled
         self._k8s_client = k8sClient.singleton_instance(namespace)
         self._restart_errors: Dict[int, str] = {}
 
@@ -148,7 +148,7 @@ class K8sJobErrorMonitor(ErrorMonitor):
             f"{node.name} on {node.host_name} is down. "
             f"Reason: {error_data}"
         )
-        if self.cordon_node_eanbled:
+        if self.cordon_node_enabled:
             succeed = self._k8s_client.cordon_node(node.host_name)
             if succeed:
                 logger.info(f"Host {node.host_name} is marked unschedulable.")

--- a/dlrover/python/tests/test_error_monitor.py
+++ b/dlrover/python/tests/test_error_monitor.py
@@ -39,9 +39,11 @@ class ErrorLogMonitorTest(unittest.TestCase):
         )
         self.assertTrue(relaunched)
 
-        self.assertFalse(err_monitor.process_error(
-            node=None,
-            restart_count=0,
-            error_data="test",
-            level=TrainingExceptionLevel.ERROR,
-        ))
+        self.assertFalse(
+            err_monitor.process_error(
+                node=None,
+                restart_count=0,
+                error_data="test",
+                level=TrainingExceptionLevel.ERROR,
+            )
+        )

--- a/dlrover/python/tests/test_error_monitor.py
+++ b/dlrover/python/tests/test_error_monitor.py
@@ -39,9 +39,10 @@ class ErrorLogMonitorTest(unittest.TestCase):
         )
         self.assertTrue(relaunched)
 
-        err_monitor.process_error(
+        relaunched = err_monitor.process_error(
             node=None,
             restart_count=0,
             error_data="test",
             level=TrainingExceptionLevel.ERROR,
         )
+        self.assertFalse(relaunched)

--- a/dlrover/python/tests/test_error_monitor.py
+++ b/dlrover/python/tests/test_error_monitor.py
@@ -39,10 +39,9 @@ class ErrorLogMonitorTest(unittest.TestCase):
         )
         self.assertTrue(relaunched)
 
-        relaunched = err_monitor.process_error(
+        self.assertFalse(err_monitor.process_error(
             node=None,
             restart_count=0,
             error_data="test",
             level=TrainingExceptionLevel.ERROR,
-        )
-        self.assertFalse(relaunched)
+        ))


### PR DESCRIPTION
### What changes were proposed in this pull request?

code enhancement

### Why are the changes needed?

1. make log output more clear, since in k8s world you can ONLY mark a worker NODE unschedulable, while not a POD.

1. complete the unit test for error monitor

### Does this PR introduce any user-facing change?

no

### How was this patch tested?

pre-commit test and unittest passed