### PR TITLE
adjust step hang default to 5 min

### DIFF
--- a/dlrover/python/common/event/context.py
+++ b/dlrover/python/common/event/context.py
@@ -244,6 +244,11 @@ class JobEventContext(Singleton):
         else:
             self.hang_threshold = 10 * avg_step_time
 
+            if self.hang_threshold > DefaultValues.HANG_DOWNTIME * 60:
+                self.hang_threshold = DefaultValues.HANG_DOWNTIME * 60
+            elif self.hang_threshold < DefaultValues.MIN_HANG_DOWNTIME * 60:
+                self.hang_threshold = DefaultValues.MIN_HANG_DOWNTIME * 60
+
         now = int(datetime.now().timestamp())
 
         # check if step is still active

--- a/dlrover/python/diagnosis/datacollector/atorch_event_collector.py
+++ b/dlrover/python/diagnosis/datacollector/atorch_event_collector.py
@@ -129,7 +129,6 @@ class AtorchEventCollector(Singleton):
 
                 line = f.readline()
                 if not line:
-                    logger.debug(f"Empty readline on {filepath}")
                     time.sleep(1)
                     continue
 

--- a/dlrover/python/master/args.py
+++ b/dlrover/python/master/args.py
@@ -193,7 +193,7 @@ def _build_master_args_parser():
     )
     parser.add_argument(
         "--hang_downtime",
-        default=30,
+        default=5,
         type=pos_int,
         help="Training downtime to detect job hang, unit is minute",
     )

--- a/dlrover/python/master/diagnosis/diagnosis_master.py
+++ b/dlrover/python/master/diagnosis/diagnosis_master.py
@@ -418,6 +418,7 @@ class DiagnosisMaster(DiagnosisManager):
 
             result, start, end = self.check_tensor_drop_zero(hang_downtime)
             step_hang = _event_context.check_job_step_hang()
+
             if result is DiagnosisResult.DIAG_HANG:
                 start_dt = datetime.fromtimestamp(start).strftime(
                     "%Y-%m-%d %H:%M:%S"
@@ -427,7 +428,7 @@ class DiagnosisMaster(DiagnosisManager):
                 )
                 logger.warning(
                     f"Detect job hang by tensor drop zero: "
-                    f"{start_dt}-{end_dt}"
+                    f"{start_dt}-{end_dt}, step hang is {step_hang}"
                 )
 
                 if _dlrover_context.hang_detection == 2:

--- a/dlrover/python/tests/test_training_events.py
+++ b/dlrover/python/tests/test_training_events.py
@@ -575,6 +575,30 @@ class TrainingEventTest(unittest.TestCase):
         _event_context.train_steps.clear_step_events()
         self.assertEqual(_event_context.check_job_step_hang(), False)
 
+        with patch(
+            "dlrover.python.common.event.context."
+            "StepEvents.last_steps_avg_time"
+        ) as mock_method:
+            mock_method.return_value = 20
+            self.assertEqual(_event_context.check_job_step_hang(), False)
+            self.assertEqual(_event_context.hang_threshold, 200)
+
+        with patch(
+            "dlrover.python.common.event.context."
+            "StepEvents.last_steps_avg_time"
+        ) as mock_method:
+            mock_method.return_value = 500
+            self.assertEqual(_event_context.check_job_step_hang(), False)
+            self.assertEqual(_event_context.hang_threshold, 600)
+
+        with patch(
+            "dlrover.python.common.event.context."
+            "StepEvents.last_steps_avg_time"
+        ) as mock_method:
+            mock_method.return_value = 10
+            self.assertEqual(_event_context.check_job_step_hang(), False)
+            self.assertEqual(_event_context.hang_threshold, 120)
+
         now = int(datetime.now().timestamp())
         evt1 = AtorchEvent(
             timestamp=now,


### PR DESCRIPTION
### What changes were proposed in this pull request?

Adjust default hang_timeout to 5min. And restrict hand_threshold between [MIN_HANG_DOWNTIME, HANG_DONWTIME]

### Why are the changes needed?

5min is more appropriate than 10min

### Does this PR introduce any user-facing change?

No

### How was this patch tested?

UT