### PR TITLE
reduce rendezvous and sync port timeout to 5s

### DIFF
--- a/dlrover/python/common/constants.py
+++ b/dlrover/python/common/constants.py
@@ -387,6 +387,12 @@ class JobConstant(object):
 
     TRAINING_AGENT_LOOP_DEFAULT_INTERVAL = 15
 
+    # sleep 5s before next rendezvous round
+    RENDEZVOUS_DEFAULT_INTERVAL = 5
+
+    # sleep 5s before next port synchronization
+    SYNC_PORTS_DEFAULT_INTERVAL = 5
+
 
 class Accelerators(object):
     NVIDIA_GPU = "nvidia.com/gpu"

--- a/dlrover/python/elastic_agent/torch/training.py
+++ b/dlrover/python/elastic_agent/torch/training.py
@@ -354,9 +354,7 @@ class MasterRendezvousHandler(RendezvousHandler):
                             "and waits for more nodes."
                         )
                         start_pending = time.time()
-                    time.sleep(
-                        JobConstant.RENDEZVOUS_DEFAULT_INTERVAL
-                    )
+                    time.sleep(JobConstant.RENDEZVOUS_DEFAULT_INTERVAL)
                     start_join = time.time()
                     if start_join - start_pending > self.pend_timeout:
                         raise TimeoutError(
@@ -1185,7 +1183,9 @@ class ElasticTrainingAgent(LocalElasticAgent):
         """Shutdown the executor to save the checkpoint."""
         self._save_ckpt_executor.shutdown(wait=False)
 
-    def sync_training_ports(self, interval=JobConstant.SYNC_PORTS_DEFAULT_INTERVAL):
+    def sync_training_ports(
+        self, interval=JobConstant.SYNC_PORTS_DEFAULT_INTERVAL
+    ):
         logger.info(f"Accelerator: {self._config.accelerator}")
         if (
             self._config.accelerator == Accelerators.ASCEND_NPU

--- a/dlrover/python/elastic_agent/torch/training.py
+++ b/dlrover/python/elastic_agent/torch/training.py
@@ -355,7 +355,7 @@ class MasterRendezvousHandler(RendezvousHandler):
                         )
                         start_pending = time.time()
                     time.sleep(
-                        JobConstant.TRAINING_AGENT_LOOP_DEFAULT_INTERVAL
+                        JobConstant.RENDEZVOUS_DEFAULT_INTERVAL
                     )
                     start_join = time.time()
                     if start_join - start_pending > self.pend_timeout:
@@ -373,7 +373,7 @@ class MasterRendezvousHandler(RendezvousHandler):
                     err_msg, level=TrainingExceptionLevel.RDZV_ERROR
                 )
                 raise TimeoutError(err_msg)
-            time.sleep(JobConstant.TRAINING_AGENT_LOOP_DEFAULT_INTERVAL)
+            time.sleep(JobConstant.RENDEZVOUS_DEFAULT_INTERVAL)
         rank = list(world.keys()).index(self._node_rank)
         world_size = len(world)
         logger.info(
@@ -1185,7 +1185,7 @@ class ElasticTrainingAgent(LocalElasticAgent):
         """Shutdown the executor to save the checkpoint."""
         self._save_ckpt_executor.shutdown(wait=False)
 
-    def sync_training_ports(self, interval=20):
+    def sync_training_ports(self, interval=JobConstant.SYNC_PORTS_DEFAULT_INTERVAL):
         logger.info(f"Accelerator: {self._config.accelerator}")
         if (
             self._config.accelerator == Accelerators.ASCEND_NPU


### PR DESCRIPTION
### What changes were proposed in this pull request?

reduce rendezvous and sync port timeout to 5s

### Why are the changes needed?

the rendezvous timeout is 15s which is too long, also the sync port timeout (20 sec)

### Does this PR introduce any user-facing change?

NO

### How was this patch tested?

UT