### PR TITLE
fix duplicate relaunch when HARDWARE ERROR happened

### DIFF
--- a/dlrover/python/master/node/event_callback.py
+++ b/dlrover/python/master/node/event_callback.py
@@ -280,7 +280,7 @@ class AllReduceNodeHandlingCallback(NodeEventCallback):
                 node.type,
                 node.id,
                 error_data=NodeExitReason.HARDWARE_ERROR,
-                level=TrainingExceptionLevel.NODE_ERROR,
+                level=TrainingExceptionLevel.ERROR,
             )
         self._remove_node_from_rdzv(node)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Should not relaunch pod in HARDWARE ERROR, leave it to process_events

### Why are the changes needed?

Pod relaunched for 2 times

### Does this PR introduce any user-facing change?

NO

### How was this patch tested?

UT