### PR TITLE
Fix node id iterator initiation.

### DIFF
--- a/dlrover/python/common/env_utils.py
+++ b/dlrover/python/common/env_utils.py
@@ -102,7 +102,7 @@ def get_proc_env(pid):
                 for k, v in (env.split("=", 1) for env in envs if "=" in env)
             }
     except Exception as e:
-        logger.error(f"error in get process {pid} env: {str(e)}")
+        logger.warning(f"Got error when getting process {pid} env: {str(e)}")
         return None
 
 

--- a/dlrover/python/diagnosis/inferencechain/inferenceoperator/observer/check_training_hang_operator.py
+++ b/dlrover/python/diagnosis/inferencechain/inferenceoperator/observer/check_training_hang_operator.py
@@ -85,13 +85,14 @@ class CheckTrainingHangOperator(InferenceOperator):
         ]
 
     def is_hang(self, diagnosis_data: List[DiagnosisData]):
-        logger.info(
+        logger.debug(
             "Hang detection start using diagnosis data, "
             f"data number: {len(diagnosis_data)}, "
             f"data size: {sys.getsizeof(diagnosis_data)}."
         )
         worker_hang_metric: Dict[int, List[Tuple[int, bool]]] = {}
         if not diagnosis_data:
+            logger.debug("Skip for no worker hang metric.")
             return False
 
         # the format of the hang metric can refer these files:

--- a/dlrover/python/master/dist_master.py
+++ b/dlrover/python/master/dist_master.py
@@ -235,7 +235,7 @@ class DistributedJobMaster(JobMaster):
             self.diagnosis_manager.start_observing()
         except Exception as e:
             logger.warning(
-                "Failed to start training " f"runtime diagnosis: {str(e)}"
+                f"Failed to start training runtime diagnosis: {str(e)}"
             )
 
         # into running loop

--- a/dlrover/python/master/node/dist_job_manager.py
+++ b/dlrover/python/master/node/dist_job_manager.py
@@ -646,7 +646,6 @@ class DistributedJobManager(JobManager):
                 # Mock event to avoid missing events
                 event = NodeEvent(event_type, node)
                 self._process_event(event)
-        logger.debug(f"Got list nodes: {exist_nodes}")
 
         for node_type in job_nodes.keys():
             #  Avoid dictionary keys changed during iteration

--- a/dlrover/python/master/node/training_node.py
+++ b/dlrover/python/master/node/training_node.py
@@ -241,14 +241,17 @@ class TrainingNodeManager(object):
     def update_nodes_iter(self):
         nodes = self._job_context.job_nodes_by_type(self._node_type)
 
+        # update everytime
         self._node_id_iter = itertools.count(
             max(nodes.keys()) + 1 if len(nodes) > 0 else 0
         )
-        self._node_rank_iter = itertools.count(len(nodes))
+
+        # update once
+        if not self._node_rank_iter:
+            self._node_rank_iter = itertools.count(len(nodes))
 
     def get_next_node_id(self):
-        if self._node_id_iter is None:
-            self.update_nodes_iter()
+        self.update_nodes_iter()
         return next(self._node_id_iter)
 
     def remove_node(self, node_id):

--- a/dlrover/python/master/node/training_node.py
+++ b/dlrover/python/master/node/training_node.py
@@ -240,7 +240,7 @@ class TrainingNodeManager(object):
 
     def update_nodes_iter(self):
         nodes = self._job_context.job_nodes_by_type(self._node_type)
-        self._node_id_iter = itertools.count(len(nodes))
+        self._node_id_iter = itertools.count(max(nodes.keys()) + 1)
         self._node_rank_iter = itertools.count(len(nodes))
 
     def remove_node(self, node_id):

--- a/dlrover/python/master/node/training_node.py
+++ b/dlrover/python/master/node/training_node.py
@@ -198,9 +198,10 @@ class TrainingNodeManager(object):
         self._node_type = node_type
         self._new_node_name_fn = new_node_name_fn
         self._lock = threading.Lock()
-        self._node_id_iter = itertools.count(len(nodes))
-        self._node_rank_iter = itertools.count(len(nodes))
+        self._node_id_iter = None
+        self._node_rank_iter = None
         self._pending_nodes: List[Node] = []
+        self.update_nodes_iter()
 
     @property
     def pending_nodes(self):

--- a/dlrover/python/master/node/training_node.py
+++ b/dlrover/python/master/node/training_node.py
@@ -240,7 +240,10 @@ class TrainingNodeManager(object):
 
     def update_nodes_iter(self):
         nodes = self._job_context.job_nodes_by_type(self._node_type)
-        self._node_id_iter = itertools.count(max(nodes.keys()) + 1)
+
+        self._node_id_iter = itertools.count(
+            max(nodes.keys()) + 1 if len(nodes) > 0 else 0
+        )
         self._node_rank_iter = itertools.count(len(nodes))
 
     def remove_node(self, node_id):

--- a/dlrover/python/master/node/worker.py
+++ b/dlrover/python/master/node/worker.py
@@ -156,7 +156,7 @@ class WorkerManager(TrainingNodeManager):
         """Launch up_num workers."""
         plan = ScalePlan()
         for _ in range(up_num):
-            worker_id = next(self._node_id_iter)
+            worker_id = self.get_next_node_id()
             task_id = next(self._node_rank_iter)
             worker_resource = self._job_resource.get_node_group_resource(
                 NodeType.WORKER
@@ -248,7 +248,7 @@ class WorkerManager(TrainingNodeManager):
             old_node.migrated = True
             old_node.relaunchable = False
             old_node.is_released = True
-            node_id = next(self._node_id_iter)
+            node_id = self.get_next_node_id()
             task_id = old_node.rank_index
             new_node = Node(
                 NodeType.WORKER,


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. Use max node id to initiate the iterator.
2. Remove  duplicate logging.

### Why are the changes needed?

Node id will be increased due to failover. So should use max node id to initiate the iterator(for master fault tolerence).

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

UT and training.

The training case:
1 worker failover -> master failover -> another worker failover
