### PR TITLE
Disable cpu hang detection when using gpu.

### DIFF
--- a/dlrover/python/master/node/dist_job_manager.py
+++ b/dlrover/python/master/node/dist_job_manager.py
@@ -1134,16 +1134,20 @@ class DistributedJobManager(JobManager):
             return
         node.update_resource_usage(cpu, memory, gpu_stats)
         if node.config_resource.cpu:
-            cpu_percent = node.used_resource.cpu / node.config_resource.cpu
-            if cpu_percent < _dlrover_context.hang_cpu_usage_percentage:
-                if node.start_hang_time == 0:
-                    now = datetime.now()
-                    node.start_hang_time = now.timestamp()
+            if node.config_resource.gpu_num:
+                # skip cpu hang for gpu case for now
+                logger.debug("CPU hang calculation is skipped when gpu > 0.")
             else:
-                if node.start_hang_time > 0:
-                    now = datetime.now()
-                node.start_hang_time = 0
-            self._job_context.update_job_node(node)
+                cpu_percent = node.used_resource.cpu / node.config_resource.cpu
+                if cpu_percent < _dlrover_context.hang_cpu_usage_percentage:
+                    if node.start_hang_time == 0:
+                        now = datetime.now()
+                        node.start_hang_time = now.timestamp()
+                else:
+                    if node.start_hang_time > 0:
+                        now = datetime.now()
+                    node.start_hang_time = 0
+                self._job_context.update_job_node(node)
         else:
             logger.warning(
                 "CPU requests not configure "

--- a/dlrover/python/tests/test_job_manager.py
+++ b/dlrover/python/tests/test_job_manager.py
@@ -750,6 +750,21 @@ class DistributedJobManagerTest(unittest.TestCase):
         hang = manager.all_running_node_hanged()
         self.assertFalse(hang)
 
+        # test when gpu > 0
+        for _, nodes in job_nodes.items():
+            for _, node in nodes.items():
+                node.start_hang_time = 0
+                node.status = NodeStatus.RUNNING
+                node.hang = False
+                node.config_resource.gpu_num = 1
+                self.job_context.update_job_node(node)
+        manager.update_node_resource_usage(NodeType.WORKER, 0, 0.01, 256)
+        hang = manager.all_running_node_hanged()
+        self.assertFalse(hang)
+        for _, nodes in job_nodes.items():
+            for _, node in nodes.items():
+                self.assertFalse(node.start_hang_time)
+
     def test_no_cpu_request_node_hang(self):
         params = MockK8sJobWithoutCPURequestArgs()
         params.initilize()
@@ -763,6 +778,7 @@ class DistributedJobManagerTest(unittest.TestCase):
         manager.update_node_resource_usage(NodeType.WORKER, 0, 0.01, 256)
         hang = manager.all_running_node_hanged()
         self.assertFalse(hang)
+
         manager.update_node_resource_usage(NodeType.WORKER, 0, 0.5, 256)
         hang = manager.all_running_node_hanged()
         self.assertFalse(hang)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Skip hang value updating if gpu > 0.

### Why are the changes needed?

The implementation for determining current CPU usage is not rigorous under GPU scenarios. Temporarily disabled. 

### Does this PR introduce any user-facing change?

NO

### How was this patch tested?

UT