### PR TITLE
SharedLock eof exception should not print error log

### DIFF
--- a/dlrover/python/common/multi_process.py
+++ b/dlrover/python/common/multi_process.py
@@ -313,7 +313,7 @@ class SharedLock(LocalSocketComm):
                 logger.error(f"SharedLock os error: {e}")
                 break
             except EOFError as e:
-                logger.error(f"SharedLock eof error: {e}")
+                logger.info(f"SharedLock eof {e}: peer closed and exit")
                 break
             except Exception as e:
                 logger.error(f"SharedLock unexpected recv error: {e}")

--- a/dlrover/python/common/multi_process.py
+++ b/dlrover/python/common/multi_process.py
@@ -307,15 +307,19 @@ class SharedLock(LocalSocketComm):
                 BrokenPipeError,
                 ConnectionError,
             ) as e:
+                # connection exception, need to re-connect a new one
                 logger.error(f"SharedLock connection error: {e}")
                 break
             except OSError as e:
+                # unexpected os error, re-connect and retry
                 logger.error(f"SharedLock os error: {e}")
                 break
             except EOFError as e:
+                # client has closed connection, exit safely
                 logger.info(f"SharedLock eof {e}: peer closed and exit")
                 break
             except Exception as e:
+                # unexpected exception, the connection may be ok
                 logger.error(f"SharedLock unexpected recv error: {e}")
                 response = SocketResponse()
                 response.status = ERROR_CODE


### PR DESCRIPTION
### What changes were proposed in this pull request?

log level

### Why are the changes needed?

from error log to info log

### Does this PR introduce any user-facing change?

No

### How was this patch tested?

UT