### PR TITLE
Resolve testing deprecation warnings

### DIFF
--- a/dlrover/python/unified/tests/master/elastic/test_job_manager.py
+++ b/dlrover/python/unified/tests/master/elastic/test_job_manager.py
@@ -108,7 +108,7 @@ class ElasticJobManagerTest(ElasticBaseTest):
 
         node0.config_resource.cpu = 10
         job_manager.update_node_resource_usage(NodeType.WORKER, 0, 0.1, 128)
-        self.assertNotEquals(node0.start_hang_time, 0)
+        self.assertNotEqual(node0.start_hang_time, 0)
 
         job_manager.update_node_resource_usage(NodeType.WORKER, 0, 5, 128)
         self.assertEqual(node0.start_hang_time, 0)


### PR DESCRIPTION
### What changes were proposed in this pull request?
This really small PR resolves the deprecation warnings of `unittest` which you can find in the [CI logs](https://github.com/intelligent-machine-learning/dlrover/actions/runs/15919940628/job/44904425497):
```python
/github/workspace/dlrover/python/unified/tests/master/elastic/test_job_manager.py:111: DeprecationWarning: Please use assertNotEqual instead.
```

### Why are the changes needed?
To fix `unittest` deprecation warnings and keep the test suite compatible with future Python versions.

### Does this PR introduce any user-facing change?
No, it only affects internal tests; there are no changes visible to users.

### How was this patch tested?
The existing test suite was re-run, and all tests passed without triggering deprecation warnings.

