### PR TITLE
Disable relaunch if node already relaunched.

### DIFF
--- a/dlrover/python/common/constants.py
+++ b/dlrover/python/common/constants.py
@@ -160,6 +160,7 @@ class NodeExitReason(object):
     HARDWARE_ERROR = "HardwareError"
     NO_HEARTBEAT = "NoHeartBeat"
     DIAG_FAIL = "DiagnosticFailure"
+    RELAUNCHED = "Relaunched"
 
 
 class NodeExitDescription(object):

--- a/dlrover/python/master/node/dist_job_manager.py
+++ b/dlrover/python/master/node/dist_job_manager.py
@@ -915,7 +915,10 @@ class DistributedJobManager(JobManager):
                 and not _dlrover_context.relaunch_always
             ):
                 should_relaunch = False
-                msg = "Disable relaunch"
+                msg = "Disable relaunch due to fatal error"
+            elif node.exit_reason == NodeExitReason.RELAUNCHED:
+                should_relaunch = False
+                msg = "Disable relaunch due to already relaunched"
             elif node.exit_reason == NodeExitReason.OOM:
                 mem = node.config_resource.memory
                 if self.is_all_reduce_type_job():
@@ -958,9 +961,7 @@ class DistributedJobManager(JobManager):
                         f"{node.relaunch_count} "
                         f"exhausted {node.max_relaunch_count}"
                     )
-            elif node.exit_reason == NodeExitReason.RELAUNCHED:
-                logger.info(f"Node {node.name} has already relaunched.")
-                should_relaunch = False
+
         if should_relaunch:
             node.relaunch_count += 1
 

--- a/dlrover/python/tests/test_job_manager.py
+++ b/dlrover/python/tests/test_job_manager.py
@@ -343,6 +343,9 @@ class DistributedJobManagerTest(unittest.TestCase):
         node.exit_reason = NodeExitReason.OOM
         self.assertFalse(manager._should_relaunch(node, NODE_STATE_FLOWS[6]))
 
+        node.exit_reason = NodeExitReason.RELAUNCHED
+        self.assertFalse(manager._should_relaunch(node, NODE_STATE_FLOWS[6]))
+
     def test_relaunch_under_deleted_event(self):
         params = MockK8sPSJobArgs()
         params.initilize()


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add a new exit reason 'relaunched' to tag the node who already relauched.

### Why are the changes needed?

Ad title described.

### Does this PR introduce any user-facing change?

NO

### How was this patch tested?

UT and Training with case: 1) node failover 2) than master failover