### PR TITLE
fix node.is_released lost in process_event

### DIFF
--- a/dlrover/python/common/node.py
+++ b/dlrover/python/common/node.py
@@ -235,6 +235,7 @@ class Node(object):
         host_ip=None,
         restart_training=False,
         relaunch_count=0,
+        is_released=False,
     ):
         if name is not None:
             self.name = name
@@ -248,6 +249,7 @@ class Node(object):
             self.host_ip = host_ip
         self.relaunch_count = max(self.relaunch_count, relaunch_count)
         self.restart_training = restart_training
+        self.is_released = is_released
 
     def update_status(self, status=None):
         if status is not None:

--- a/dlrover/python/master/node/dist_job_manager.py
+++ b/dlrover/python/master/node/dist_job_manager.py
@@ -750,6 +750,7 @@ class DistributedJobManager(JobManager):
                 host_ip=event.node.host_ip,
                 restart_training=event.node.restart_training,
                 relaunch_count=event.node.relaunch_count,
+                is_released=event.node.is_released,
             )
             self._job_context.update_job_node(cur_node)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

the node is deleted but the node.is_released is not updated

### Why are the changes needed?

the previous node.is_released is a deepcopy so node.is_released = true won't work
we need to add it in node.update_info

### Does this PR introduce any user-facing change?

NO

### How was this patch tested?

UT