### PR TITLE
Set default brain addr

### DIFF
--- a/dlrover/go/operator/pkg/controllers/master/master.go
+++ b/dlrover/go/operator/pkg/controllers/master/master.go
@@ -38,6 +38,7 @@ const (
 	defaultImagePullPolicy     = "Always"
 	envMasterAddrKey           = "DLROVER_MASTER_ADDR"
 	envBrainServiceAddrKey     = "DLROVER_BRAIN_SERVICE_ADDR"
+	defaultBrainServiceAddr    = "dlrover-brain.dlrover.svc.cluster.local:50001"
 	envPodIP                   = "POD_IP"
 
 	// ReplicaTypeJobMaster is the type for DLRover ElasticJob Master replica.
@@ -60,8 +61,12 @@ func (m *Manager) newJobMaster(
 	)
 	pod.Labels[common.LabelReplicaTypeKey] = string(ReplicaTypeJobMaster)
 	pod.Labels[common.LabelReplicaIndexKey] = fmt.Sprintf("%d", replicaIndex)
-	if job.Spec.BrainService != "" {
-		setBrainServiceIntoContainer(&pod.Spec.Containers[0], job.Spec.BrainService)
+	if job.Spec.OptimizeMode == "cluster" {
+		brainServiceAddr := defaultBrainServiceAddr
+		if job.Spec.BrainService != "" {
+			brainServiceAddr = job.Spec.BrainService
+		}
+		setBrainServiceIntoContainer(&pod.Spec.Containers[0], brainServiceAddr)
 	}
 	return pod
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR enhances the code's robustness by setting `defaultBrainServiceAddr` when `optimizeMode` is `cluster`.

### Why are the changes needed?

If `optimizeMode` is configure to `cluster` in the yaml file but `brainService` is not configured, the only difference from configuring `optimizeMode` to 'single-job' is the warning message in the master container logs: 'Fail to JobMetricCollector.collect_custom_data by 'NoneType' object has no attribute 'persist_metrics'.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

UT and training test.
