### PR TITLE
Add precheck argument to setup the pre-check level.

### DIFF
--- a/dlrover/python/elastic_agent/torch/training.py
+++ b/dlrover/python/elastic_agent/torch/training.py
@@ -226,7 +226,7 @@ class ElasticLaunchConfig(LaunchConfig):
         if self.precheck == 1:
             self.network_check = True
             self.comm_perf_test = False or self.comm_perf_test
-        
+
         if self.precheck == 2:
             self.network_check = True
             self.comm_perf_test = True

--- a/dlrover/python/elastic_agent/torch/training.py
+++ b/dlrover/python/elastic_agent/torch/training.py
@@ -146,6 +146,8 @@ class ElasticLaunchConfig(LaunchConfig):
     Creates a rendezvous config of elastic training.
 
     Args:
+        precheck: the level to run pre-check task before starting
+            the training task.
         network_check: whether to check the network available before training.
         comm_perf_test: whether to test the communication performance.
         node_unit: the number of unit of nodes. The number of nodes must be
@@ -164,6 +166,7 @@ class ElasticLaunchConfig(LaunchConfig):
             is a failure node
     """
 
+    precheck: int = 0
     network_check: bool = False
     comm_perf_test: bool = False
     node_unit: int = 1
@@ -214,6 +217,19 @@ class ElasticLaunchConfig(LaunchConfig):
             self.nproc_per_node = torch.cuda.device_count()
         if self.min_nodes >= 4:
             self.network_check = True
+
+    def update_precheck_args(self):
+        if self.precheck == 0:
+            self.comm_perf_test = False or self.comm_perf_test
+            self.network_check = False or self.network_check
+
+        if self.precheck == 1:
+            self.network_check = True
+            self.comm_perf_test = False or self.comm_perf_test
+        
+        if self.precheck == 2:
+            self.network_check = True
+            self.comm_perf_test = True
 
 
 class MasterRendezvousHandler(RendezvousHandler):

--- a/dlrover/trainer/tests/torch/elastic_run_test.py
+++ b/dlrover/trainer/tests/torch/elastic_run_test.py
@@ -71,8 +71,8 @@ class ElasticRunTest(unittest.TestCase):
         self._master, addr = start_local_master()
         MasterClient._instance = build_master_client(addr, 1)
         args = [
-            "--network_check",
-            "--comm_perf_test",
+            "--precheck",
+            "1",
             "--auto_tunning",
             "--node_unit",
             "4",
@@ -86,8 +86,9 @@ class ElasticRunTest(unittest.TestCase):
         ]
         args = parse_args(args)
         config, cmd, cmd_args = _elastic_config_from_args(args)
+        self.assertEqual(config.precheck, 1)
         self.assertTrue(config.network_check)
-        self.assertTrue(config.comm_perf_test)
+        self.assertFalse(config.comm_perf_test)
         self.assertTrue(config.auto_tunning)
         self.assertEqual(config.node_unit, 4)
         self.assertEqual(config.rdzv_configs["node_unit"], 4)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add precheck argument to setup the pre-check level before starting the training task.

### Why are the changes needed?

We may add more and more pre-check task like network check, matmul, dcgm. It is redundant to configure an argument for each check. We can use an argument to indicate the pre-check level to run different check tasks.

### Does this PR introduce any user-facing change?

Yes. For example, `dlrover-run --precheck=1`

### How was this patch tested?

UT.