### PR TITLE
Refactor client's node-check invocation timeout default value.

### DIFF
--- a/dlrover/python/common/constants.py
+++ b/dlrover/python/common/constants.py
@@ -363,9 +363,9 @@ class JobConstant(object):
     # grpc timeout 60s
     MASTER_CLIENT_GRPC_DEFAULT_TIMEOUT = 60
 
-    # master_client.check_fault_node/check_straggler timeout min value
+    # master_client.check_fault_node/check_straggler timeout value
     # must > NODE_CHECK_TIMEOUT
-    MASTER_CLIENT_CHECK_NODE_TIMEOUT_MIN = 360
+    MASTER_CLIENT_CHECK_NODE_TIMEOUT = 360
 
     # sleep 1s on NetworkFailureReason.WAITING_NODE
     MASTER_CLIENT_CHECK_FAULT_SLEEP_TIMEOUT = 1

--- a/dlrover/python/common/constants.py
+++ b/dlrover/python/common/constants.py
@@ -358,15 +358,14 @@ class JobConstant(object):
     INSUFFICIENT_NODE_TIMEOUT_DEFAULT_MIN = 600
     INSUFFICIENT_NODE_TIMEOUT_DEFAULT_MAX = 3600
     PENDING_NODE_TIMEOUT_DEFAULT_MIN = 600
+    NODE_CHECK_TIMEOUT = 300
 
     # grpc timeout 60s
     MASTER_CLIENT_GRPC_DEFAULT_TIMEOUT = 60
 
-    # master_client.check_straggler timeout
-    MASTER_CLIENT_CHECK_FAULT_NODE_TIMEOUT = 300
-
-    # master_client.check_fault_node timeout
-    MASTER_CLIENT_CHECK_STRAGGLER_NODE_TIMEOUT = 300
+    # master_client.check_fault_node/check_straggler timeout min value
+    # must > NODE_CHECK_TIMEOUT
+    MASTER_CLIENT_CHECK_NODE_TIMEOUT_MIN = 360
 
     # sleep 1s on NetworkFailureReason.WAITING_NODE
     MASTER_CLIENT_CHECK_FAULT_SLEEP_TIMEOUT = 1

--- a/dlrover/python/elastic_agent/master_client.py
+++ b/dlrover/python/elastic_agent/master_client.py
@@ -402,7 +402,7 @@ class MasterClient(Singleton):
             break
         return result.nodes, result.reason
 
-    def check_straggler(self, timeout=3):
+    def check_straggler(self, timeout=300):
         request = grpc.StragglerExistRequest()
         start = time.time()
         while True:

--- a/dlrover/python/elastic_agent/torch/training.py
+++ b/dlrover/python/elastic_agent/torch/training.py
@@ -1397,6 +1397,15 @@ class NodeCheckElasticAgent(ElasticTrainingAgent):
         self._check_round = check_round
         self._config: ElasticLaunchConfig = config
 
+    def _get_check_node_timeout(self):
+        # get join timeout value from MasterRendezvousHandler
+        if not self._rdzv_handler:
+            timeout = int(self._rdzv_handler.join_timeout / 2)
+            if timeout >= JobConstant.MASTER_CLIENT_CHECK_NODE_TIMEOUT_MIN:
+                return timeout
+
+        return JobConstant.MASTER_CLIENT_CHECK_NODE_TIMEOUT_MIN
+
     def run(self, role: str = DEFAULT_ROLE) -> bool:
         spec = self._worker_group.spec
         role = spec.role
@@ -1409,7 +1418,9 @@ class NodeCheckElasticAgent(ElasticTrainingAgent):
         fault_nodes = []
         stragglers = []
         for i in range(self._check_round):
