### PR TITLE
no need to detect cpu hang in torch training,

### DIFF
--- a/dlrover/python/master/node/dist_job_manager.py
+++ b/dlrover/python/master/node/dist_job_manager.py
@@ -1066,14 +1066,15 @@ class DistributedJobManager(JobManager):
             return
         node.update_resource_usage(cpu, memory, gpu_stats)
         cpu_percent = node.used_resource.cpu / node.config_resource.cpu
-        if cpu_percent < _dlrover_context.hang_cpu_usage_percentage:
-            if node.start_hang_time == 0:
-                now = datetime.now()
-                node.start_hang_time = now.timestamp()
-        else:
-            if node.start_hang_time > 0:
-                now = datetime.now()
-            node.start_hang_time = 0
+        if not self.is_all_reduce_type_job():
+            if cpu_percent < _dlrover_context.hang_cpu_usage_percentage:
+                if node.start_hang_time == 0:
+                    now = datetime.now()
+                    node.start_hang_time = now.timestamp()
+            else:
+                if node.start_hang_time > 0:
+                    now = datetime.now()
+                node.start_hang_time = 0
         self._job_context.update_job_node(node)
 
     def update_node_service_addr(self, node_type, node_id, service_addr):


### PR DESCRIPTION
since cpu may drop to less than 2 percent in the normal training process

### What changes were proposed in this pull request?

only check cpu hang in non-allreduce job

### Why are the changes needed?

in some allreduce job cases, cpu may drop to less than 2% while the training is normal

### Does this PR introduce any user-facing change?

No

### How was this patch tested?

UT