### PR TITLE
Fix unexpected heartbeat issue after worker relaunching.

### DIFF
--- a/dlrover/python/common/node.py
+++ b/dlrover/python/common/node.py
@@ -276,6 +276,7 @@ class Node(object):
         new_node.is_released = False
         new_node.relaunchable = True
         new_node.init_time = time.time()
+        new_node.reported_status = ""
         return new_node
 
     def is_unrecoverable_failure(self):
@@ -379,9 +380,10 @@ class Node(object):
             f"rank_index:{self.rank_index};"
             f"type:{self.type};"
             f"status:{self.status};"
+            f"reported_status:{self.reported_status};"
             f"addr:{self.service_addr};"
             f"is_released:{self.is_released};"
-            f"priroity:{self.config_resource.priority}"
+            f"priority:{self.config_resource.priority};"
         )
 
     def to_dict(self):

--- a/dlrover/python/elastic_agent/monitor/resource.py
+++ b/dlrover/python/elastic_agent/monitor/resource.py
@@ -133,7 +133,7 @@ class ResourceMonitor(Singleton):
             pynvml.nvmlInit()
             self._gpu_enabled = True
         except pynvml.NVMLError_LibraryNotFound:
-            logger.warn(
+            logger.warning(
                 "NVIDIA NVML library not found. "
                 "GPU monitoring features will be disabled."
             )

--- a/dlrover/python/elastic_agent/torch/training.py
+++ b/dlrover/python/elastic_agent/torch/training.py
@@ -1342,7 +1342,7 @@ class NodeCheckElasticAgent(ElasticTrainingAgent):
             )
             raise RuntimeError("This node is down.")
         elif self._node_rank in stragglers:
-            logger.warn("This node is a straggler!")
+            logger.warning("This node is a straggler!")
             if self._config.exclude_straggler:
                 raise RuntimeError("The node is a straggler and exits.")
         return success

--- a/dlrover/python/master/node/dist_job_manager.py
+++ b/dlrover/python/master/node/dist_job_manager.py
@@ -514,7 +514,7 @@ class DistributedJobManager(JobManager):
             )
             time.sleep(15)
 
-    def _get_dead_node_event(self, window_interval=900) -> List[NodeEvent]:
+    def _get_dead_node_event(self, window_interval=600) -> List[NodeEvent]:
         now = time.time()
         dead_events: List[NodeEvent] = []
         job_nodes = self.get_job_nodes()

--- a/dlrover/python/tests/test_node.py
+++ b/dlrover/python/tests/test_node.py
@@ -84,3 +84,7 @@ class NodeTest(unittest.TestCase):
         node.update_from_node(node)
         node.id = 100
         node.update_from_node(node)
+
+        node = node.get_relaunch_node_info(123)
+        self.assertEqual(node.id, 123)
+        self.assertFalse(node.reported_status)


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. Node's 'reported status' should not be inherited during relaunching.
2. Revert heartbeat timeout back to 10mins(Considering that some other optimizations have been applied recently, a 15-minute timeout period is somewhat too long.).

### Why are the changes needed?

Bug fix and enhancement.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

UT and Training.

Training validation: failover worker-0 -> manual hang worker-1 -> verify if worker-1 will relaunch by heartbeat timeout
