### PR TITLE
fix incorrect version comparison for PyTorch with extra tags

### DIFF
--- a/dlrover/trainer/tests/torch/util_test.py
+++ b/dlrover/trainer/tests/torch/util_test.py
@@ -1,0 +1,64 @@
+# Copyright 2023 The DLRover Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest.mock import patch
+
+from dlrover.trainer.torch.utils import (
+    version_less_than_230,
+    version_less_than_240,
+)
+
+
+class TestTorchVersionFunctions(unittest.TestCase):
+    def test_version_less_than_230(self):
+        with patch("torch.__version__", "2.2.1"):
+            self.assertTrue(
+                version_less_than_230(), "Expected True for version < 2.2.2"
+            )
+
+        with patch("torch.__version__", "2.2.1+cu111"):
+            self.assertTrue(
+                version_less_than_230(), "Expected True for version < 2.2.2"
+            )
+
+        with patch("torch.__version__", "2.2.2+cu111"):
+            self.assertTrue(
+                version_less_than_230(), "Expected True for version = 2.2.2"
+            )
+
+        with patch("torch.__version__", "2.3.0+cu111"):
+            self.assertFalse(
+                version_less_than_230(), "Expected False for version > 2.2.2"
+            )
+
+    def test_version_less_than_240(self):
+        with patch("torch.__version__", "2.3.0"):
+            self.assertTrue(
+                version_less_than_240(), "Expected True for version < 2.3.1"
+            )
+
+        with patch("torch.__version__", "2.3.0+cu111"):
+            self.assertTrue(
+                version_less_than_240(), "Expected True for version < 2.3.1"
+            )
+
+        with patch("torch.__version__", "2.3.1+cu111"):
+            self.assertTrue(
+                version_less_than_240(), "Expected True for version = 2.3.1"
+            )
+
+        with patch("torch.__version__", "2.4.0+cu111"):
+            self.assertFalse(
+                version_less_than_240(), "Expected False for version > 2.3.1"
+            )

--- a/dlrover/trainer/torch/utils.py
+++ b/dlrover/trainer/torch/utils.py
@@ -12,12 +12,14 @@
 # limitations under the License.
 
 import torch
-from packaging.version import Version
+from packaging import version
 
 
 def version_less_than_230():
-    return Version(torch.__version__) <= Version("2.2.2")
+    current_version = version.parse(torch.__version__).base_version
+    return version.parse(current_version) <= version.parse("2.2.2")
 
 
 def version_less_than_240():
-    return Version(torch.__version__) <= Version("2.3.1")
+    current_version = version.parse(torch.__version__).base_version
+    return version.parse(current_version) <= version.parse("2.3.1")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes version comparison by stripping extra build tags (e.g., `+cu121`) from the PyTorch version string before performing the comparison.

### Why are the changes needed?

The extra build tags in version strings (e.g., `2.3.1+cu121`) cause incorrect comparisons when compared to versions without tags (e.g., `2.3.1`). Stripping the tags ensures accurate version comparisons.
#1433 

### Does this PR introduce any user-facing change?

NO

### How was this patch tested?

UT
