### PR TITLE
disable async exporter and error hook

### DIFF
--- a/dlrover/python/training_event/config.py
+++ b/dlrover/python/training_event/config.py
@@ -99,11 +99,11 @@ def is_dlrover_event_enabled():
 class Config(Singleton):
 
     event_exporter: str = DEFAULT_EVENT_EXPORTER
-    async_exporter: bool = True
+    async_exporter: bool = False  # Be careful, Don't use async exporter
     queue_size: int = 1024
     file_dir: str = DEFAULT_FILE_DIR
     text_formatter: str = DEFAULT_TEXT_FORMATTER
-    hook_error: bool = True
+    hook_error: bool = False  # Be careful, Don't hook signal
 
     rank: str = "empty"
     pid: str = "empty"

--- a/dlrover/python/training_event/predefined/trainer.py
+++ b/dlrover/python/training_event/predefined/trainer.py
@@ -21,8 +21,8 @@ from dlrover.python.training_event.predefined.common import CommonPredefined
 class TrainerEventName(Enum):
     TRAIN_START = "#start"
     TRAIN_INIT = "#init"
-    TRAIN_LOAD_DATASET = "load_dataset"
-    TRAIN_LOAD_CKPT = "load_ckpt"
+    TRAIN_LOAD_DATASET = "#load_dataset"
+    TRAIN_LOAD_CKPT = "#load_ckpt"
     TRAIN_PERSIST_CKPT = "#persist_ckpt"
     TRAIN_FINISH = "#finish"
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

disable error hook or async exporter

### Why are the changes needed?

async exporter may get semaphore leak in process exit
error hook may issue exporter stuck or reentrant problems, so disable it

### Does this PR introduce any user-facing change?

No

### How was this patch tested?

UT