### PR TITLE
add exception catch in _initialize_workers

### DIFF
--- a/dlrover/python/elastic_agent/torch/training.py
+++ b/dlrover/python/elastic_agent/torch/training.py
@@ -892,9 +892,9 @@ class ElasticTrainingAgent(LocalElasticAgent):
                 if err_cnt < max_errors:
                     stack_trace = traceback.format_exc()
                     logger.error(
-                        f"Unexpected exception in _initialize_workers: {e}"
+                        f"Unexpected exception in _initialize_workers: {e}\n"
+                        f"Stack backtrace:\n {stack_trace}"
                     )
-                    logger.error(f"Stack backtrace:\n {stack_trace}")
                     self._stop_workers(worker_group)
                     continue
                 else:

--- a/dlrover/python/elastic_agent/torch/training.py
+++ b/dlrover/python/elastic_agent/torch/training.py
@@ -20,6 +20,7 @@ import socket
 import sys
 import tempfile
 import time
+import traceback
 import uuid
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
@@ -864,6 +865,7 @@ class ElasticTrainingAgent(LocalElasticAgent):
             f"training({self.__class__.__name__}) workers."
         )
         start_pending = 0
+        err_cnt = 0
         pend_timeout = float(
             self._config.rdzv_configs.get("pend_timeout", "inf")
         )
@@ -885,6 +887,18 @@ class ElasticTrainingAgent(LocalElasticAgent):
                 time.sleep(JobConstant.TRAINING_AGENT_LOOP_DEFAULT_INTERVAL)
                 if time.time() - start_pending > pend_timeout:
                     raise TimeoutError("Timeout to wait for new nodes.")
+            except Exception as e:
+                err_cnt += 1
+                if err_cnt < 3:
+                    stack_trace = traceback.format_exc()
+                    logger.error(
+                        f"Unexpected exception in _initialize_workers: {e}"
+                    )
+                    logger.error(f"Stack backtrace:\n {stack_trace}")
+                    self._stop_workers(worker_group)
+                    continue
+                else:
+                    raise e
             else:
                 logger.info("Finish initializing training workers.")
                 break

--- a/dlrover/python/elastic_agent/torch/training.py
+++ b/dlrover/python/elastic_agent/torch/training.py
@@ -859,7 +859,7 @@ class ElasticTrainingAgent(LocalElasticAgent):
                 workers.append(worker)
         return workers
 
-    def _initialize_workers(self, worker_group):
+    def _initialize_workers(self, worker_group, max_errors=3):
         logger.info(
             "Start initializing "
             f"training({self.__class__.__name__}) workers."
@@ -889,7 +889,7 @@ class ElasticTrainingAgent(LocalElasticAgent):
                     raise TimeoutError("Timeout to wait for new nodes.")
             except Exception as e:
                 err_cnt += 1
-                if err_cnt < 3:
+                if err_cnt < max_errors:
                     stack_trace = traceback.format_exc()
                     logger.error(
                         f"Unexpected exception in _initialize_workers: {e}"


### PR DESCRIPTION
### What changes were proposed in this pull request?

add final exception handler in _initialize_workers

### Why are the changes needed?

Due to unexpected corner-cases or bugs, which sometimes comes from torch, the _initialize_workers
may throw exceptions other than RendezvousOutSyncErro, which we need to handle gracefully.
Otherwise the dlrover agent would fail and exit

### Does this PR introduce any user-facing change?

No

### How was this patch tested?

UT