### PR TITLE
make dlrover working in python 3.11

### DIFF
--- a/dlrover/python/common/grpc.py
+++ b/dlrover/python/common/grpc.py
@@ -179,7 +179,7 @@ class Shard(Message):
 @dataclass
 class Task(Message):
     task_id: int = 0
-    shard: Shard = Shard()
+    shard: Shard = field(default_factory=Shard)
     type: int = 0
     extended_config: Dict[str, str] = field(default_factory=dict)
 
@@ -218,8 +218,8 @@ class OpStats(Message):
 class ModelInfo(Message):
     """ModelInfo contains profiling data of a model."""
 
-    tensor_stats: TensorStats = TensorStats()
-    op_stats: OpStats = OpStats()
+    tensor_stats: TensorStats = field(default_factory=TensorStats)
+    op_stats: OpStats = field(default_factory=OpStats)
     instantiation_memory: int = 0
     activation_memory: int = 0
 
@@ -331,7 +331,7 @@ class NodeEvent(Message):
     event_message: str = ""
     event_time: float = 0.0
     event_elapsed_time: float = 0.0
-    node: NodeMeta = NodeMeta()
+    node: NodeMeta = field(default_factory=NodeMeta)
 
 
 @dataclass
@@ -475,8 +475,8 @@ class CheckHardwareResetRequest(Message):
 
 @dataclass
 class ParallelConfig(Message):
-    dataloader: DataLoaderConfig = DataLoaderConfig()
-    optimizer: OptimizerConfig = OptimizerConfig()
+    dataloader: DataLoaderConfig = field(default_factory=DataLoaderConfig)
+    optimizer: OptimizerConfig = field(default_factory=OptimizerConfig)
     restart: bool = False
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Please describe the changes you have made or proposed in this pull request.
Current dlrover fails on python 3.11:

```
 File "/opt/conda/lib/python3.11/dataclasses.py", line 958, in _process_class
    cls_fields.append(_get_field(cls, name, type, kw_only))
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/dataclasses.py", line 815, in _get_field
    raise ValueError(f'mutable default {type(f.default)} for field '
ValueError: mutable default <class 'dlrover.python.common.grpc.Shard'> for field shard is not allowed: use default_factory
```

This PR will fix this error.

### Why are the changes needed?

Explain the purpose or motivation behind these changes. What problem are you trying to solve?

### Does this PR introduce any user-facing change?

Specify whether this pull request introduces any changes that users will directly interact with or notice.

### How was this patch tested?

Detail the testing process you have undertaken to ensure the changes in this pull request are valid and working as intended.
