### PR TITLE
Release locks on checkpoints when to restart training process

### DIFF
--- a/dlrover/python/elastic_agent/torch/ckpt_saver.py
+++ b/dlrover/python/elastic_agent/torch/ckpt_saver.py
@@ -579,6 +579,10 @@ class AsyncCheckpointSaver(metaclass=ABCMeta):
         self._event_queue.unlink()
         self._executor.shutdown(wait=False)
 
+    def release_locks(self):
+        for i in range(self.local_shard_num):
+            self._shm_locks[i].release()
+
     def _sync_shm_to_storage(self):
         """
         The loop to persist the state dict from the memory
@@ -853,6 +857,7 @@ class AsyncCheckpointSaver(metaclass=ABCMeta):
             return
         cls._saver_instance.reset_shared_memory()
         logger.info("Reset all shared memory of shards.")
+        cls._saver_instance.release_locks()
 
     @abstractmethod
     def save_step_checkpoint(self, step: int):

--- a/dlrover/python/elastic_agent/torch/training.py
+++ b/dlrover/python/elastic_agent/torch/training.py
@@ -1173,7 +1173,7 @@ class ElasticTrainingAgent(LocalElasticAgent):
     def _restart_workers(self, worker_group: WorkerGroup):
         self._restart_count += 1
         self._remaining_restarts -= 1
-        # Relase the shared memory lock before starting workers.
+        # Release the shared memory lock before starting workers.
         AsyncCheckpointSaver.reset()
         super()._restart_workers(worker_group)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Release all locks on the checkpoints when to restart the training.

### Why are the changes needed?

We have observed the locks on the checkpointing are not released when the training process is restarted.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

Unit test