### PR TITLE
Fix job manager endlessly waiting when pod reported SUCCEEDED_EXITED but DELETED when terminating timeout

### DIFF
--- a/dlrover/python/common/metric/monitor.py
+++ b/dlrover/python/common/metric/monitor.py
@@ -308,6 +308,9 @@ class SimpleMetricMonitor(MetricMonitor):
                     ):
                         raise Exception("collect_job_metrics return None")
                 _metric_context.add_node_metrics(tm, job_metrics)
+                logger.debug(
+                    f"Add job metrics at timestamp {tm}: {job_metrics}"
+                )
                 time.sleep(interval)
 
             except Exception as e:

--- a/dlrover/python/common/node.py
+++ b/dlrover/python/common/node.py
@@ -354,6 +354,9 @@ class Node(object):
         now = int(datetime.now().timestamp())
         self.reported_status = (status, now)
 
+    def get_reported_status(self):
+        return self.reported_status[0]
+
     def is_exited_reported(self):
         return (
             self.reported_status[0] == NodeEventType.SUCCEEDED_EXITED

--- a/dlrover/python/master/dist_master.py
+++ b/dlrover/python/master/dist_master.py
@@ -292,6 +292,9 @@ class DistributedJobMaster(JobMaster):
         try:
             while True:
                 if self._job_ctx.is_request_stopped():
+                    logger.info(
+                        f"Job is stopped: {self._job_ctx.get_job_stage()}"
+                    )
                     break
                 should_stop, reason, msg = self.job_manager.should_early_stop()
                 if should_stop:

--- a/dlrover/python/master/node/training_node.py
+++ b/dlrover/python/master/node/training_node.py
@@ -345,6 +345,7 @@ class TrainingNodeManager(object):
     def all_nodes_exited(self):
         nodes = self._job_context.job_nodes_by_type(self._node_type)
         if len(nodes) == 0:
+            logger.debug(f"All {self._node_type} nodes exited")
             return True
         counter = self._get_node_counter()
 
@@ -378,6 +379,11 @@ class TrainingNodeManager(object):
                     ]:
                         pending_high_workers.append(worker_id)
 
+            logger.debug(
+                f"Check all {self._node_type} nodes exited: "
+                f"{running_workers} {pending_high_workers} "
+                f"{pending_low_workers} {high_worker_num}"
+            )
             if (
                 running_workers
                 or pending_high_workers

--- a/dlrover/python/master/node/worker.py
+++ b/dlrover/python/master/node/worker.py
@@ -280,7 +280,12 @@ class WorkerManager(TrainingNodeManager):
         return plan
 
     def has_exited_worker(self):
-        """Check whether there is exited worker except evicted workers."""
+        """Check whether there is exited worker except evicted workers.
+
+        If the worker has reported SUCCEEDED_EXITED, but been deleted
+        by dlrover finally, the status will be DELETED instead of SUCCEEDED
+        In such cases the worker should also be regard as exited worker
+        """
         nodes = self._get_nodes()
         for worker in nodes.values():
             if (
@@ -288,7 +293,7 @@ class WorkerManager(TrainingNodeManager):
                 or worker.status == NodeStatus.SUCCEEDED
                 or (
                     worker.status == NodeStatus.DELETED
-                    and worker.reported_status[0]
+                    and worker.get_reported_status()
                     == NodeEventType.SUCCEEDED_EXITED
                 )
             ):

--- a/dlrover/python/master/node/worker.py
+++ b/dlrover/python/master/node/worker.py
@@ -286,6 +286,10 @@ class WorkerManager(TrainingNodeManager):
                 worker.exit_reason == NodeExitReason.FATAL_ERROR
                 or worker.status == NodeStatus.SUCCEEDED
             ):
+                logger.debug(
+                    f"Worker {worker} has exited: "
+                    f"{worker.exit_reason} {worker.status}"
+                )
                 return True
         return False
 
