### PR TITLE
fix pickle CVE of executing illegal instructions or commands

### DIFF
--- a/dlrover/python/common/comm.py
+++ b/dlrover/python/common/comm.py
@@ -11,13 +11,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import base64
-import pickle
 import socket
 from dataclasses import dataclass, field
 from typing import Dict, List
 
 import grpc
 
+import dlrover.python.util.dlrover_pickle as pickle
 from dlrover.python.common.constants import GRPC
 from dlrover.python.common.log import default_logger as logger
 from dlrover.python.common.serialize import JsonSerializable

--- a/dlrover/python/tests/test_common_util.py
+++ b/dlrover/python/tests/test_common_util.py
@@ -71,5 +71,6 @@ class CommonUtilTest(unittest.TestCase):
             dlrover_pickle.loads(pickled)
         dlrover_pickle.whitelist.append(_module)
 
+
 if __name__ == "__main__":
     unittest.main()

--- a/dlrover/python/tests/test_common_util.py
+++ b/dlrover/python/tests/test_common_util.py
@@ -66,10 +66,10 @@ class CommonUtilTest(unittest.TestCase):
 
         dlrover_pickle.loads(pickled)
 
-        dlrover_pickle.whitelist.clear()
+        _module = dlrover_pickle.whitelist.pop()
         with self.assertRaises(pickle.UnpicklingError):
             dlrover_pickle.loads(pickled)
-
+        dlrover_pickle.whitelist.append(_module)
 
 if __name__ == "__main__":
     unittest.main()

--- a/dlrover/python/tests/test_common_util.py
+++ b/dlrover/python/tests/test_common_util.py
@@ -11,10 +11,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pickle
 import socket
 import unittest
 
 import dlrover.python.util.common_util as cu
+import dlrover.python.util.dlrover_pickle as dlrover_pickle
+from dlrover.python.common.comm import KeyValuePair
 
 
 class CommonUtilTest(unittest.TestCase):
@@ -53,6 +56,19 @@ class CommonUtilTest(unittest.TestCase):
         s.bind(("", 64003))
         port = cu.find_free_port_for_hccl()
         self.assertEqual(port, 64004)
+
+    def test_dlrover_pickle(self):
+        msg = KeyValuePair("foo", "bar".encode())
+        pickled = pickle.dumps(msg)
+
+        with self.assertRaises(TypeError):
+            dlrover_pickle.loads("test message")
+
+        dlrover_pickle.loads(pickled)
+
+        dlrover_pickle.whitelist.clear()
+        with self.assertRaises(pickle.UnpicklingError):
+            dlrover_pickle.loads(pickled)
 
 
 if __name__ == "__main__":

--- a/dlrover/python/util/dlrover_pickle.py
+++ b/dlrover/python/util/dlrover_pickle.py
@@ -1,0 +1,36 @@
+# Copyright 2025 The DLRover Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import io
+import pickle
+
+whitelist = ["dlrover.python.common.comm"]
+
+
+class RestrictedUnpickler(pickle.Unpickler):
+    def find_class(self, module, name):
+        if module not in whitelist:
+            raise pickle.UnpicklingError(
+                f"Unpickle illegal module: {module} or class: {name}"
+            )
+
+        return pickle.Unpickler.find_class(self, module, name)
+
+
+def loads(s):
+    if isinstance(s, str):
+        raise TypeError("Can't load pickle from unicode string")
+    return RestrictedUnpickler(io.BytesIO(s)).load()
+
+
+dumps = pickle.dumps


### PR DESCRIPTION
### What changes were proposed in this pull request?

use dlrover_pickle to replace pickle to secure illegal unpickling

### Why are the changes needed?

pickle is unsecure as we known for a long time. since dlrover also uses pickle to deserialize messages, we need to restrict the module that can be unpickled

### Does this PR introduce any user-facing change?

No

### How was this patch tested?

UT