### PR TITLE
Remove markdownlint because it is slow to install.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,14 +67,3 @@ repos:
       - id: yamllint
         exclude:
           (dlrover/python/tests/data|operator/config)
-#  - repo: https://github.com/igorshubovych/markdownlint-cli
-#    rev: v0.35.0
-#    hooks:
-#      - id: markdownlint
-#        name: markdownlint
-#        description: "Checks the style of Markdown files."
-#        entry: markdownlint --fix --config .markdownlint.yaml
-#        language: node
-#        types: [markdown]
-#        exclude: (dlrover/go/brain/vendor)
-#        args: [--fix]


### PR DESCRIPTION
### What changes were proposed in this pull request?

Remove markdownlint int the pre-commit configuration.

### Why are the changes needed?

It is very slow to install the markdownlint.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

CI.
