### PR TITLE
Add master client timeout env

### DIFF
--- a/dlrover/python/common/constants.py
+++ b/dlrover/python/common/constants.py
@@ -279,6 +279,9 @@ class NodeEnv(object):
     TRAINING_LOG_FILE = "TRAINING_LOG_FILE"
     FAILURE_NODE_ERRORS = "FAILURE_NODE_ERRORS"
 
+    # grpc env
+    MASTER_CLIENT_TIMEOUT = "MASTER_CLIENT_TIMEOUT"
+
 
 class DatasetType(object):
     TEXT = "text"

--- a/dlrover/python/elastic_agent/master_client.py
+++ b/dlrover/python/elastic_agent/master_client.py
@@ -501,7 +501,7 @@ class MasterClient(Singleton):
         return cls._instance
 
 
-def build_master_client(master_addr=None, timeout=5):
+def build_master_client(master_addr=None, timeout=15):
     """
     Build a master client.
 
@@ -514,6 +514,13 @@ def build_master_client(master_addr=None, timeout=5):
         master_addr = os.getenv(NodeEnv.DLROVER_MASTER_ADDR, "")
     node_id = env_utils.get_node_id()
     node_type = env_utils.get_node_type()
+
+    try:
+        _timeout = int(os.getenv(NodeEnv.MASTER_CLIENT_TIMEOUT, ""))
+        logger.info(f"set master_client timeout to env {_timeout}")
+    except Exception:
+        _timeout = timeout
+        logger.info(f"set master_client timeout to {_timeout}")
 
     master_client = None
     logger.info(f"Build master client with addr {master_addr}.")

--- a/dlrover/python/elastic_agent/master_client.py
+++ b/dlrover/python/elastic_agent/master_client.py
@@ -501,7 +501,7 @@ class MasterClient(Singleton):
         return cls._instance
 
 
-def build_master_client(master_addr=None, timeout=15):
+def build_master_client(master_addr=None, timeout=60):
     """
     Build a master client.
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

change master client timeout to 60s, to prevent grpc from timeout when master is in high load

### Why are the changes needed?

master in high load may drop grpc request in a short timeout

### Does this PR introduce any user-facing change?

No

### How was this patch tested?

UT