### PR TITLE
Enhance torch240 rendezvous to improve fault tolerance ability.

### DIFF
--- a/dlrover/python/common/constants.py
+++ b/dlrover/python/common/constants.py
@@ -385,7 +385,8 @@ class JobConstant(object):
     # sleep 5s before next node check round
     NODE_CHECK_NEXT_ROUND_TIMEOUT = 5
 
-    TRAINING_AGENT_LOOP_DEFAULT_INTERVAL = 15
+    TRAINING_AGENT_LOOP_INTERVAL = 15
+    TRAINING_AGENT_CORE_LOOP_INTERVAL = 5
 
 
 class Accelerators(object):

--- a/dlrover/trainer/torch/flash_checkpoint/engine.py
+++ b/dlrover/trainer/torch/flash_checkpoint/engine.py
@@ -361,7 +361,7 @@ class CheckpointEngine(metaclass=ABCMeta):
         if not all_rank_ready or not state_dict:
             logger.info(
                 f"Rank {self._rank} skips the save the checkpoint "
-                f"in CPU memory since it is saving the latest "
+                "in CPU memory since it is saving the latest "
                 "checkpoint from the CPU memory into the storage."
             )
             if acquired:


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add 'wait' logic on 2 parts:

1. Rank0 retrieve all role info.
2. Other ranks retrieve rank info.

### Why are the changes needed?

Optimization for rendezvous logic targeting torch version greater than 2.4.0. 

If a worker exits during the process of assigning RANK for rendezvous, resulting in empty metadata retrieval, the process will not immediately exit due to deserialization failure. Instead, it will wait (to prevent all networking workers from encountering errors and exiting immediately). If non-empty data cannot be obtained eventually, the process will terminate with an exception due to a pending timeout.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

UT and training(TODO).
