### PR TITLE
Optimize task-manager when master exit.

### DIFF
--- a/dlrover/python/master/dist_master.py
+++ b/dlrover/python/master/dist_master.py
@@ -311,7 +311,9 @@ class DistributedJobMaster(JobMaster):
                         self._exit_code = 1
                         self._exit_reason = JobExitReason.UNKNOWN_ERROR
                     elif (
-                        self.task_manager and not self.task_manager.finished()
+                        self.task_manager
+                        and not self.task_manager.finished()
+                        and not self.task_manager.is_dataset_initialized()
                     ):
                         logger.warning(
                             "All workers exited but there also are "

--- a/dlrover/python/master/shard/task_manager.py
+++ b/dlrover/python/master/shard/task_manager.py
@@ -158,7 +158,8 @@ class TaskManager(object):
     def finished(self):
         """Return if all tasks are done"""
         if not self._datasets:
-            return False
+            logger.info("No datasets have been initialized.")
+            return True
 
         # Place the values into a list to avoid the error
         # OrderedDict mutated during iteration.

--- a/dlrover/python/master/shard/task_manager.py
+++ b/dlrover/python/master/shard/task_manager.py
@@ -155,11 +155,16 @@ class TaskManager(object):
             return all(dataset_hang)
         return False
 
-    def finished(self):
-        """Return if all tasks are done"""
+    def is_dataset_initialized(self):
         if not self._datasets:
             logger.info("No datasets have been initialized.")
-            return True
+            return False
+        return True
+
+    def finished(self):
+        """Return if all tasks are done"""
+        if not self.is_dataset_initialized():
+            return False
 
         # Place the values into a list to avoid the error
         # OrderedDict mutated during iteration.

--- a/dlrover/python/tests/test_task_manager.py
+++ b/dlrover/python/tests/test_task_manager.py
@@ -28,6 +28,7 @@ class TaskMangerTest(unittest.TestCase):
     def test_dispatch_task(self):
         dataset_name = "test"
         task_manager = create_task_manager()
+        self.assertTrue(task_manager.is_dataset_initialized())
         self.assertEqual(len(task_manager._datasets), 1)
         task = task_manager.get_dataset_task(NodeType.WORKER, 0, dataset_name)
         self.assertEqual(task.task_id, 0)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Return true when dataset is empty when invoke 'finished'.

### Why are the changes needed?

To avoid task-manager's warning(has unfinished task) when task-manager is not used.

### Does this PR introduce any user-facing change?

NO

### How was this patch tested?

UT