### PR TITLE
adjust xpu_type into job args

### DIFF
--- a/dlrover/python/common/constants.py
+++ b/dlrover/python/common/constants.py
@@ -406,6 +406,12 @@ class Accelerators(object):
     ASCEND_NPU = "ascend-npu"
 
 
+class XpuType(object):
+    GPU = "nvidia"
+    NPU = "ascend"
+    CPU = "cpu"
+
+
 class AscendConstants(object):
     # By default， there are 16(max) npu on one machine
     NPU_PER_NODE = 16

--- a/dlrover/python/common/constants.py
+++ b/dlrover/python/common/constants.py
@@ -404,12 +404,7 @@ class JobConstant(object):
 class Accelerators(object):
     NVIDIA_GPU = "nvidia.com/gpu"
     ASCEND_NPU = "ascend-npu"
-
-
-class XpuType(object):
-    GPU = "nvidia"
-    NPU = "ascend"
-    CPU = "cpu"
+    GENERIC_CPU = "cpu"
 
 
 class AscendConstants(object):

--- a/dlrover/python/common/global_context.py
+++ b/dlrover/python/common/global_context.py
@@ -15,7 +15,6 @@ import os
 from typing import List, Tuple
 
 from dlrover.python.common.constants import (
-    Accelerators,
     CommunicationType,
     PendingTimeoutStrategyType,
     UserEnv,
@@ -126,8 +125,9 @@ class Context(Singleton):
         self.hang_detection = DefaultValues.HANG_DETECTION
         # The duration of downtime as training hang, unit is minute
         self.hang_downtime = DefaultValues.HANG_DOWNTIME
-        # The default xpu device type.
-        self.xpu_type = Accelerators.NVIDIA_GPU
+        # The metric url and token, passed through env or args
+        self.metric_url = ""
+        self.metric_token = ""
         self.gpu_per_node = DefaultValues.GPU_NUM_PER_NODE
         self.npu_per_node = DefaultValues.NPU_NUM_PER_NODE
         # pre-check args

--- a/dlrover/python/common/global_context.py
+++ b/dlrover/python/common/global_context.py
@@ -125,9 +125,6 @@ class Context(Singleton):
         self.hang_detection = DefaultValues.HANG_DETECTION
         # The duration of downtime as training hang, unit is minute
         self.hang_downtime = DefaultValues.HANG_DOWNTIME
-        # The metric url and token, passed through env or args
-        self.metric_url = ""
-        self.metric_token = ""
         self.gpu_per_node = DefaultValues.GPU_NUM_PER_NODE
         self.npu_per_node = DefaultValues.NPU_NUM_PER_NODE
         # pre-check args

--- a/dlrover/python/common/metric/monitor.py
+++ b/dlrover/python/common/metric/monitor.py
@@ -11,7 +11,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import threading
 import time
 import traceback
@@ -219,11 +218,11 @@ class SimpleMetricMonitor(MetricMonitor):
     def query_job_metrics(
         self, job_name, metric_type, start, end, is_gpu=True, pod_name=None
     ):
-        url = os.getenv("DLROVER_METRIC_URL", "")
+        url = _dlrover_context.metric_url
         if url == "":
             logger.warning("No GPU metrics url defined")
             return None
-        token = os.getenv("DLROVER_METRIC_TOKEN", "")
+        token = _dlrover_context.metric_token
         if token == "":
             logger.warning("No GPU metrics token defined")
             return None

--- a/dlrover/python/common/metric/monitor.py
+++ b/dlrover/python/common/metric/monitor.py
@@ -10,7 +10,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import os
 import threading
 import time
 import traceback
@@ -218,14 +218,8 @@ class SimpleMetricMonitor(MetricMonitor):
     def query_job_metrics(
         self, job_name, metric_type, start, end, is_gpu=True, pod_name=None
     ):
-        url = _dlrover_context.metric_url
-        if url == "":
-            logger.warning("No GPU metrics url defined")
-            return None
-        token = _dlrover_context.metric_token
-        if token == "":
-            logger.warning("No GPU metrics token defined")
-            return None
+        url = os.getenv("DLROVER_METRIC_URL", "")
+        token = os.getenv("DLROVER_METRIC_TOKEN", "")
 
         try:
             start_time, end_time = self.adjust_timestamp(start, end)

--- a/dlrover/python/diagnosis/common/constants.py
+++ b/dlrover/python/diagnosis/common/constants.py
@@ -73,6 +73,8 @@ class DiagnosisActionType(object):
 
 
 class DiagnosisResult(object):
+    # diag invalid param
+    DIAG_INVALID_PARAM = "invalid"
     # diag error
     DIAG_ERROR = "error"
     # waiting for more data to finish diag

--- a/dlrover/python/master/diagnosis/diagnosis_manager.py
+++ b/dlrover/python/master/diagnosis/diagnosis_manager.py
@@ -276,22 +276,26 @@ class DiagnosisManager:
 
         """
         if not self._job_args.metric_url:
-            self._job_args.metric_url = os.getenv("DLROVER_METRIC_URL", "")
-        _dlrover_context.metric_url = self._job_args.metric_url
+            _dlrover_context.metric_url = os.getenv("DLROVER_METRIC_URL", "")
+        else:
+            _dlrover_context.metric_url = self._job_args.metric_url
 
         if not self._job_args.metric_token:
-            self._job_args.metric_token = os.getenv("DLROVER_METRIC_TOKEN", "")
-        _dlrover_context.metric_token = self._job_args.metric_token
+            _dlrover_context.metric_token = os.getenv(
+                "DLROVER_METRIC_TOKEN", ""
+            )
+        else:
+            _dlrover_context.metric_token = self._job_args.metric_token
 
         logger.info(f"start {self._job_args.xpu_type} metric collector...")
         if not _dlrover_context.metric_url:
             logger.warning("no GPU metrics url defined, stop metric collector")
-            return
+            return DiagnosisResult.DIAG_ERROR
         if not _dlrover_context.metric_token:
             logger.warning(
                 "no GPU metrics token defined, stop metric collector"
             )
-            return
+            return DiagnosisResult.DIAG_ERROR
 
         if self._job_args.xpu_type is XpuType.NPU:
             self._metric_monitor = NpuMetricMonitor(
@@ -312,7 +316,7 @@ class DiagnosisManager:
             logger.info(
                 f"No need to collect metrics in {self._job_args.xpu_type}"
             )
-            return
+            return DiagnosisResult.DIAG_ERROR
 
         if self._metric_monitor:
             self._metric_monitor.start()

--- a/dlrover/python/master/local_master.py
+++ b/dlrover/python/master/local_master.py
@@ -20,7 +20,6 @@ from dlrover.python.common.constants import (
     PreCheckStatus,
     RendezvousName,
     ReporterType,
-    XpuType,
 )
 from dlrover.python.common.log import default_logger as logger
 from dlrover.python.master.diagnosis.diagnosis_manager import DiagnosisManager
@@ -44,7 +43,6 @@ class LocalJobMaster(JobMaster):
         self.speed_monitor = SpeedMonitor()
         self.task_manager = TaskManager(0, self.speed_monitor)
         self.job_manager = create_job_manager(args, self.speed_monitor)
-        args.xpu_type = XpuType.GPU
         self.diagnosis_manager = DiagnosisManager(args)
         elastic_training = RendezvousName.ELASTIC_TRAINING
         self.rdzv_managers: Dict[str, RendezvousManager] = {

--- a/dlrover/python/master/local_master.py
+++ b/dlrover/python/master/local_master.py
@@ -20,6 +20,7 @@ from dlrover.python.common.constants import (
     PreCheckStatus,
     RendezvousName,
     ReporterType,
+    XpuType,
 )
 from dlrover.python.common.log import default_logger as logger
 from dlrover.python.master.diagnosis.diagnosis_manager import DiagnosisManager
@@ -43,6 +44,7 @@ class LocalJobMaster(JobMaster):
         self.speed_monitor = SpeedMonitor()
         self.task_manager = TaskManager(0, self.speed_monitor)
         self.job_manager = create_job_manager(args, self.speed_monitor)
+        args.xpu_type = XpuType.GPU
         self.diagnosis_manager = DiagnosisManager(args)
         elastic_training = RendezvousName.ELASTIC_TRAINING
         self.rdzv_managers: Dict[str, RendezvousManager] = {

--- a/dlrover/python/master/main.py
+++ b/dlrover/python/master/main.py
@@ -14,10 +14,10 @@
 import os
 
 from dlrover.python.common.constants import (
+    Accelerators,
     DistributionStrategy,
     NodeType,
     PlatformType,
-    XpuType,
 )
 from dlrover.python.common.global_context import Context
 from dlrover.python.common.log import default_logger as logger
@@ -55,12 +55,12 @@ def run(args):
     _dlrover_context.master_service_type = args.service_type
     _dlrover_context.pre_check_operators = args.pre_check_ops
     if args.xpu_type.lower() == "ascend":
-        job_args.xpu_type = XpuType.NPU
+        job_args.xpu_type = Accelerators.ASCEND_NPU
     elif args.xpu_type.lower() == "nvidia":
-        job_args.xpu_type = XpuType.GPU
+        job_args.xpu_type = Accelerators.NVIDIA_GPU
     else:
         logger.info(f"{args.xpu_type}, use cpu as default")
-        job_args.xpu_type = XpuType.CPU
+        job_args.xpu_type = Accelerators.GENERIC_CPU
 
     if job_args.platform == PlatformType.LOCAL:
         from dlrover.python.master.local_master import LocalJobMaster

--- a/dlrover/python/master/main.py
+++ b/dlrover/python/master/main.py
@@ -14,10 +14,10 @@
 import os
 
 from dlrover.python.common.constants import (
-    Accelerators,
     DistributionStrategy,
     NodeType,
     PlatformType,
+    XpuType,
 )
 from dlrover.python.common.global_context import Context
 from dlrover.python.common.log import default_logger as logger
@@ -55,14 +55,12 @@ def run(args):
     _dlrover_context.master_service_type = args.service_type
     _dlrover_context.pre_check_operators = args.pre_check_ops
     if args.xpu_type.lower() == "ascend":
-        _dlrover_context.xpu_type = Accelerators.ASCEND_NPU
+        job_args.xpu_type = XpuType.NPU
     elif args.xpu_type.lower() == "nvidia":
-        _dlrover_context.xpu_type = Accelerators.NVIDIA_GPU
+        job_args.xpu_type = XpuType.GPU
     else:
-        logger.info(
-            f"Invalid XPU type: {args.xpu_type}, use Nvidia as default"
-        )
-        _dlrover_context.xpu_type = Accelerators.NVIDIA_GPU
+        logger.info(f"{args.xpu_type}, use cpu as default")
+        job_args.xpu_type = XpuType.CPU
 
     if job_args.platform == PlatformType.LOCAL:
         from dlrover.python.master.local_master import LocalJobMaster

--- a/dlrover/python/scheduler/job.py
+++ b/dlrover/python/scheduler/job.py
@@ -14,7 +14,11 @@
 from abc import ABCMeta, abstractmethod
 from typing import Dict
 
-from dlrover.python.common.constants import DistributionStrategy, NodeType
+from dlrover.python.common.constants import (
+    Accelerators,
+    DistributionStrategy,
+    NodeType,
+)
 from dlrover.python.common.node import NodeGroupResource, NodeResource
 from dlrover.python.common.serialize import JsonSerializable
 
@@ -99,9 +103,7 @@ class JobArgs(JsonSerializable):
         self.relaunch_always = True
         self.remove_exited_node = False
         self.cordon_fault_node = False
-        self.xpu_type = ""
-        self.metric_url = ""
-        self.metric_token = ""
+        self.xpu_type: Accelerators = Accelerators.GENERIC_CPU
 
     @abstractmethod
     def initilize(self):

--- a/dlrover/python/scheduler/job.py
+++ b/dlrover/python/scheduler/job.py
@@ -99,6 +99,9 @@ class JobArgs(JsonSerializable):
         self.relaunch_always = True
         self.remove_exited_node = False
         self.cordon_fault_node = False
+        self.xpu_type = ""
+        self.metric_url = ""
+        self.metric_token = ""
 
     @abstractmethod
     def initilize(self):

--- a/dlrover/python/tests/test_diagnosis_manager.py
+++ b/dlrover/python/tests/test_diagnosis_manager.py
@@ -12,7 +12,6 @@
 # limitations under the License.
 
 import copy
-import os
 import time
 import unittest
 from datetime import datetime
@@ -21,10 +20,10 @@ from unittest import mock
 from unittest.mock import MagicMock, patch
 
 from dlrover.python.common.constants import (
+    Accelerators,
     GpuMetricEnum,
     PlatformType,
     PreCheckStatus,
-    XpuType,
 )
 from dlrover.python.common.global_context import Context
 from dlrover.python.common.metric.context import JobMetricContext
@@ -95,36 +94,14 @@ class DiagnosisManagerTest(unittest.TestCase):
 
     def test_diagnosis_manager_api(self):
         args = K8sJobArgs(PlatformType.KUBERNETES, "default", "test")
-        args.xpu_type = XpuType.GPU
+        args.xpu_type = Accelerators.GENERIC_CPU
         mgr = DiagnosisManager(job_args=args)
         self.assertEqual(
-            mgr.start_metric_collect(), DiagnosisResult.DIAG_ERROR
+            mgr.start_metric_collect(), DiagnosisResult.DIAG_INVALID_PARAM
         )
-        os.environ["DLROVER_METRIC_URL"] = "test"
-        self.assertEqual(
-            mgr.start_metric_collect(), DiagnosisResult.DIAG_ERROR
-        )
-        os.environ["DLROVER_METRIC_TOKEN"] = "test"
+        mgr._job_args.xpu_type = Accelerators.ASCEND_NPU
         self.assertNotEqual(
-            mgr.start_metric_collect(), DiagnosisResult.DIAG_ERROR
-        )
-
-        os.environ["DLROVER_METRIC_URL"] = ""
-        os.environ["DLROVER_METRIC_TOKEN"] = ""
-        _dlrover_context.metric_url = ""
-        _dlrover_context.token = ""
-        mgr._job_args.metric_url = "test"
-        self.assertEqual(
-            mgr.start_metric_collect(), DiagnosisResult.DIAG_ERROR
-        )
-        mgr._job_args.metric_token = "test"
-        self.assertNotEqual(
-            mgr.start_metric_collect(), DiagnosisResult.DIAG_ERROR
-        )
-
-        mgr._job_args.xpu_type = XpuType.NPU
-        self.assertNotEqual(
-            mgr.start_metric_collect(), DiagnosisResult.DIAG_ERROR
+            mgr.start_metric_collect(), DiagnosisResult.DIAG_INVALID_PARAM
         )
 
         mgr = DiagnosisManager(job_args=args)
@@ -170,7 +147,7 @@ class DiagnosisManagerTest(unittest.TestCase):
 
     def test_gpu_tensor_drop_zero(self):
         args = K8sJobArgs(PlatformType.KUBERNETES, "default", "test")
-        args.xpu_type = XpuType.GPU
+        args.xpu_type = Accelerators.NVIDIA_GPU
         mgr = DiagnosisManager(job_args=args)
         _metric_context.clear_node_metrics()
 

--- a/dlrover/python/tests/test_diagnosis_manager.py
+++ b/dlrover/python/tests/test_diagnosis_manager.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 
 import copy
+import os
 import time
 import unittest
 from datetime import datetime
@@ -94,6 +95,38 @@ class DiagnosisManagerTest(unittest.TestCase):
 
     def test_diagnosis_manager_api(self):
         args = K8sJobArgs(PlatformType.KUBERNETES, "default", "test")
+        args.xpu_type = XpuType.GPU
+        mgr = DiagnosisManager(job_args=args)
+        self.assertEqual(
+            mgr.start_metric_collect(), DiagnosisResult.DIAG_ERROR
+        )
+        os.environ["DLROVER_METRIC_URL"] = "test"
+        self.assertEqual(
+            mgr.start_metric_collect(), DiagnosisResult.DIAG_ERROR
+        )
+        os.environ["DLROVER_METRIC_TOKEN"] = "test"
+        self.assertNotEqual(
+            mgr.start_metric_collect(), DiagnosisResult.DIAG_ERROR
+        )
+
+        os.environ["DLROVER_METRIC_URL"] = ""
+        os.environ["DLROVER_METRIC_TOKEN"] = ""
+        _dlrover_context.metric_url = ""
+        _dlrover_context.token = ""
+        mgr._job_args.metric_url = "test"
+        self.assertEqual(
+            mgr.start_metric_collect(), DiagnosisResult.DIAG_ERROR
+        )
+        mgr._job_args.metric_token = "test"
+        self.assertNotEqual(
+            mgr.start_metric_collect(), DiagnosisResult.DIAG_ERROR
+        )
+
+        mgr._job_args.xpu_type = XpuType.NPU
+        self.assertNotEqual(
+            mgr.start_metric_collect(), DiagnosisResult.DIAG_ERROR
+        )
+
         mgr = DiagnosisManager(job_args=args)
         mgr.pre_check()
         mgr.start_observing()

--- a/dlrover/python/tests/test_diagnosis_manager.py
+++ b/dlrover/python/tests/test_diagnosis_manager.py
@@ -20,9 +20,10 @@ from unittest import mock
 from unittest.mock import MagicMock, patch
 
 from dlrover.python.common.constants import (
-    Accelerators,
     GpuMetricEnum,
+    PlatformType,
     PreCheckStatus,
+    XpuType,
 )
 from dlrover.python.common.global_context import Context
 from dlrover.python.common.metric.context import JobMetricContext
@@ -60,6 +61,7 @@ from dlrover.python.master.diagnosis.precheck_operator import (
     PreCheckResult,
 )
 from dlrover.python.master.node.job_context import get_job_context
+from dlrover.python.scheduler.kubernetes import K8sJobArgs
 from dlrover.python.util.function_util import TimeoutException
 
 _metric_context = JobMetricContext.singleton_instance()
@@ -91,7 +93,8 @@ class DiagnosisManagerTest(unittest.TestCase):
         self.assertEqual(len(logs), 1)
 
     def test_diagnosis_manager_api(self):
-        mgr = DiagnosisManager()
+        args = K8sJobArgs(PlatformType.KUBERNETES, "default", "test")
+        mgr = DiagnosisManager(job_args=args)
         mgr.pre_check()
         mgr.start_observing()
         mgr.stop_observing()
@@ -133,10 +136,11 @@ class DiagnosisManagerTest(unittest.TestCase):
         self.assertEqual(action.action_type, DiagnosisActionType.NONE)
 
     def test_gpu_tensor_drop_zero(self):
-        mgr = DiagnosisManager()
+        args = K8sJobArgs(PlatformType.KUBERNETES, "default", "test")
+        args.xpu_type = XpuType.GPU
+        mgr = DiagnosisManager(job_args=args)
         _metric_context.clear_node_metrics()
 
-        _dlrover_context.xpu_type = Accelerators.NVIDIA_GPU
         job_metrics = {}
         metric = GpuNodeMetric()
         for i in range(8):

--- a/dlrover/python/tests/test_elastic_training_agent.py
+++ b/dlrover/python/tests/test_elastic_training_agent.py
@@ -442,7 +442,6 @@ class ElasticTrainingAgentRunTest(unittest.TestCase):
             self.assertIsNot(os.getenv("DLROVER_METRIC_TOKEN", ""), "")
 
             _metric_context.clear_node_metrics()
-            _dlrover_context.xpu_type = Accelerators.NVIDIA_GPU
 
             self._master.diagnosis_manager.stop_metric_collect()
 
@@ -458,7 +457,6 @@ class ElasticTrainingAgentRunTest(unittest.TestCase):
             self.assertIsNot(os.getenv("DLROVER_METRIC_TOKEN", ""), "")
 
             _metric_context.clear_node_metrics()
-            _dlrover_context.xpu_type = Accelerators.ASCEND_NPU
 
             self._master.diagnosis_manager.stop_metric_collect()
 

--- a/dlrover/python/tests/test_metric_monitor.py
+++ b/dlrover/python/tests/test_metric_monitor.py
@@ -571,8 +571,6 @@ class MetricMonitorTests(unittest.TestCase):
         logging.basicConfig()
         logging.getLogger().setLevel(logging.DEBUG)
         _metric_context.clear_node_metrics()
-        _dlrover_context.metric_url = "test"
-        _dlrover_context.metric_token = "test"
 
     def tearDown(self):
         _metric_context.clear_node_metrics()

--- a/dlrover/python/tests/test_metric_monitor.py
+++ b/dlrover/python/tests/test_metric_monitor.py
@@ -27,6 +27,7 @@ from dlrover.python.common.constants import (
     GpuMetricEnum,
     NpuMetricEnum,
 )
+from dlrover.python.common.global_context import Context
 from dlrover.python.common.metric.context import (
     JobMetricContext,
     get_job_metric_context,
@@ -42,11 +43,10 @@ from dlrover.python.common.metric.monitor import (
     NpuMetricMonitor,
     SimpleMetricMonitor,
 )
-from dlrover.python.common.global_context import Context
-
 
 _metric_context = JobMetricContext.singleton_instance()
 _dlrover_context = Context.singleton_instance()
+
 
 class MetricContextTests(unittest.TestCase):
     def test_gpu_metric(self):

--- a/dlrover/python/tests/test_metric_monitor.py
+++ b/dlrover/python/tests/test_metric_monitor.py
@@ -42,9 +42,11 @@ from dlrover.python.common.metric.monitor import (
     NpuMetricMonitor,
     SimpleMetricMonitor,
 )
+from dlrover.python.common.global_context import Context
+
 
 _metric_context = JobMetricContext.singleton_instance()
-
+_dlrover_context = Context.singleton_instance()
 
 class MetricContextTests(unittest.TestCase):
     def test_gpu_metric(self):
@@ -569,6 +571,8 @@ class MetricMonitorTests(unittest.TestCase):
         logging.basicConfig()
         logging.getLogger().setLevel(logging.DEBUG)
         _metric_context.clear_node_metrics()
+        _dlrover_context.metric_url = "test"
+        _dlrover_context.metric_token = "test"
 
     def tearDown(self):
         _metric_context.clear_node_metrics()


### PR DESCRIPTION
### What changes were proposed in this pull request?

use job_args to store xpu_type

### Why are the changes needed?

provides multiple ways of setting xpu_type, as well as metric_url and metric_token

xpu_type is CPU/GPU/NPU in multiple kinds of arch. it can be setup in master params to define the job xpu type, as well as during job_args initialization of sub-class instance of JobMaster

metric_url and metric_token can be job params, or set up in OS env before master is running

### Does this PR introduce any user-facing change?

No

### How was this patch tested?

UT