### PR TITLE
optimize diagnosing in job manager

### DIFF
--- a/dlrover/python/tests/test_job_manager.py
+++ b/dlrover/python/tests/test_job_manager.py
@@ -819,7 +819,7 @@ class DistributedJobManagerTest(unittest.TestCase):
         manager.start()
         active_threads_name = [t.name for t in threading.enumerate()]
         self.assertIn("node_monitor", active_threads_name)
-        self.assertIn("diagnose_job", active_threads_name)
+        self.assertIn("job_diagnosing", active_threads_name)
         manager.stop()
 
     def test_concurrency_heart_beat_collecting(self):


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. Use noun to naming thread.
2. Simplify '_diagnose_job' and '_monitor_node_heart_beat'.

### Why are the changes needed?

Optimization.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

UT.
