### PR TITLE
fix signal hanlder: don't unregister if origin signal handler is SIG_IGN

### DIFF
--- a/dlrover/python/tests/conftest.py
+++ b/dlrover/python/tests/conftest.py
@@ -1,0 +1,6 @@
+import os
+
+
+def pytest_configure():
+    # disable default event exporter for unit tests
+    os.environ["DLROVER_EVENT_ENABLE"] = "false"

--- a/dlrover/python/tests/conftest.py
+++ b/dlrover/python/tests/conftest.py
@@ -1,3 +1,16 @@
+# Copyright 2025 The DLRover Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 
 

--- a/dlrover/python/tests/test_error_handler.py
+++ b/dlrover/python/tests/test_error_handler.py
@@ -11,11 +11,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import signal
 import sys
 import threading
 from unittest.mock import Mock
-import os
 
 import pytest
 
@@ -65,6 +65,10 @@ def test_handle_exception(exception_handler):
 
 
 def test_handle_signal(exception_handler):
+    # set default signal handler for SIGINT in case other
+    # modules have already set it
+    signal.signal(signal.SIGINT, signal.default_int_handler)
+
     exception_handler.register()
     mock_frame = None
     with pytest.raises(KeyboardInterrupt):
@@ -77,6 +81,10 @@ def test_handle_signal(exception_handler):
 
 
 def test_handle_signal_generate_frame_failed(exception_handler):
+    # set default signal handler for SIGINT in case other
+    # modules have already set it
+    signal.signal(signal.SIGINT, signal.default_int_handler)
+
     exception_handler.register()
     mock_frame = "mock_frame"
     with pytest.raises(KeyboardInterrupt):
@@ -105,7 +113,6 @@ def test_handle_signal_event_failed(exception_handler):
 
 
 def test_handle_signal_unregister_signal(exception_handler, monkeypatch):
-
     def mock_kill(pid, sig):
         pass
 

--- a/dlrover/python/tests/test_error_handler.py
+++ b/dlrover/python/tests/test_error_handler.py
@@ -66,10 +66,8 @@ def test_handle_exception(exception_handler):
 def test_handle_signal(exception_handler):
     exception_handler.register()
     mock_frame = None
-    try:
+    with pytest.raises(KeyboardInterrupt):
         exception_handler._handle_signal(signal.SIGINT, mock_frame)
-    except Exception:
-        pass
     mock_process = exception_handler._process
     assert mock_process.instant.call_count == 1
     assert mock_process.instant.call_args.args[0] == "exit_sig"

--- a/dlrover/python/tests/test_error_handler.py
+++ b/dlrover/python/tests/test_error_handler.py
@@ -47,7 +47,7 @@ def test_register_unregister(exception_handler):
     assert len(exception_handler._original_handlers) > 0
 
     exception_handler.unregister()
-    assert sys.excepthook is original_excepthook  # 使用 'is' 而不是 '=='
+    assert sys.excepthook is original_excepthook  # use 'is' instead of '=='
     assert len(exception_handler._original_handlers) == 0
 
 
@@ -127,9 +127,9 @@ def test_handle_signal_unregister_signal(exception_handler, monkeypatch):
     assert mock_process.instant.call_count == 1
     assert mock_process.instant.call_args.args[0] == "exit_sig"
 
-    # 测试 unregister
+    #  test unregister
     exception_handler.unregister()
-    assert not exception_handler._registered  # 确保已注销
+    assert not exception_handler._registered  # ensure unregistered
 
 
 def test_thread_safety():

--- a/dlrover/python/training_event/error_handler.py
+++ b/dlrover/python/training_event/error_handler.py
@@ -19,7 +19,6 @@ import traceback
 
 from dlrover.python.training_event.config import Config, get_default_logger
 from dlrover.python.training_event.emitter import Process
-from dlrover.python.training_event.exporter import close_default_exporter
 
 logger = get_default_logger()
 
@@ -80,7 +79,6 @@ class ErrorHandler:
                 content["stack"] = f"get stack failed: {str(e)}"
 
             self._process.instant("exit_sig", content)
-            close_default_exporter()
 
         except Exception as e:
             logger.error(f"process signal {signum} error: {str(e)}")

--- a/dlrover/python/training_event/error_handler.py
+++ b/dlrover/python/training_event/error_handler.py
@@ -16,7 +16,6 @@ import signal
 import sys
 import threading
 import traceback
-from inspect import iscallable
 
 from dlrover.python.training_event.config import Config, get_default_logger
 from dlrover.python.training_event.emitter import Process
@@ -91,7 +90,7 @@ class ErrorHandler:
 
     def _call_original_handler(self, signum, frame):
         """call original handler with signal"""
-        if iscallable(self._original_handlers[signum]):
+        if callable(self._original_handlers[signum]):
             self._original_handlers[signum](signum, frame)
         elif self._original_handlers[signum] == signal.SIG_IGN:
             return

--- a/dlrover/python/training_event/error_handler.py
+++ b/dlrover/python/training_event/error_handler.py
@@ -90,9 +90,15 @@ class ErrorHandler:
 
     def _call_original_handler(self, signum, frame):
         """call original handler with signal"""
+
+        # if the handler is callable, call it
         if callable(self._original_handlers[signum]):
             self._original_handlers[signum](signum, frame)
-        elif self._original_handlers[signum] == signal.SIG_IGN:
+        # if the handler is SIG_IGN or signal is SIGCHLD, do nothing
+        elif (
+            self._original_handlers[signum] == signal.SIG_IGN
+            or signum == signal.SIGCHLD
+        ):
             return
         else:
             if self._registered:


### PR DESCRIPTION
### What changes were proposed in this pull request?

fix signal hanlder: don't unregister if origin signal handler is SIG_IGN

### Why are the changes needed?

if unregister for all signals, signals after SIG_IGN will be lost.

### Does this PR introduce any user-facing change?

No

### How was this patch tested?

UT