### PR TITLE
Fix spelling error for app.kubernetes.io/name

### DIFF
--- a/go/elasticjob/pkg/common/resource.go
+++ b/go/elasticjob/pkg/common/resource.go
@@ -32,7 +32,7 @@ import (
 
 const (
 	// LabelAppNameKey is the key of application name in the cluster.
-	LabelAppNameKey = "app.kubernets.io/name"
+	LabelAppNameKey = "app.kubernetes.io/name"
 	// ElasticJobAppName is the application name of dlrover elasticjob.
 	ElasticJobAppName = "elasticjob"
 	// LabelJobNameKey is the label key of the elasticjob name.


### PR DESCRIPTION
Fix the spelling error. Recommended Labels is app.kubernetes.io/name.