### PR TITLE
Fix all node-check-failed with workers relaunching.

### DIFF
--- a/dlrover/python/master/node/dist_job_manager.py
+++ b/dlrover/python/master/node/dist_job_manager.py
@@ -262,7 +262,9 @@ class DistributedJobManager(JobManager):
         # node-check all failed
         if (
             self.is_all_reduce_type_job()
-            and self._worker_manager.is_all_workers_node_check_failed()
+            and self._worker_manager.is_all_initial_workers_node_check_failed(
+                self.get_worker_num()
+            )
         ):
             msg = (
                 "Stop the training early because all worker nodes has "

--- a/dlrover/python/master/node/worker.py
+++ b/dlrover/python/master/node/worker.py
@@ -579,3 +579,12 @@ class WorkerManager(TrainingNodeManager):
     def is_all_workers_node_check_failed(self):
         nodes = self._get_nodes()
         return all([node.is_node_check_failed() for _, node in nodes.items()])
+
+    def is_all_initial_workers_node_check_failed(self, workers: int):
+        """Check all initial workers are check-failed (exclude new created workers)"""
+        nodes = [
+            node for _, node in self._get_nodes().items() if node.id < workers
+        ]
+        return len(nodes) > 0 and all(
+            [node.is_node_check_failed() for node in nodes]
+        )


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add one function `is_all_initial_workers_node_check_failed` and use it for node-check-all-failed

### Why are the changes needed?
`is_all_workers_node_check_failed` doesn't work when there are workers relaunching.

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
Tested through unittest and reproducing experiment.