@@ -297,6 +301,7 @@ class WorkerManager(TrainingNodeManager):
                 worker.exit_reason == NodeExitReason.KILLED
                 and worker.relaunch_count < worker.max_relaunch_count
             ):
+                logger.debug(f"Worker {worker} is restarting")
                 return True
         return False
 

--- a/dlrover/python/master/node/worker.py
+++ b/dlrover/python/master/node/worker.py
@@ -18,6 +18,7 @@ from typing import Dict, List, Tuple
 from dlrover.python.common.constants import (
     DistributionStrategy,
     JobConstant,
+    NodeEventType,
     NodeExitReason,
     NodeStatus,
     NodeType,
@@ -285,6 +286,11 @@ class WorkerManager(TrainingNodeManager):
             if (
                 worker.exit_reason == NodeExitReason.FATAL_ERROR
                 or worker.status == NodeStatus.SUCCEEDED
+                or (
+                    worker.status == NodeStatus.DELETED
+                    and worker.reported_status[0]
+                    == NodeEventType.SUCCEEDED_EXITED
+                )
             ):
                 logger.debug(
                     f"Worker {worker} has exited: "

--- a/dlrover/python/master/servicer.py
+++ b/dlrover/python/master/servicer.py
@@ -329,7 +329,7 @@ class MasterServicer(ABC):
         """
         waiting_num = self._rdzv_managers[rdzv_name].num_nodes_waiting()
         if job_ctx.get_job_stage() == JobStage.JOB_STOPPING:
-            logger.info(
+            logger.debug(
                 f"Job is stopping, set waiting_num {waiting_num} to -1"
             )
             waiting_num = -1

--- a/dlrover/python/tests/test_node.py
+++ b/dlrover/python/tests/test_node.py
@@ -69,6 +69,9 @@ class NodeTest(unittest.TestCase):
         node.update_reported_status(NodeEventType.SUCCEEDED_EXITED)
         self.assertTrue(node.is_succeeded_and_exited())
         self.assertTrue(node.is_exited_reported())
+        self.assertEqual(
+            node.get_reported_status(), NodeEventType.SUCCEEDED_EXITED
+        )
 
         node.update_reported_status(NodeEventType.NODE_CHECK_FAILED)
         self.assertTrue(node.is_succeeded_and_exited())

--- a/dlrover/python/tests/test_worker_manager.py
+++ b/dlrover/python/tests/test_worker_manager.py
@@ -18,6 +18,7 @@ from unittest import mock
 
 from dlrover.python.common.constants import (
     DistributionStrategy,
+    NodeEventType,
     NodeExitReason,
     NodeStatus,
     NodeType,
@@ -196,6 +197,13 @@ class WorkerManagerTest(unittest.TestCase):
         self.job_context.update_job_node(
             self.job_context.get_mutable_worker_nodes()[0]
         )
+        exited = worker_manager.has_exited_worker()
+        self.assertTrue(exited)
+
+        worker = self.job_context.get_mutable_worker_nodes()[0]
+        worker.status = NodeStatus.DELETED
+        worker.reported_status = (NodeEventType.SUCCEEDED_EXITED, 0)
+        self.job_context.update_job_node(worker)
         exited = worker_manager.has_exited_worker()
         self.assertTrue(exited)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

If pod has reported SUCCEEDED_EXITED, but didn't terminated successfully, We need to tag it as Succeeded after all.

### Why are the changes needed?
If worker finished but pod didn't exit after 10min, e.g. stuck in TerminatingPOD, some postmordem work hang etc., dlrover will DELETE the pod. So if the pod has reported SUCCEEDED_EXITED, the status is DELETED, and relaunch_count may be 0 because dlrover will not relaunch any pod in JOB_STOPPING stage. Meanwhile, although SUCCEEDED_EXITED reported, the pod staus is not "Succeeded" but "Deleted", so that job_manager will return True in pend_without_workers() and continue to wait endlessly

### Does this PR introduce any user-facing change?
NO

### How was this patch tested?
UT and BVT