### PR TITLE
add customized step collector into dlrover

### DIFF
--- a/dlrover/python/common/constants.py
+++ b/dlrover/python/common/constants.py
@@ -367,3 +367,4 @@ class ErrorMonitorConstants(object):
     ACTION_RESUME_MEM_CKPT_START = "resume_mem_ckpt_start"
     ACTION_RESUME_MEM_CKPT_COMPLETE = "resume_mem_ckpt_complete"
     ACTION_HANG_WARN = "hang_warning"
+    ACTION_TORCH_STEP = "torch_step"

--- a/dlrover/python/common/env_utils.py
+++ b/dlrover/python/common/env_utils.py
@@ -29,6 +29,10 @@ def get_node_rank():
     return int(rank)
 
 
+def get_world_size():
+    return int(os.getenv("WORLD_SIZE", 1))
+
+
 def get_local_world_size():
     return int(os.getenv("LOCAL_WORLD_SIZE", 1))
 

--- a/dlrover/python/common/global_context.py
+++ b/dlrover/python/common/global_context.py
@@ -35,6 +35,7 @@ class ConfigKeys(object):
     SECONDS_TO_CHANGE_PS = "seconds_to_change_ps"
     SECONDS_TO_WAIT_FAILED_PS = "seconds_to_wait_failed_ps"
     HANG_CPU_USAGE_RATE = "hang_cpu_usage_rate"
+    MAX_JOB_STEP_COUNT = "max_job_step_count"
 
 
 class DefaultValues(object):
@@ -54,11 +55,13 @@ class DefaultValues(object):
     SEC_TO_WAIT_FAILED_PS = 600  # 10min
     HANG_CPU_USAGE_RATE = 0.05
     HANG_DETECTION = 1
+    MAX_JOB_STEP_COUNT = 1000_000
 
 
 class Context(Singleton):
     def __init__(self):
         self.train_speed_record_num = DefaultValues.TRAIN_SPEED_RECORD_NUM
+        self.max_job_step_count = DefaultValues.MAX_JOB_STEP_COUNT
         self.seconds_to_autoscale_worker = (
             DefaultValues.SEC_TO_START_AUTOSCALE_WORKER
         )

--- a/dlrover/python/common/grpc.py
+++ b/dlrover/python/common/grpc.py
@@ -239,6 +239,13 @@ class GlobalStep(Message):
 
 
 @dataclass
+class UserStep(Message):
+    timestamp: int = 0
+    step: int = 0
+    total: int = 1
+
+
+@dataclass
 class HeartBeat(Message):
     timestamp: int = 0
 

--- a/dlrover/python/elastic_agent/diagnosis/diagnosis_agent.py
+++ b/dlrover/python/elastic_agent/diagnosis/diagnosis_agent.py
@@ -79,8 +79,6 @@ class DiagnosisAgent(Singleton):
         self._diagnosis_thread = None
         self._report_thread = None
 
-        self.start()
-
         logger.info(
             "Initializing diagnosis agent with\n"
             f"training_log_file:    {self._training_log_file}\n"
@@ -244,5 +242,8 @@ class DiagnosisAgent(Singleton):
     def _periodically_report(self):
         logger.info("Start diagnosis agent reporter.")
         while True:
+            if self._stopped:
+                logger.info("Stop periodically report.")
+                break
             self.send_heartbeat()
             time.sleep(15)

--- a/dlrover/python/elastic_agent/master_client.py
+++ b/dlrover/python/elastic_agent/master_client.py
@@ -244,6 +244,14 @@ class MasterClient(Singleton):
         )
         return self._report(message)
 
+    def report_user_step(self, ts, step, total_step):
+        message = grpc.UserStep(
+            timestamp=ts,
+            step=step,
+            total=total_step,
+        )
+        return self._report(message)
+
     def report_heart_beat(self, timestamp) -> DiagnosisAction:
         message = grpc.HeartBeat(timestamp=timestamp)
         response: grpc.HeartbeatResponse = self._get(message)

--- a/dlrover/python/elastic_agent/monitor/training.py
+++ b/dlrover/python/elastic_agent/monitor/training.py
@@ -192,6 +192,14 @@ class TorchTrainingMonitor(Singleton):
             logger.warning(f"failed to collect user steps: {str(e)}")
 
     def _user_step_report(self):
