### PR TITLE
Fix: ncclKernel is displayed as cudaLaunchKernelExC

### DIFF
--- a/xpu_timer/xpu_timer/nvidia/nvidia_timer.cc
+++ b/xpu_timer/xpu_timer/nvidia/nvidia_timer.cc
@@ -423,7 +423,7 @@ std::string NcclCommWrapper::getNcclVersion() {
       ::xpu_timer::util::config::GlobalConfig::dlopen_path["NCCL"];
   std::string nccl_version_cmd =
       "strings " + nccl_lib_path +
-      R"(| grep -E "version.*cuda" | awk -F"[ +]" '{print $1 "_" $3}')";
+      R"(| grep -E "version.*cuda" | grep -v VERSION_STRING | awk -F"[ +]" '{print $1 "_" $3}')";
   bp::environment env = boost::this_process::environment();
   env.erase("LD_PRELOAD");
   bp::ipstream out_stream;


### PR DESCRIPTION
### What changes were proposed in this pull request?

I have modified the NcclCommWrapper: : getNcclVersion method to get the correct NCCL version.

### Why are the changes needed?

When I start megatron using xpu_timer_launch to run a Dense model and dump the timeline, ncclKerne is displayed as CudaLaunchKernelExC_UNKNOWN.

![image](https://github.com/user-attachments/assets/14eeee99-8966-4f4a-9c5c-93901cd107f7)

And I found that I couldn't get basic information like rank correctly from the NcclCommWrapper.  And the xpu_hook.log.0 log file shows:

xpu_timer/nvidia/nvidia_timer.cc:500 [Rank 0] Not Found Func: get_Comm_commHash in VERSION_STRING_version

![image](https://github.com/user-attachments/assets/83e7010c-aad5-439d-8be1-1aff82702481)

strings libnccl.so | grep -E "version.*cuda" | awk -F"[ +]" '{print $1 "_" $3}' got wrong nccl version, so we can not load get correct function from libparse_params.so.

add " grep -v VERSION_STRING" will fix it.

![image](https://github.com/user-attachments/assets/b93b3a94-0e80-4265-9f88-f71755dc0992)


### Does this PR introduce any user-facing change?

Users won't feel any change