### PR TITLE
New trainer entry(for internal using).

### DIFF
--- a/dlrover/trainer/tests/torch/elastic_run_test.py
+++ b/dlrover/trainer/tests/torch/elastic_run_test.py
@@ -19,6 +19,7 @@ from argparse import Namespace
 from unittest import mock
 from unittest.mock import ANY, MagicMock, patch
 
+import dlrover
 from dlrover.python.common import env_utils
 from dlrover.python.common.constants import (
     JobConstant,
@@ -358,3 +359,66 @@ class ElasticRunTest(unittest.TestCase):
 
                 if case["name"] == "standalone_with_dlrover":
                     master_handler.close.assert_called_once()
+
+
+class TestMainFunction(unittest.TestCase):
+    def setUp(self):
+        self.patchers = []
+
+    def tearDown(self):
+        for patcher in self.patchers:
+            patcher.stop()
+
+    def test_main_with_dlrover_master(self):
+        env_patcher = patch(
+            "dlrover.trainer.torch.compatible_main.env_utils.get_env",
+            return_value="127.0.0.1:12345",
+        )
+        self.patchers.append(env_patcher)
+        mock_get_env = env_patcher.start()
+
+        dlrover_patcher = patch(
+            "dlrover.trainer.torch.compatible_main.dlrover_main",
+            return_value=None,
+        )
+        self.patchers.append(dlrover_patcher)
+        mock_dlrover_main = dlrover_patcher.start()
+        torch_patcher = patch(
+            "dlrover.trainer.torch.compatible_main.torch_main",
+            return_value=None,
+        )
+        self.patchers.append(torch_patcher)
+        mock_torch_main = torch_patcher.start()
+
+        dlrover.trainer.torch.compatible_main.main()
+
+        mock_get_env.assert_called_once_with(NodeEnv.DLROVER_MASTER_ADDR)
+        mock_dlrover_main.assert_called_once()
+        mock_torch_main.assert_not_called()
+
+    def test_main_without_dlrover_master(self):
+        env_patcher = patch(
+            "dlrover.trainer.torch.compatible_main.env_utils.get_env",
+            return_value=None,
+        )
+        self.patchers.append(env_patcher)
+        mock_get_env = env_patcher.start()
+
+        dlrover_patcher = patch(
+            "dlrover.trainer.torch.compatible_main.dlrover_main",
+            return_value=None,
+        )
+        self.patchers.append(dlrover_patcher)
+        mock_dlrover_main = dlrover_patcher.start()
+        torch_patcher = patch(
+            "dlrover.trainer.torch.compatible_main.torch_main",
+            return_value=None,
+        )
+        self.patchers.append(torch_patcher)
+        mock_torch_main = torch_patcher.start()
+
+        dlrover.trainer.torch.compatible_main.main()
+
+        mock_get_env.assert_called_once_with(NodeEnv.DLROVER_MASTER_ADDR)
+        mock_dlrover_main.assert_not_called()
+        mock_torch_main.assert_called_once()

--- a/dlrover/trainer/torch/compatible_main.py
+++ b/dlrover/trainer/torch/compatible_main.py
@@ -1,0 +1,37 @@
+# Copyright 2025 The DLRover Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from dlrover.python.common import env_utils
+from dlrover.trainer.torch.elastic_run import main as dlrover_main
+from torch.distributed.run import main as torch_main
+
+from dlrover.python.common.log import default_logger as logger
+from dlrover.python.common.constants import NodeEnv
+
+
+if __name__ == "__main__":
+    """
+    This entry point is mainly designed for adapting to special scenarios, 
+    enforcing the use of `dlrover-run`. 
+    
+    If the dlrover master exists, the `dlrover-run` command is executed 
+    directly; otherwise, the use of `torchrun` is allowed for execution.  
+    """
+
+    if env_utils.get_env(NodeEnv.DLROVER_MASTER_ADDR):
+        logger.warning("DLRover master exists but using torchrun command. "
+                       "Replace with dlrover-run directly.")
+        dlrover_main()
+    else:
+        logger.info(
+            "DLRover master not exist so using torchrun command directly.")
+        torch_main()

--- a/dlrover/trainer/torch/compatible_main.py
+++ b/dlrover/trainer/torch/compatible_main.py
@@ -10,28 +10,35 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from dlrover.python.common import env_utils
-from dlrover.trainer.torch.elastic_run import main as dlrover_main
 from torch.distributed.run import main as torch_main
 
-from dlrover.python.common.log import default_logger as logger
+from dlrover.python.common import env_utils
 from dlrover.python.common.constants import NodeEnv
+from dlrover.python.common.log import default_logger as logger
+from dlrover.trainer.torch.elastic_run import main as dlrover_main
 
 
-if __name__ == "__main__":
+def main():
     """
-    This entry point is mainly designed for adapting to special scenarios, 
-    enforcing the use of `dlrover-run`. 
-    
-    If the dlrover master exists, the `dlrover-run` command is executed 
-    directly; otherwise, the use of `torchrun` is allowed for execution.  
+    This entry point is mainly designed for adapting to special scenarios,
+    enforcing the use of `dlrover-run`.
+
+    If the dlrover master exists, the `dlrover-run` command is executed
+    directly; otherwise, the use of `torchrun` is allowed for execution.
     """
 
     if env_utils.get_env(NodeEnv.DLROVER_MASTER_ADDR):
-        logger.warning("DLRover master exists but using torchrun command. "
-                       "Replace with dlrover-run directly.")
+        logger.warning(
+            "DLRover master exists but using torchrun command. "
+            "Replace with dlrover-run directly."
+        )
         dlrover_main()
     else:
         logger.info(
-            "DLRover master not exist so using torchrun command directly.")
+            "DLRover master not exist so using torchrun command directly."
+        )
         torch_main()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add new entry function to route 'torchrun' or 'dlrover-run'.

### Why are the changes needed?

Force to use dlrover-run for internal scenarios.

### Does this PR introduce any user-facing change?

no

### How was this patch tested?

DLRover job with torchun command(with setup.py modified).