### PR TITLE
change requirement grpcio-tools to grpcio

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@
 from setuptools import find_packages, setup
 
 install_requires = [
-    "grpcio-tools>=1.58.0",
+    "grpcio>=1.58.0",
     "psutil",
     "pynvml",
     "urllib3<1.27,>=1.21.1",


### PR DESCRIPTION
### What changes were proposed in this pull request?
Dlrover does not compile protobuf when running, thus change grpcio-tools requirement to grpcio.

Please describe the changes you have made or proposed in this pull request.

### Why are the changes needed?

Explain the purpose or motivation behind these changes. What problem are you trying to solve?

### Does this PR introduce any user-facing change?

Specify whether this pull request introduces any changes that users will directly interact with or notice.

### How was this patch tested?

Detail the testing process you have undertaken to ensure the changes in this pull request are valid and working as intended.
