### PR TITLE
Fix insufficient judgement.

### DIFF
--- a/dlrover/python/master/node/worker.py
+++ b/dlrover/python/master/node/worker.py
@@ -510,7 +510,10 @@ class WorkerManager(TrainingNodeManager):
                 available_nodes.append(node)
 
         now = time.time()
-        if len(available_nodes) < self.get_min_nodes_required():
+        if (
+            len(available_nodes) > 0
+            and len(available_nodes) < self.get_min_nodes_required()
+        ):
             if self._last_insufficient_nodes_timestamp == 0:
                 self._last_insufficient_nodes_timestamp = int(now)
                 logger.warning(

--- a/dlrover/python/tests/test_worker_manager.py
+++ b/dlrover/python/tests/test_worker_manager.py
@@ -231,6 +231,7 @@ class WorkerManagerTest(unittest.TestCase):
         self.assertFalse(reset)
 
     def test_is_training_hang_by_pending_workers(self):
+        self.job_context.clear_job_nodes()
         _dlrover_ctx.pending_fail_strategy = 2
         worker_manager = WorkerManager(
             self._job_resource,
@@ -547,6 +548,7 @@ class WorkerManagerTest(unittest.TestCase):
         )
 
     def test_is_training_hang_by_insufficient_worker(self):
+        self.job_context.clear_job_nodes()
         worker_manager = WorkerManager(
             self._job_resource,
             3,
@@ -568,6 +570,23 @@ class WorkerManagerTest(unittest.TestCase):
         worker_manager._get_insufficient_timeout = mock.MagicMock(
             return_value=1
         )
+
+        # mock with 2 succeeded
+        for index in range(2):
+            mock_node = Node(
+                NodeType.WORKER,
+                index,
+                NodeResource(0, 0),
+                "test-" + str(index),
+                NodeStatus.SUCCEEDED,
+            )
+            self.job_context.update_job_node(mock_node)
+            mock_nodes[index] = mock_node
+        for _ in range(3):
+            self.assertFalse(
+                worker_manager.is_training_hang_by_insufficient_worker()
+            )
+            time.sleep(0.1)
 
         # mock with 3 running + 1 pending
         for index in range(4):


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add ```len(available_nodes) > 0``` as a condition. 
Because if there are no 'available_nodes 'at the moment, it implies one of two scenarios:

1. All nodes have succeeded.
2. All nodes have failed (and exited at the same moment).

In the case of the first scenario, directly ignoring it aligns with expectations. 

For the second scenario, if the failure causes an exit, there will inevitably be fault tolerance (as long as the master hasn't exited), meaning this logical judgment process will be entered again.

### Why are the changes needed?

Bug fix.

### Does this PR introduce any user-facing change?

NO

### How was this patch tested?

UT