### PR TITLE
Refactor failed node counter.

### DIFF
--- a/dlrover/python/elastic_agent/torch/training.py
+++ b/dlrover/python/elastic_agent/torch/training.py
@@ -327,6 +327,7 @@ class MasterRendezvousHandler(RendezvousHandler):
         )
         logger.info(msg)
         self._join_rendezvous()
+
         start_pending = 0
         while True:
             self._check_network_rdzv_for_elastic_training()
@@ -848,7 +849,10 @@ class ElasticTrainingAgent(LocalElasticAgent):
         return workers
 
     def _initialize_workers(self, worker_group):
-        logger.info("Start initializing training workers.")
+        logger.info(
+            "Start initializing "
+            f"training({self.__class__.__name__}) workers."
+        )
         start_pending = 0
         pend_timeout = float(
             self._config.rdzv_configs.get("pend_timeout", "inf")

--- a/dlrover/python/elastic_agent/torch/training.py
+++ b/dlrover/python/elastic_agent/torch/training.py
@@ -1424,9 +1424,11 @@ class NodeCheckElasticAgent(ElasticTrainingAgent):
                 f"Network check time of round {i} is {elapsed_time}"
                 f" and succeed is {result}."
             )
+
+            success = success or result
             status = (
                 NodeEventType.NODE_CHECK_SUCCEEDED
-                if result
+                if success
                 else NodeEventType.NODE_CHECK_FAILED
             )
             self._client.report_network_check_status(
@@ -1434,7 +1436,7 @@ class NodeCheckElasticAgent(ElasticTrainingAgent):
                 status,
                 elapsed_time,
             )
-            success = success or result
+
             fault_nodes, fault_reason = self._client.check_fault_node(
                 timeout=self._get_check_node_timeout()
             )
@@ -1474,6 +1476,9 @@ class NodeCheckElasticAgent(ElasticTrainingAgent):
             logger.warning("This node is a straggler!")
             if self._config.exclude_straggler:
                 raise RuntimeError("The node is a straggler and exits.")
+
+
+
         return success
 
     def _run_node_check(self, monitor_interval=3, timeout=300):

--- a/dlrover/python/master/node/dist_job_manager.py
+++ b/dlrover/python/master/node/dist_job_manager.py
@@ -1163,10 +1163,13 @@ class DistributedJobManager(JobManager):
         error_data: str,
         level: str,
     ) -> bool:
-        if self._error_monitor and node is not None:
-            return self._error_monitor.process_error(
-                node, restart_count, error_data, level
-            )
+        if node:
+            if level == TrainingExceptionLevel.NODE_ERROR:
+                self._job_context.report_failed_node(node.id)
+            if self._error_monitor:
+                return self._error_monitor.process_error(
+                    node, restart_count, error_data, level
+                )
         return False
 
     def all_running_node_hanged(self):

--- a/dlrover/python/master/node/event_callback.py
+++ b/dlrover/python/master/node/event_callback.py
@@ -272,7 +272,7 @@ class AllReduceNodeHandlingCallback(NodeEventCallback):
     @NodeEventCallback.log_callback_exception
     def on_node_failed(self, node: Node, cluster_context):
         node.finish_time = datetime.now()  # type: ignore
