### PR TITLE
fix test_save_to_storage termination error in test_ckpt_saver.py

### DIFF
--- a/dlrover/python/tests/test_ckpt_saver.py
+++ b/dlrover/python/tests/test_ckpt_saver.py
@@ -264,6 +264,7 @@ class CheckpointSaverTest(unittest.TestCase):
             saver._shm_handlers[0].shared_memory = SharedMemory(
                 name=saver._shm_handlers[0]._shm_name
             )
+            signal.signal(signal.SIGTERM, signal.SIG_IGN)
             AsyncCheckpointSaver._saver_instance = saver
             AsyncCheckpointSaver.register_signal_handler()
             handler = signal.getsignal(signal.SIGTERM)


### PR DESCRIPTION
### What changes were proposed in this pull request?

add SIG_IGN in test_save_to_storage

### Why are the changes needed?

fix test_ckpt_saver case error, the unit test may terminated by the SIGTERM when running locally

### Does this PR introduce any user-facing change?

NO

### How was this patch tested?

UT