### PR TITLE
use RdzvTimeoutError to replace builtin TimeoutError

### DIFF
--- a/dlrover/python/tests/test_elastic_training_agent.py
+++ b/dlrover/python/tests/test_elastic_training_agent.py
@@ -75,6 +75,7 @@ from dlrover.python.elastic_agent.torch.training import (
     NodeCheckFailedError,
     RendezvousOutSyncError,
     RendezvousTimeoutError,
+    StopWorkerTimeoutError,
     _create_check_agent,
     _create_worker_spec,
     _get_local_ip,
@@ -783,7 +784,7 @@ class ElasticTrainingAgentRunTest(unittest.TestCase):
             try:
                 agent._stop_workers(None, is_restart=False, timeout=3)
                 self.fail()
-            except RendezvousTimeoutError:
+            except StopWorkerTimeoutError:
                 self.assertTrue(True)
 
     def test_diagnosis(self):

--- a/dlrover/python/tests/test_elastic_training_agent.py
+++ b/dlrover/python/tests/test_elastic_training_agent.py
@@ -301,6 +301,18 @@ class ElasticTrainingAgentTest(unittest.TestCase):
         agent._config.network_check = False
 
         agent._rendezvous = mock.MagicMock(
+            side_effect=[NodeCheckFailedError("test")],
+        )
+        with self.assertRaises(NodeCheckFailedError):
+            agent._initialize_workers(agent._worker_group)
+
+        agent._rendezvous = mock.MagicMock(
+            side_effect=[RendezvousTimeoutError("test")],
+        )
+        with self.assertRaises(RendezvousTimeoutError):
+            agent._initialize_workers(agent._worker_group)
+
+        agent._rendezvous = mock.MagicMock(
             side_effect=[ValueError("test")],
         )
         with self.assertRaises(ValueError):

--- a/dlrover/python/tests/test_elastic_training_agent.py
+++ b/dlrover/python/tests/test_elastic_training_agent.py
@@ -73,6 +73,7 @@ from dlrover.python.elastic_agent.torch.training import (
     MasterRendezvousHandler,
     NodeCheckElasticAgent,
     NodeCheckFailedError,
+    RdzvTimeoutError,
     RendezvousOutSyncError,
     _create_check_agent,
     _create_worker_spec,
@@ -283,7 +284,7 @@ class ElasticTrainingAgentTest(unittest.TestCase):
             raise RendezvousOutSyncError("test")
 
         agent._rendezvous = _mock_rendezvous
-        with self.assertRaises(TimeoutError):
+        with self.assertRaises(RdzvTimeoutError):
             agent._initialize_workers(agent._worker_group)
             agent._save_ckpt_future
 
@@ -770,7 +771,7 @@ class ElasticTrainingAgentRunTest(unittest.TestCase):
             try:
                 agent._stop_workers(None, is_restart=False, timeout=3)
                 self.fail()
-            except TimeoutError:
+            except RdzvTimeoutError:
                 self.assertTrue(True)
 
     def test_diagnosis(self):
@@ -1032,7 +1033,7 @@ class MasterRendezvousHandlerTest(unittest.TestCase):
         rdzv_handler._client.get_comm_world = mock.MagicMock(
             return_value=(0, 0, {1: 8})
         )
-        with self.assertRaises(TimeoutError):
+        with self.assertRaises(RdzvTimeoutError):
             rdzv_handler.next_rendezvous()
 
 

--- a/dlrover/python/tests/test_elastic_training_agent.py
+++ b/dlrover/python/tests/test_elastic_training_agent.py
@@ -73,8 +73,8 @@ from dlrover.python.elastic_agent.torch.training import (
     MasterRendezvousHandler,
     NodeCheckElasticAgent,
     NodeCheckFailedError,
-    RdzvTimeoutError,
     RendezvousOutSyncError,
+    RendezvousTimeoutError,
     _create_check_agent,
     _create_worker_spec,
     _get_local_ip,
@@ -284,7 +284,7 @@ class ElasticTrainingAgentTest(unittest.TestCase):
             raise RendezvousOutSyncError("test")
 
         agent._rendezvous = _mock_rendezvous
-        with self.assertRaises(RdzvTimeoutError):
+        with self.assertRaises(RendezvousTimeoutError):
             agent._initialize_workers(agent._worker_group)
             agent._save_ckpt_future
 
@@ -771,7 +771,7 @@ class ElasticTrainingAgentRunTest(unittest.TestCase):
             try:
                 agent._stop_workers(None, is_restart=False, timeout=3)
                 self.fail()
-            except RdzvTimeoutError:
+            except RendezvousTimeoutError:
                 self.assertTrue(True)
 
     def test_diagnosis(self):
@@ -1033,7 +1033,7 @@ class MasterRendezvousHandlerTest(unittest.TestCase):
         rdzv_handler._client.get_comm_world = mock.MagicMock(
             return_value=(0, 0, {1: 8})
         )
-        with self.assertRaises(RdzvTimeoutError):
+        with self.assertRaises(RendezvousTimeoutError):
             rdzv_handler.next_rendezvous()
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

We add an exception handler in _initialize_workers and when TimeoutError raised, it will retry util max_errors reached.
But during pending or rendezvous timeout, it is better to raise it out instead of retrying, to failover fastly

### Why are the changes needed?

To let pending timeout and rendezvous timeout to fail-fast, instead of retry many times

### Does this PR introduce any user-facing change?

No

### How was this patch tested?

UT