+        logger.info(
+            f"step report: {self._user_step_logfile} {self._user_step_pattern}"
+        )
+        if self._user_step_logfile == "" or self._user_step_pattern == "":
+            logger.info(
+                "stop step report because of invalid logfile or pattern"
+            )
+            return
         myrank = env_utils.get_rank()
         logger.info(
             f"my rank is {myrank}, step rank is {self._user_step_rank}"

--- a/dlrover/python/elastic_agent/torch/training.py
+++ b/dlrover/python/elastic_agent/torch/training.py
@@ -186,12 +186,10 @@ class ElasticLaunchConfig(LaunchConfig):
         self.rdzv_configs["node_unit"] = node_unit
 
     def auto_configure_params(self):
-        if self.training_log_file == "":
+        if os.getenv(NodeEnv.TRAINING_LOG_FILE, "") != "":
             self.training_log_file = os.getenv(NodeEnv.TRAINING_LOG_FILE, "")
-        if self.failure_node_errors == "":
-            self.failure_node_errors = os.getenv(
-                NodeEnv.FAILURE_NODE_ERRORS, ""
-            )
+        if os.getenv(NodeEnv.FAILURE_NODE_ERRORS, "") != "":
+            self.failure_node_errors = os.getenv(NodeEnv.FAILURE_NODE_ERRORS, "")
         if len(self.failure_node_errors) > 0:
             errors = self.failure_node_errors.strip()
             if errors[0] != "#" or errors[-1] != "#":

--- a/dlrover/python/elastic_agent/torch/training.py
+++ b/dlrover/python/elastic_agent/torch/training.py
@@ -189,7 +189,9 @@ class ElasticLaunchConfig(LaunchConfig):
         if os.getenv(NodeEnv.TRAINING_LOG_FILE, "") != "":
             self.training_log_file = os.getenv(NodeEnv.TRAINING_LOG_FILE, "")
         if os.getenv(NodeEnv.FAILURE_NODE_ERRORS, "") != "":
-            self.failure_node_errors = os.getenv(NodeEnv.FAILURE_NODE_ERRORS, "")
+            self.failure_node_errors = os.getenv(
+                NodeEnv.FAILURE_NODE_ERRORS, ""
+            )
         if len(self.failure_node_errors) > 0:
             errors = self.failure_node_errors.strip()
             if errors[0] != "#" or errors[-1] != "#":

--- a/dlrover/python/elastic_agent/torch/training.py
+++ b/dlrover/python/elastic_agent/torch/training.py
@@ -463,6 +463,14 @@ class ElasticTrainingAgent(LocalElasticAgent):
         self._agent_context = get_agent_context()
 
     @prof
+    def start_diagnose_agent(self) -> None:
+        self._diagnose_agent.start()
+
+    @prof
+    def stop_diagnose_agent(self) -> None:
+        self._diagnose_agent.stop()
+
+    @prof
     def _stop_workers_ascend(self, worker_group: WorkerGroup) -> None:
         logger.info("stop workers via SIGKILL for Ascend NPU")
         """The ASCEND framework might fork multiple sub-processes, we should
@@ -1161,6 +1169,7 @@ def launch_agent(
         training_log_file=config.training_log_file,
         failure_node_errors=config.failure_node_errors,
     )
+    agent.start_diagnose_agent()
 
     shutdown_rdzv = True
     result = None

--- a/dlrover/python/master/elastic_training/kv_store_service.py
+++ b/dlrover/python/master/elastic_training/kv_store_service.py
@@ -14,6 +14,8 @@
 from threading import Lock
 from typing import Dict
 
+from dlrover.python.common.log import default_logger as logger
+
 
 class KVStoreService(object):
     def __init__(self):
@@ -21,12 +23,15 @@ class KVStoreService(object):
         self._store: Dict[str, bytes] = {}
 
     def set(self, key, value):
+        logger.debug(f"KVStore set: {key}, {value}")
         with self._lock:
             self._store[key] = value
 
     def get(self, key):
+        logger.debug(f"KVStore get: {key}")
         with self._lock:
             return self._store.get(key, b"")
 
     def clear(self):
+        logger.debug(f"KVStore clear: {self._store}")
         self._store.clear()

--- a/dlrover/python/master/elastic_training/kv_store_service.py
+++ b/dlrover/python/master/elastic_training/kv_store_service.py
@@ -23,7 +23,7 @@ class KVStoreService(object):
         self._store: Dict[str, bytes] = {}
 
     def set(self, key, value):
-        logger.debug(f"KVStore set: {key}, {value}")
+        logger.info(f"KVStore set: {key}, {value}")
         with self._lock:
             self._store[key] = value
 

--- a/dlrover/python/master/servicer.py
+++ b/dlrover/python/master/servicer.py
@@ -332,6 +332,8 @@ class MasterServicer(elastic_training_pb2_grpc.MasterServicer):
             success = self._collect_model_info(message)
         elif isinstance(message, grpc.GlobalStep):
             success = self._collect_global_step(message)
+        elif isinstance(message, grpc.UserStep):
+            success = self._collect_user_step(message)
         elif isinstance(message, grpc.ShardCheckpoint):
             success = self._restore_shard_checkpoint(message)
         elif isinstance(message, grpc.TaskResult):
@@ -434,6 +436,12 @@ class MasterServicer(elastic_training_pb2_grpc.MasterServicer):
         )
         self._collect_runtime_stats()
         self._check_start_auto_scale_worker()
+        return True
+
+    def _collect_user_step(self, metrics: grpc.UserStep):
+        self._speed_monitor.collect_user_step(
+            metrics.timestamp, metrics.step, metrics.total
+        )
         return True
 
     def _restore_shard_checkpoint(self, message: grpc.ShardCheckpoint):

--- a/dlrover/python/tests/test_args.py
+++ b/dlrover/python/tests/test_args.py
@@ -14,6 +14,7 @@
 import unittest
 
 from dlrover.python.master.args import parse_master_args
+from dlrover.trainer.torch.elastic_run import parse_args
 
 
 class ArgsTest(unittest.TestCase):
@@ -27,3 +28,24 @@ class ArgsTest(unittest.TestCase):
         parsed_args = parse_master_args(original_args)
         self.assertEqual(parsed_args.job_name, "test")
         self.assertTrue(parsed_args.namespace, "default")
+
+    def test_parse_agent_args(self):
+        original_args = [
+            "--training_log_file",
+            "/tmp/dlrover",
+            "--step_rank",
+            "-1",
+            "--step_pattern",
+            r"""^\s+\[(\d{4}\-\d{2}\-\d{2} \d{2}:\d{2}:\d{2})\]
+            \s+iteration\s+(\d+)\/\s+(\d+)\s+\|""",
+            "sleep",
+            "60",
+        ]
+        parsed_args = parse_args(original_args)
+        self.assertEqual(parsed_args.training_log_file, "/tmp/dlrover")
+        self.assertEqual(parsed_args.step_rank, -1)
+        self.assertEqual(
+            parsed_args.step_pattern,
+            r"""^\s+\[(\d{4}\-\d{2}\-\d{2} \d{2}:\d{2}:\d{2})\]
+            \s+iteration\s+(\d+)\/\s+(\d+)\s+\|""",
+        )

--- a/dlrover/python/tests/test_elastic_training_agent.py
+++ b/dlrover/python/tests/test_elastic_training_agent.py
@@ -188,14 +188,8 @@ class ElasticTrainingAgentTest(unittest.TestCase):
         )
 
         store = self.rdzv_handler._get_store(round=1, group=0)
-
-        def _set_store(store):
-            time.sleep(5)
-            store.set("MASTER_ADDR", "127.0.0.1".encode())
-            store.set("MASTER_PORT", "12345".encode())
-
-        _task = threading.Thread(target=_set_store, args=(store,))
-        _task.start()
+        store.set("MASTER_ADDR", "127.0.0.1".encode())
+        store.set("MASTER_PORT", "12345".encode())
 
         addr, port = agent._safe_get_master_addr_port(store)
         self.assertEqual(addr, "127.0.0.1")

--- a/dlrover/python/tests/test_elastic_training_agent.py
+++ b/dlrover/python/tests/test_elastic_training_agent.py
@@ -152,7 +152,6 @@ class ElasticTrainingAgentTest(unittest.TestCase):
             start_method=self.config.start_method,
             log_dir=self.config.log_dir,
         )
-        agent._diagnose_agent.stop()
 
         # Mock node rank 1 joins the rendezvous.
         self.rdzv_handler._client._node_id = 1
@@ -182,7 +181,6 @@ class ElasticTrainingAgentTest(unittest.TestCase):
             start_method=self.config.start_method,
             log_dir=self.config.log_dir,
         )
-        agent._diagnose_agent.stop()
 
         # Mock node rank 0 joins the rendezvous.
         self.rdzv_handler._client._node_id = 0

--- a/dlrover/python/tests/test_elastic_training_agent.py
+++ b/dlrover/python/tests/test_elastic_training_agent.py
@@ -70,7 +70,7 @@ class ElasticTrainingAgentTest(unittest.TestCase):
     def setUp(self) -> None:
         _set_paral_config()
         self._master, addr = start_local_master()
-        MasterClient._instance = build_master_client(addr, 0.5)
+        MasterClient._instance = build_master_client(addr, 3)
         launch_config = LaunchConfig(
             min_nodes=2,
             max_nodes=2,

--- a/dlrover/python/tests/test_speed_monitor.py
+++ b/dlrover/python/tests/test_speed_monitor.py
@@ -41,3 +41,23 @@ class SpeedMonitorTest(unittest.TestCase):
         monitor.update_worker_eval_time(0)
         eval_time = monitor.get_worker_eval_time(0)
         self.assertTrue(eval_time > 0.1)
+
+    def test_monitor_user_step(self):
+        monitor = SpeedMonitor()
+        ts = time.time()
+        monitor.max_step_count = 3
+        monitor.collect_user_step(ts, 1, 1000)
+        self.assertEqual(monitor.first_step_time, ts)
+        monitor.collect_user_step(time.time(), 2, 1000)
+        monitor.collect_user_step(time.time(), 3, 1000)
+        self.assertEqual(len(monitor.user_step_records), 3)
+        self.assertEqual(monitor.user_step_records[0].step_num, 1)
+        self.assertEqual(monitor.user_step_records[0].total_step, 1000)
+        self.assertEqual(monitor.user_step_records[0].timestamp, ts)
+        self.assertEqual(monitor.user_step_records[1].step_num, 2)
+        self.assertEqual(monitor.user_step_records[2].step_num, 3)
+        monitor.collect_user_step(time.time(), 4, 1000)
+        self.assertEqual(len(monitor.user_step_records), 3)
+        self.assertEqual(monitor.user_step_records[0].step_num, 2)
+        monitor.collect_user_step(time.time(), 10, 1000)
+        self.assertEqual(len(monitor.user_step_records), 1)

--- a/dlrover/trainer/torch/elastic_run.py
+++ b/dlrover/trainer/torch/elastic_run.py
@@ -191,6 +191,38 @@ def parse_args(args):
         default=60000,
         help="The start of training port.",
     )
+    parser.add_argument(
+        "--failure-node-errors",
+        "--failure_node_errors",
+        type=str,
+        action=env,
+        default="",
+    )
+    parser.add_argument(
+        "--training-log-file",
+        "--training_log_file",
+        type=str,
+        action=env,
+        default="",
+        help="The training log file path.",
+    )
+    parser.add_argument(
+        "--step-rank",
+        "--step_rank",
+        type=int,
+        action=env,
+        default=0,
+        help="The rank on which training logs have step counter",
+    )
+    parser.add_argument(
+        "--step-pattern",
+        "--step_pattern",
+        type=str,
+        action=env,
+        default="",
+        help="The pattern used to match the steps",
+    )
+
     return parser.parse_args(args)
 
 
@@ -348,6 +380,12 @@ def _elastic_config_from_args(
     )
     if master_config.save_at_breakpoint:
         elastic_config.save_at_breakpoint = True
+    elastic_config.training_log_file = getattr(args, "training_log_file", "")
+    elastic_config.failure_node_errors = getattr(
+        args, "failure_node_errors", ""
+    )
+    elastic_config.step_rank = getattr(args, "step_rank", -1)
+    elastic_config.step_pattern = getattr(args, "step_pattern", "")
     elastic_config.auto_configure_params()
     elastic_config.rdzv_backend = "dlrover-master"
     elastic_config.rdzv_endpoint = ""


### PR DESCRIPTION
usage: add such parameters into agent command line, e.g. dlrover-run

--training_log_file specifies which logfile we collect step info 
--step_rank specifies the rank which will output the step info into logfile 
--step_pattern specifies the regex pattern of step info matching each log line

This patch support user defined step log format, so dlrover can collect training steps info from log file. It is useful for
us to detect training errors, e.g. hang or stepback

### What changes were proposed in this pull request?

step pattern and file match

### Why are the changes needed?

add customized step collector into dlrover

### Does this PR introduce any user-facing change?

Yes

### How was this patch tested?

UT