-            result, elapsed_time = self._run_node_check()
+            result, elapsed_time = self._run_node_check(
+                timeout=JobConstant.NODE_CHECK_TIMEOUT
+            )
             elapsed_time = round(elapsed_time, 3)
             logger.info(
                 f"Network check time of round {i} is {elapsed_time}"
@@ -1427,10 +1438,10 @@ class NodeCheckElasticAgent(ElasticTrainingAgent):
             )
             success = success or result
             fault_nodes, fault_reason = self._client.check_fault_node(
-                timeout=JobConstant.MASTER_CLIENT_CHECK_FAULT_NODE_TIMEOUT
+                timeout=self._get_check_node_timeout()
             )
             stragglers, straggler_reason = self._client.check_straggler(
-                timeout=JobConstant.MASTER_CLIENT_CHECK_STRAGGLER_NODE_TIMEOUT
+                timeout=self._get_check_node_timeout()
             )
             logger.info(
                 f"Fault nodes are: {fault_nodes} with {fault_reason} "

--- a/dlrover/python/elastic_agent/torch/training.py
+++ b/dlrover/python/elastic_agent/torch/training.py
@@ -1398,15 +1398,7 @@ class NodeCheckElasticAgent(ElasticTrainingAgent):
         self._config: ElasticLaunchConfig = config
 
     def _get_check_node_timeout(self):
-        # based on join timeout value from config
-        if "join_timeout" in self._config.rdzv_configs:
-            timeout = int(
-                int(self._config.rdzv_configs.get("join_timeout")) / 2
-            )
-            if timeout >= JobConstant.MASTER_CLIENT_CHECK_NODE_TIMEOUT_MIN:
-                return timeout
-
-        return JobConstant.MASTER_CLIENT_CHECK_NODE_TIMEOUT_MIN
+        return JobConstant.MASTER_CLIENT_CHECK_NODE_TIMEOUT
 
     def run(self, role: str = DEFAULT_ROLE) -> bool:
         spec = self._worker_group.spec

--- a/dlrover/python/elastic_agent/torch/training.py
+++ b/dlrover/python/elastic_agent/torch/training.py
@@ -1399,9 +1399,12 @@ class NodeCheckElasticAgent(ElasticTrainingAgent):
 
     def _get_check_node_timeout(self):
         # based on join timeout value from config
-        timeout = int(self._config.rdzv_configs.get("join_timeout") / 2)
-        if timeout >= JobConstant.MASTER_CLIENT_CHECK_NODE_TIMEOUT_MIN:
-            return timeout
+        if "join_timeout" in self._config.rdzv_configs:
+            timeout = int(
+                int(self._config.rdzv_configs.get("join_timeout")) / 2
+            )
+            if timeout >= JobConstant.MASTER_CLIENT_CHECK_NODE_TIMEOUT_MIN:
+                return timeout
 
         return JobConstant.MASTER_CLIENT_CHECK_NODE_TIMEOUT_MIN
 

--- a/dlrover/python/elastic_agent/torch/training.py
+++ b/dlrover/python/elastic_agent/torch/training.py
@@ -1398,7 +1398,7 @@ class NodeCheckElasticAgent(ElasticTrainingAgent):
         self._config: ElasticLaunchConfig = config
 
     def _get_check_node_timeout(self):
-        # get join timeout value from MasterRendezvousHandler
+        # based on join timeout value from config
         timeout = int(self._config.rdzv_configs.get("join_timeout") / 2)
         if timeout >= JobConstant.MASTER_CLIENT_CHECK_NODE_TIMEOUT_MIN:
             return timeout

--- a/dlrover/python/elastic_agent/torch/training.py
+++ b/dlrover/python/elastic_agent/torch/training.py
@@ -1399,10 +1399,9 @@ class NodeCheckElasticAgent(ElasticTrainingAgent):
 
     def _get_check_node_timeout(self):
         # get join timeout value from MasterRendezvousHandler
-        if not self._rdzv_handler:
-            timeout = int(self._rdzv_handler.join_timeout / 2)
-            if timeout >= JobConstant.MASTER_CLIENT_CHECK_NODE_TIMEOUT_MIN:
-                return timeout
+        timeout = int(self._config.rdzv_configs.get("join_timeout") / 2)
+        if timeout >= JobConstant.MASTER_CLIENT_CHECK_NODE_TIMEOUT_MIN:
+            return timeout
 
         return JobConstant.MASTER_CLIENT_CHECK_NODE_TIMEOUT_MIN
 

--- a/dlrover/python/tests/test_elastic_training_agent.py
+++ b/dlrover/python/tests/test_elastic_training_agent.py
@@ -835,27 +835,8 @@ class NodeCheckElasticAgentTest(unittest.TestCase):
         )
         self.assertEqual(
             agent._get_check_node_timeout(),
-            JobConstant.MASTER_CLIENT_CHECK_NODE_TIMEOUT_MIN,
+            JobConstant.MASTER_CLIENT_CHECK_NODE_TIMEOUT,
         )
-
-        agent._config.rdzv_configs = {
-            "join_timeout": "600",
-            "rank": 0,
-            "timeout": "16000",
-            "node_unit": 1,
-        }
-        self.assertEqual(
-            agent._get_check_node_timeout(),
-            JobConstant.MASTER_CLIENT_CHECK_NODE_TIMEOUT_MIN,
-        )
-
-        agent._config.rdzv_configs = {
-            "join_timeout": "1200",
-            "rank": 0,
-            "timeout": "16000",
-            "node_unit": 1,
-        }
-        self.assertEqual(agent._get_check_node_timeout(), 600)
 
 
 class MasterRendezvousHandlerTest(unittest.TestCase):

--- a/dlrover/python/tests/test_elastic_training_agent.py
+++ b/dlrover/python/tests/test_elastic_training_agent.py
@@ -823,6 +823,25 @@ class NodeCheckElasticAgentTest(unittest.TestCase):
         comm_perf_check(config, entrypoint, args)
         mock_run.assert_called()
 