-        self._job_context.report_failed_node()
+        self._job_context.report_failed_node(node.id)
         self._stop_job_if_needed(node)
         if node.is_unrecoverable_failure():
             self._master.speed_monitor.reduce_target_worker_num(

--- a/dlrover/python/master/node/job_context.py
+++ b/dlrover/python/master/node/job_context.py
@@ -13,7 +13,8 @@
 
 import copy
 import threading
-from typing import Dict, Optional
+import time
+from typing import Dict, Optional, Union
 
 from dlrover.python.common.constants import NodeType
 from dlrover.python.common.node import Node
@@ -36,6 +37,7 @@ class JobContext(Singleton):
     def __init__(self):
         self._action_queue = DiagnosisActionQueue()
         self._job_nodes: Dict[str, Dict[int, Node]] = {}
+        self._failed_nodes: Dict[int, int] = {}
         self._locker = threading.Lock()
 
     def enqueue_action(self, action):
@@ -178,6 +180,18 @@ class JobContext(Singleton):
     def clear_job_nodes(self):
         with self._locker:
             self._job_nodes = {}
+
+    def report_failed_node(self, node_id: Union[int, str] = None):
+        if node_id is None:
+            return
+
+        node_id = int(node_id)
+        with self._locker:
+            if node_id not in self._failed_nodes:
+                self._failed_nodes[node_id] = int(time.time())
+
+    def get_failed_node_cnt(self):
+        return len(self._failed_nodes)
 
 
 def get_job_context() -> JobContext:

--- a/dlrover/python/tests/test_event_callback.py
+++ b/dlrover/python/tests/test_event_callback.py
@@ -72,7 +72,7 @@ class AllReduceEventCallbackTest(unittest.TestCase):
         worker.relaunch_count = 1
         worker.exit_reason = NodeExitReason.FATAL_ERROR
         self.event_cb.on_node_failed(worker, None)
-        self.assertEqual(self.event_cb._failed_worker_count, 1)
+        self.assertEqual(self.event_cb._job_context.get_failed_node_cnt(), 1)
         self.assertTrue(self.master._stop_requested)
         self.master._stop_requested = False
         _dlrover_ctx.relaunch_always = True

--- a/dlrover/python/tests/test_job_manager.py
+++ b/dlrover/python/tests/test_job_manager.py
@@ -55,7 +55,7 @@ from dlrover.python.master.node.event_callback import (
     TaskRescheduleCallback,
     TFPSNodeHandlingCallback,
 )
-from dlrover.python.master.node.job_context import get_job_context, JobContext
+from dlrover.python.master.node.job_context import JobContext, get_job_context
 from dlrover.python.master.node.local_job_manager import LocalJobManager
 from dlrover.python.master.node.status_flow import (
     ALLOWED_TRANSITIONS,

--- a/dlrover/python/tests/test_job_manager.py
+++ b/dlrover/python/tests/test_job_manager.py
@@ -55,7 +55,7 @@ from dlrover.python.master.node.event_callback import (
     TaskRescheduleCallback,
     TFPSNodeHandlingCallback,
 )
-from dlrover.python.master.node.job_context import get_job_context
+from dlrover.python.master.node.job_context import get_job_context, JobContext
 from dlrover.python.master.node.local_job_manager import LocalJobManager
 from dlrover.python.master.node.status_flow import (
     ALLOWED_TRANSITIONS,
@@ -296,18 +296,18 @@ class DistributedJobManagerTest(unittest.TestCase):
         should_relaunch = manager._should_relaunch(node, NODE_STATE_FLOWS[6])
         self.assertFalse(should_relaunch)
 
-        self.assertEqual(manager._job_context.get_failed_node_cnt(), 0)
+        self.assertEqual(self.job_context.get_failed_node_cnt(), 2)
         manager.handle_training_failure(
             NodeType.WORKER, 0, level=TrainingExceptionLevel.NODE_ERROR
         )
         manager.handle_training_failure(
             NodeType.WORKER, 0, level=TrainingExceptionLevel.NODE_ERROR
         )
-        self.assertEqual(manager._job_context.get_failed_node_cnt(), 1)
+        self.assertEqual(self.job_context.get_failed_node_cnt(), 3)
         manager.handle_training_failure(
             NodeType.WORKER, 1, level=TrainingExceptionLevel.NODE_ERROR
         )
-        self.assertEqual(manager._job_context.get_failed_node_cnt(), 2)
+        self.assertEqual(self.job_context.get_failed_node_cnt(), 3)
 
     def test_relaunch_under_deleted_event(self):
         params = MockK8sPSJobArgs()

--- a/dlrover/python/tests/test_job_manager.py
+++ b/dlrover/python/tests/test_job_manager.py
@@ -240,6 +240,9 @@ class DistributedJobManagerTest(unittest.TestCase):
         manager = create_job_manager(params, SpeedMonitor())
         self.assertEqual(manager._ps_relaunch_max_num, 1)
         manager.start()
+
+        # reset failed nodes for testing
+        self.job_context._failed_nodes = {}
         self.assertEqual(manager._job_args.job_uuid, _MOCK_JOB_UUID)
 
         job_nodes = self.job_context.job_nodes()
@@ -296,18 +299,18 @@ class DistributedJobManagerTest(unittest.TestCase):
         should_relaunch = manager._should_relaunch(node, NODE_STATE_FLOWS[6])
         self.assertFalse(should_relaunch)
 
-        self.assertEqual(self.job_context.get_failed_node_cnt(), 2)
+        self.assertEqual(self.job_context.get_failed_node_cnt(), 0)
         manager.handle_training_failure(
             NodeType.WORKER, 0, level=TrainingExceptionLevel.NODE_ERROR
         )
         manager.handle_training_failure(
             NodeType.WORKER, 0, level=TrainingExceptionLevel.NODE_ERROR
         )
-        self.assertEqual(self.job_context.get_failed_node_cnt(), 3)
+        self.assertEqual(self.job_context.get_failed_node_cnt(), 1)
         manager.handle_training_failure(
             NodeType.WORKER, 1, level=TrainingExceptionLevel.NODE_ERROR
         )
-        self.assertEqual(self.job_context.get_failed_node_cnt(), 3)
+        self.assertEqual(self.job_context.get_failed_node_cnt(), 2)
 
     def test_relaunch_under_deleted_event(self):
         params = MockK8sPSJobArgs()

--- a/dlrover/python/tests/test_job_manager.py
+++ b/dlrover/python/tests/test_job_manager.py
@@ -55,7 +55,7 @@ from dlrover.python.master.node.event_callback import (
     TaskRescheduleCallback,
     TFPSNodeHandlingCallback,
 )
-from dlrover.python.master.node.job_context import JobContext, get_job_context
+from dlrover.python.master.node.job_context import get_job_context
 from dlrover.python.master.node.local_job_manager import LocalJobManager
 from dlrover.python.master.node.status_flow import (
     ALLOWED_TRANSITIONS,

--- a/dlrover/python/tests/test_job_manager.py
+++ b/dlrover/python/tests/test_job_manager.py
@@ -296,9 +296,18 @@ class DistributedJobManagerTest(unittest.TestCase):
         should_relaunch = manager._should_relaunch(node, NODE_STATE_FLOWS[6])
         self.assertFalse(should_relaunch)
 
+        self.assertEqual(manager._job_context.get_failed_node_cnt(), 0)
         manager.handle_training_failure(
             NodeType.WORKER, 0, level=TrainingExceptionLevel.NODE_ERROR
         )
+        manager.handle_training_failure(
+            NodeType.WORKER, 0, level=TrainingExceptionLevel.NODE_ERROR
+        )
+        self.assertEqual(manager._job_context.get_failed_node_cnt(), 1)
+        manager.handle_training_failure(
+            NodeType.WORKER, 1, level=TrainingExceptionLevel.NODE_ERROR
+        )
+        self.assertEqual(manager._job_context.get_failed_node_cnt(), 2)
 
     def test_relaunch_under_deleted_event(self):
         params = MockK8sPSJobArgs()


### PR DESCRIPTION
### What changes were proposed in this pull request?

Use a dict to save fault node info in job context. 
Node check failed should also be counted as 'failed worker'.

### Why are the changes needed?

Bug fix: some worker failed is not counted.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

Training with node check failed.
