### PR TITLE
Fix network check status report issue.

### DIFF
--- a/dlrover/python/elastic_agent/torch/training.py
+++ b/dlrover/python/elastic_agent/torch/training.py
@@ -135,7 +135,13 @@ def _set_paral_config():
 def _get_local_ip():
     local_ip = os.getenv("POD_IP", "")
     if not local_ip:
-        local_ip = socket.gethostbyname(_get_fq_hostname())
+        try:
+            local_ip = socket.gethostbyname(_get_fq_hostname())
+        except socket.gaierror:
+            logger.warning(
+                "Can not resolve host IP. " "Use default '127.0.0.1' instead."
+            )
+            local_ip = "127.0.0.1"
     return local_ip
 
 
@@ -1315,8 +1321,7 @@ def launch_agent(
         if (
             (exc_type is not None)
             or (result is not None and result.is_failed())
-            and not is_node_check_failed
-        ):
+        ) and not is_node_check_failed:
             client.report_failed_exited()
             logger.info("Failed and exit.")
         elif is_node_check_failed:

--- a/dlrover/python/tests/test_elastic_training_agent.py
+++ b/dlrover/python/tests/test_elastic_training_agent.py
@@ -59,12 +59,14 @@ from dlrover.python.elastic_agent.torch.training import (
     ElasticTrainingAgent,
     MasterRendezvousHandler,
     NodeCheckElasticAgent,
+    NodeCheckFailedError,
     RendezvousOutSyncError,
     _create_check_agent,
     _create_worker_spec,
     _get_local_ip,
     _set_paral_config,
     comm_perf_check,
+    launch_agent,
     node_health_check,
 )
 from dlrover.python.tests.test_utils import start_local_master
@@ -677,6 +679,37 @@ class ElasticTrainingAgentRunTest(unittest.TestCase):
             ),
             1,
         )
+
+    @patch(
+        "dlrover.python.elastic_agent.master_client"
+        ".MasterClient.report_failed_exited"
+    )
+    @patch(
+        "dlrover.python.elastic_agent.torch.training"
+        ".ElasticTrainingAgent.run"
+    )
+    def test_node_status_report(self, mock_run, mock_report_failed_exited):
+        config = ElasticLaunchConfig(1, 1, 1)
+        entrypoint = "python"
+
+        mock_run.side_effect = RuntimeError("test")
+        mock_report_failed_exited.return_value = True
+        try:
+            launch_agent(config, entrypoint, [])
+            self.fail()
+        except RuntimeError:
+            self.assertTrue(True)
+            mock_run.assert_called_once()
+            mock_report_failed_exited.assert_called_once()
+
+        mock_run.side_effect = NodeCheckFailedError("test")
+        try:
+            launch_agent(config, entrypoint, [])
+            self.fail()
+        except NodeCheckFailedError:
+            self.assertTrue(True)
+            self.assertEqual(mock_run.call_count, 2)
+            mock_report_failed_exited.assert_called_once()
 
 
 class NodeCheckElasticAgentTest(unittest.TestCase):


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. Use 'success' as flag to determine whether to use 'node-check failed' or 'node-check success' for reporting.
2. Use a defined error 'NodeCheckFailedError' to distinguish 'failed' and 'node-check failed' reporting.

### Why are the changes needed?

1. Should return 'node-check success' if there is 1 round check which result is success.
2. Should not use 'failed exited' status to override 'node-check failed' status if the node is failed by node-check.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

Training with node check failed.