+    def test_get_check_node_timeout(self):
+        config = ElasticLaunchConfig(4, 4, 8)
+        agent = _create_check_agent(
+            config=config,
+            entrypoint="python",
+            args=[],
+            rdzv_name="elastic-training",
+            check_round=2,
+        )
+
+        agent._rdzv_handler.join_timeout = mock.MagicMock(return_value=600)
+        self.assertEqual(
+            agent._get_check_node_timeout,
+            JobConstant.MASTER_CLIENT_CHECK_NODE_TIMEOUT_MIN,
+        )
+
+        agent._rdzv_handler.join_timeout = mock.MagicMock(return_value=1200)
+        self.assertEqual(agent._get_check_node_timeout, 600)
+
 
 class MasterRendezvousHandlerTest(unittest.TestCase):
     def setUp(self) -> None:

--- a/dlrover/python/tests/test_elastic_training_agent.py
+++ b/dlrover/python/tests/test_elastic_training_agent.py
@@ -833,29 +833,29 @@ class NodeCheckElasticAgentTest(unittest.TestCase):
             rdzv_name="elastic-training",
             check_round=2,
         )
-
-        agent._config.rdzv_configs = mock.MagicMock(
-            return_value={
-                "join_timeout": "600",
-                "rank": 0,
-                "timeout": "16000",
-                "node_unit": 1,
-            }
-        )
         self.assertEqual(
-            agent._get_check_node_timeout,
+            agent._get_check_node_timeout(),
             JobConstant.MASTER_CLIENT_CHECK_NODE_TIMEOUT_MIN,
         )
 
-        agent._config.rdzv_configs = mock.MagicMock(
-            return_value={
-                "join_timeout": "1200",
-                "rank": 0,
-                "timeout": "16000",
-                "node_unit": 1,
-            }
+        agent._config.rdzv_configs = {
+            "join_timeout": "600",
+            "rank": 0,
+            "timeout": "16000",
+            "node_unit": 1,
+        }
+        self.assertEqual(
+            agent._get_check_node_timeout(),
+            JobConstant.MASTER_CLIENT_CHECK_NODE_TIMEOUT_MIN,
         )
-        self.assertEqual(agent._get_check_node_timeout, 600)
+
+        agent._config.rdzv_configs = {
+            "join_timeout": "1200",
+            "rank": 0,
+            "timeout": "16000",
+            "node_unit": 1,
+        }
+        self.assertEqual(agent._get_check_node_timeout(), 600)
 
 
 class MasterRendezvousHandlerTest(unittest.TestCase):

--- a/dlrover/python/tests/test_elastic_training_agent.py
+++ b/dlrover/python/tests/test_elastic_training_agent.py
@@ -834,7 +834,7 @@ class NodeCheckElasticAgentTest(unittest.TestCase):
             check_round=2,
         )
 
-        config.rdzv_configs = mock.MagicMock(
+        agent._config.rdzv_configs = mock.MagicMock(
             return_value={
                 "join_timeout": "600",
                 "rank": 0,
@@ -847,7 +847,7 @@ class NodeCheckElasticAgentTest(unittest.TestCase):
             JobConstant.MASTER_CLIENT_CHECK_NODE_TIMEOUT_MIN,
         )
 
-        agent._rdzv_handler.join_timeout = mock.MagicMock(
+        agent._config.rdzv_configs = mock.MagicMock(
             return_value={
                 "join_timeout": "1200",
                 "rank": 0,

--- a/dlrover/python/tests/test_elastic_training_agent.py
+++ b/dlrover/python/tests/test_elastic_training_agent.py
@@ -825,6 +825,7 @@ class NodeCheckElasticAgentTest(unittest.TestCase):
 
     def test_get_check_node_timeout(self):
         config = ElasticLaunchConfig(4, 4, 8)
+
         agent = _create_check_agent(
             config=config,
             entrypoint="python",
@@ -833,13 +834,27 @@ class NodeCheckElasticAgentTest(unittest.TestCase):
             check_round=2,
         )
 
-        agent._rdzv_handler.join_timeout = mock.MagicMock(return_value=600)
+        config.rdzv_configs = mock.MagicMock(
+            return_value={
+                "join_timeout": "600",
+                "rank": 0,
+                "timeout": "16000",
+                "node_unit": 1,
+            }
+        )
         self.assertEqual(
             agent._get_check_node_timeout,
             JobConstant.MASTER_CLIENT_CHECK_NODE_TIMEOUT_MIN,
         )
 
-        agent._rdzv_handler.join_timeout = mock.MagicMock(return_value=1200)
+        agent._rdzv_handler.join_timeout = mock.MagicMock(
+            return_value={
+                "join_timeout": "1200",
+                "rank": 0,
+                "timeout": "16000",
+                "node_unit": 1,
+            }
+        )
         self.assertEqual(agent._get_check_node_timeout, 600)
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

The client invocation timeout must > node check timeout(300s) . 

### Why are the changes needed?

To optimize the node-check logic.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

UT and training.
