### PR TITLE
The go master sets Pod owner reference as the ElasticJob instance.

### DIFF
--- a/go/master/pkg/batchscheduler/scheduler.go
+++ b/go/master/pkg/batchscheduler/scheduler.go
@@ -17,7 +17,7 @@ import (
 	"context"
 	"time"
 
-	elasticjob "github.com/intelligent-machine-learning/dlrover/go/elasticjob/api/v1alpha1"
+	elasticjobv1 "github.com/intelligent-machine-learning/dlrover/go/elasticjob/api/v1alpha1"
 	commonv1 "github.com/intelligent-machine-learning/dlrover/go/elasticjob/pkg/common/api/v1"
 	"github.com/intelligent-machine-learning/dlrover/go/master/pkg/common"
 	"github.com/intelligent-machine-learning/dlrover/go/master/pkg/kubeutils"
@@ -41,10 +41,15 @@ type SchedulingPlan struct {
 	CreatedPods []*kubeutils.PodConfig
 
 	// RemovedPods are Pods to be removed
-	RemovedPods []*kubeutils.PodConfig
+	RemovedPods []string
 
 	// OwnerJob specifies a job to scale.
-	OwnerJob *elasticjob.ElasticJob
+	OwnerJob *elasticjobv1.ElasticJob
+}
+
+// KubeScheduler is the base scheduler to create/update/remove pods.
+type KubeScheduler struct {
+	toCreatePods *common.Queue
 }
 
 // NewBatchScheduler creates a batch scheduler according to the scheduler name.
@@ -54,11 +59,6 @@ func NewBatchScheduler(schedulerName string) BatchScheduler {
 		return scheduler
 	}
 	return nil
-}
-
-// KubeScheduler is the base scheduler to create/update/remove pods.
-type KubeScheduler struct {
-	toCreatePods *common.Queue
 }
 
 // LoopToLaunchPods launches pods from the pod queue.

--- a/go/master/pkg/kubeutils/client.go
+++ b/go/master/pkg/kubeutils/client.go
@@ -25,6 +25,7 @@ import (
 	k8sApi "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/utils/ptr"
 )
 
 // GlobalK8sClient is the global client to access a k8s cluster.
@@ -105,5 +106,15 @@ func (client *K8sClient) CreatePod(ctx context.Context, pod *corev1.Pod) error {
 		CoreV1().
 		Pods(client.namespace).
 		Create(ctx, pod, metav1.CreateOptions{})
+	return err
+}
+
+// RemovePod removes a Pod instance in the cluster
+func (client *K8sClient) RemovePod(name string) error {
+	err := client.clientset.CoreV1().Pods(client.namespace).Delete(
+		context.Background(),
+		name,
+		metav1.DeleteOptions{GracePeriodSeconds: ptr.To(int64(0))},
+	)
 	return err
 }

--- a/go/master/pkg/kubeutils/pod.go
+++ b/go/master/pkg/kubeutils/pod.go
@@ -16,6 +16,7 @@ package kubeutils
 import (
 	"fmt"
 
+	elasticjobv1 "github.com/intelligent-machine-learning/dlrover/go/elasticjob/api/v1alpha1"
 	"github.com/intelligent-machine-learning/dlrover/go/master/pkg/common"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -54,7 +55,7 @@ type PodConfig struct {
 }
 
 // BuildPod builds a corev1.Pod.
-func BuildPod(jobContext *common.JobContext, podConfig *PodConfig) *corev1.Pod {
+func BuildPod(jobContext *common.JobContext, podConfig *PodConfig, ownerJob *elasticjobv1.ElasticJob) *corev1.Pod {
 	podName := fmt.Sprintf("%s-%s-%d", jobContext.Name, podConfig.Replica.Type, podConfig.Replica.ID)
 	pod := &corev1.Pod{
 		TypeMeta: metav1.TypeMeta{
@@ -67,6 +68,9 @@ func BuildPod(jobContext *common.JobContext, podConfig *PodConfig) *corev1.Pod {
 	// Set pod name and namespace.
 	pod.ObjectMeta.Name = podName
 	pod.ObjectMeta.Namespace = jobContext.NameSpace
+	pod.ObjectMeta.OwnerReferences = []metav1.OwnerReference{
+		*metav1.NewControllerRef(ownerJob, elasticjobv1.SchemeGroupVersionKind),
+	}
 
 	if pod.ObjectMeta.Labels == nil {
 		pod.ObjectMeta.Labels = make(map[string]string)


### PR DESCRIPTION
### What changes were proposed in this pull request?

The go master sets Pod owner reference as the ElasticJob instance.

### Why are the changes needed?

The pod should be deleted once when the job is deleted.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

UT.
