### PR TITLE
Do not clean up checkpoint path with step 0

### DIFF
--- a/dlrover/python/common/storage.py
+++ b/dlrover/python/common/storage.py
@@ -306,7 +306,7 @@ class PosixStorageWithDeletion(PosixDiskStorage):
 
     def commit(self, step, success):
         super().commit(step, success)
-        if not success or self._pre_step == step:
+        if not success or self._pre_step == step or self._pre_step == 0:
             return
         self._deletion_strategy.clean_up(self._pre_step, shutil.rmtree)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
 
Optimize the handling of boundary values in the checkpoint cleanup path.

### Why are the changes needed?
 
During training, step 0 checkpoint are not saved, but the original logic attempts to clean up `/tmp/checkpoint/0`, which triggers the following warning
```
[INFO] [storage.py:258:clean_up] Clean path /tmp/checkpoint/0
[WARNING] [storage.py:261:clean_up] Fail to clean path /tmp/checkpoint/0!
```

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

UT and training test.