### PR TITLE
Support relaunch with node group

### DIFF
--- a/dlrover/python/common/constants.py
+++ b/dlrover/python/common/constants.py
@@ -72,9 +72,11 @@ class ElasticJobLabel(object):
 
 
 class SchedulingLabel(object):
-    NODE_GROUP = "scheduling/rack-group"  # int
-    NODE_GROUP_SIZE = "scheduling/rack-group-size"  # int
-    NODE_GROUP_ID = "scheduling/rack-id"  # str
+    NODE_GROUP = "scheduling/rack-group"  # int, the node group index
+    NODE_GROUP_SIZE = (
+        "scheduling/rack-group-num"  # int, the total node group numbers
+    )
+    NODE_GROUP_ID = "scheduling/rack-id"  # str, node group name
 
 
 class ScalePlanLabel(object):

--- a/dlrover/python/master/node/dist_job_manager.py
+++ b/dlrover/python/master/node/dist_job_manager.py
@@ -621,6 +621,16 @@ class DistributedJobManager(JobManager):
                     new_node = copy.deepcopy(node)
                     self._job_context.update_job_node(new_node)
 
+                # update node group info if necessary
+                if (
+                    node_type == NodeType.WORKER
+                    and node_id in job_nodes[node_type]
+                    and job_nodes[node_type][node_id].group != node.group
+                ):
+                    job_nodes[node_type][node_id].group = node.group
+                    job_nodes[node_type][node_id].group_size = node.group_size
+                    job_nodes[node_type][node_id].group_id = node.group_id
+
                 if node.status == NodeStatus.DELETED:
                     event_type = NodeEventType.DELETED
                 else:

--- a/dlrover/python/master/scaler/pod_scaler.py
+++ b/dlrover/python/master/scaler/pod_scaler.py
@@ -28,6 +28,7 @@ from kubernetes.client import V1EnvVar, V1EnvVarSource, V1ObjectFieldSelector
 from dlrover.python.common.constants import (
     DistributionStrategy,
     ElasticJobLabel,
+    SchedulingLabel,
     EventReportConstants,
     NodeEnv,
     NodeStatus,
@@ -584,6 +585,12 @@ class PodScaler(Scaler):
             labels=labels,
         )
         pod_meta: client.V1ObjectMeta = pod.metadata
+
+        logger.debug(
+            f"Add pod {pod_name} info into meta: {node.type} "
+            f"{node.id} {node.rank_index} {node.relaunch_count} "
+            f"{node.group} {node.group_size}"
+        )
         # Add replica type and index
         pod_meta.labels[ElasticJobLabel.REPLICA_TYPE_KEY] = node.type
         pod_meta.labels[ElasticJobLabel.REPLICA_INDEX_KEY] = str(node.id)
@@ -591,6 +598,8 @@ class PodScaler(Scaler):
         pod_meta.labels[ElasticJobLabel.RELAUNCH_COUNT] = str(
             node.relaunch_count
         )
+        if node.group is not None:
+            pod_meta.labels[SchedulingLabel.NODE_GROUP] = str(node.group)
         pod.spec.containers[0].env.append(
             V1EnvVar(name=NodeEnv.MONITOR_ENABLED, value="true")
         )

--- a/dlrover/python/master/watcher/k8s_watcher.py
+++ b/dlrover/python/master/watcher/k8s_watcher.py
@@ -108,16 +108,32 @@ def _convert_pod_yaml_to_node(pod):
     node_group = None
     node_group_size = None
     node_group_id = None
+
+    logger.debug(
+        f"Convert yaml meta: {pod_name} {pod_type} with {metadata.labels}"
+    )
+
     if pod_type == NodeType.DLROVER_MASTER:
         return None
     elif pod_type == NodeType.WORKER:
         try:
-            node_group = int(metadata.labels[SchedulingLabel.NODE_GROUP])
-            node_group_size = int(
-                metadata.labels[SchedulingLabel.NODE_GROUP_SIZE]
+            if SchedulingLabel.NODE_GROUP in metadata.labels:
+                node_group = int(metadata.labels[SchedulingLabel.NODE_GROUP])
+                node_group_size = int(
+                    metadata.labels[SchedulingLabel.NODE_GROUP_SIZE]
+                )
+                node_group_id = metadata.labels[SchedulingLabel.NODE_GROUP_ID]
+                logger.debug(
+                    f"Parse {metadata.labels[SchedulingLabel.NODE_GROUP]} "
+                    f"{metadata.labels[SchedulingLabel.NODE_GROUP_SIZE]} "
+                    f"{metadata.labels[SchedulingLabel.NODE_GROUP_ID]} "
+                    f"to {node_group} {node_group_size} {node_group_id}"
+                )
+        except Exception as e:
+            logger.error(
+                f"Unexpected exception {e} on parsing {metadata} "
+                f"with {pod_name} {pod_type}"
             )
-            node_group_id = metadata.labels[SchedulingLabel.NODE_GROUP_ID]
-        except (KeyError, ValueError):
             node_group = None
             node_group_size = None
             node_group_id = None
@@ -156,6 +172,14 @@ def _convert_pod_yaml_to_node(pod):
         node_group_size=node_group_size,
         node_group_id=node_group_id,
     )
+
+    logger.debug(
+        f"convert yaml to node: {node} "
+        f"type {pod_type}, id {pod_id}, name {pod_name} "
+        f"rank {rank_id}, status {status} "
+        f"group {node_group} node_group_size {node_group_size} "
+    )
+
     node.create_time = metadata.creation_timestamp
     if NodeStatus.is_terminal_status(status):
         node.set_exit_reason(_get_pod_exit_reason(pod))

--- a/dlrover/python/tests/test_job_manager.py
+++ b/dlrover/python/tests/test_job_manager.py
@@ -543,23 +543,35 @@ class DistributedJobManagerTest(unittest.TestCase):
         self.assertListEqual(ps_ids, [0, 1, 2])
         self.assertTrue(4 in self.job_context.job_nodes()[NodeType.WORKER])
 
-        self.assertIsNone(self.job_context.job_nodes()[NodeType.WORKER][4].group)
-        self.assertIsNone(self.job_context.job_nodes()[NodeType.WORKER][4].group_size)
-        self.assertIsNone(self.job_context.job_nodes()[NodeType.WORKER][4].group_id)
+        self.assertIsNone(
+            self.job_context.job_nodes()[NodeType.WORKER][4].group
+        )
+        self.assertIsNone(
+            self.job_context.job_nodes()[NodeType.WORKER][4].group_size
+        )
+        self.assertIsNone(
+            self.job_context.job_nodes()[NodeType.WORKER][4].group_id
+        )
         new_node = Node(
-                node_type=NodeType.WORKER,
-                node_id=4,
-                status=NodeStatus.RUNNING,
-                config_resource=NodeResource(1, 4096),
-                max_relaunch_count=1,
-                node_group=1024,
-                node_group_size=1,
-                node_group_id='rack-0',
-            )
+            node_type=NodeType.WORKER,
+            node_id=4,
+            status=NodeStatus.RUNNING,
+            config_resource=NodeResource(1, 4096),
+            max_relaunch_count=1,
+            node_group=1024,
+            node_group_size=1,
+            node_group_id="rack-0",
+        )
         manager._process_list_nodes([new_node])
-        self.assertEqual(self.job_context.job_nodes()[NodeType.WORKER][4].group, 1024)
-        self.assertEqual(self.job_context.job_nodes()[NodeType.WORKER][4].group_size, 1)
-        self.assertEqual(self.job_context.job_nodes()[NodeType.WORKER][4].group_id, 'rack-0')
+        self.assertEqual(
+            self.job_context.job_nodes()[NodeType.WORKER][4].group, 1024
+        )
+        self.assertEqual(
+            self.job_context.job_nodes()[NodeType.WORKER][4].group_size, 1
+        )
+        self.assertEqual(
+            self.job_context.job_nodes()[NodeType.WORKER][4].group_id, "rack-0"
+        )
 
     @patch.object(DistributedJobManager, "_process_event")
     def test_process_list_nodes_for_empty_case(self, mock_method):

--- a/dlrover/python/tests/test_job_manager.py
+++ b/dlrover/python/tests/test_job_manager.py
@@ -543,6 +543,24 @@ class DistributedJobManagerTest(unittest.TestCase):
         self.assertListEqual(ps_ids, [0, 1, 2])
         self.assertTrue(4 in self.job_context.job_nodes()[NodeType.WORKER])
 
+        self.assertIsNone(self.job_context.job_nodes()[NodeType.WORKER][4].group)
+        self.assertIsNone(self.job_context.job_nodes()[NodeType.WORKER][4].group_size)
+        self.assertIsNone(self.job_context.job_nodes()[NodeType.WORKER][4].group_id)
+        new_node = Node(
+                node_type=NodeType.WORKER,
+                node_id=4,
+                status=NodeStatus.RUNNING,
+                config_resource=NodeResource(1, 4096),
+                max_relaunch_count=1,
+                node_group=1024,
+                node_group_size=1,
+                node_group_id='rack-0',
+            )
+        manager._process_list_nodes([new_node])
+        self.assertEqual(self.job_context.job_nodes()[NodeType.WORKER][4].group, 1024)
+        self.assertEqual(self.job_context.job_nodes()[NodeType.WORKER][4].group_size, 1)
+        self.assertEqual(self.job_context.job_nodes()[NodeType.WORKER][4].group_id, 'rack-0')
+
     @patch.object(DistributedJobManager, "_process_event")
     def test_process_list_nodes_for_empty_case(self, mock_method):
         params = MockK8sPSJobArgs()

--- a/dlrover/python/tests/test_k8s_watcher.py
+++ b/dlrover/python/tests/test_k8s_watcher.py
@@ -180,6 +180,41 @@ class PodWatcherTest(unittest.TestCase):
                         "phase": "Running",
                     },
                 },
+                {
+                    "kind": "Pod",
+                    "apiVersion": "v1",
+                    "metadata": {
+                        "name": "test-edljob-2",
+                        "labels": {
+                            ElasticJobLabel.REPLICA_TYPE_KEY: NodeType.WORKER,
+                            ElasticJobLabel.REPLICA_INDEX_KEY: "2",
+                            ElasticJobLabel.RANK_INDEX_KEY: "2",
+                            ElasticJobLabel.RELAUNCH_COUNT: "0",
+                            SchedulingLabel.NODE_GROUP: "abc",
+                            SchedulingLabel.NODE_GROUP_SIZE: "4",
+                            SchedulingLabel.NODE_GROUP_ID: "rack-5678",
+                        },
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "name": "main",
+                                "image": "dlrover-worker:latest",
+                                "resources": {
+                                    "requests": {
+                                        "cpu": "4",
+                                        "memory": "512Mi",
+                                    },
+                                    "limits": {},
+                                },
+                            }
+                        ],
+                        "nodeName": "host-2",
+                    },
+                    "status": {
+                        "phase": "Running",
+                    },
+                },
             ],
         }
 
@@ -272,6 +307,16 @@ class PodWatcherTest(unittest.TestCase):
         self.assertEqual(worker1.group_id, None)
         self.assertEqual(worker1.rank_index, 1)
         self.assertEqual(worker1.status, NodeStatus.DELETED)
+
+        worker2 = _convert_pod_yaml_to_node(pod_list.items[3])
+        self.assertEqual(worker2.name, "test-edljob-2")
+        self.assertEqual(worker2.id, 2)
+        self.assertEqual(worker2.type, NodeType.WORKER)
+        self.assertEqual(worker2.group, None)
+        self.assertEqual(worker2.group_size, None)
+        self.assertEqual(worker2.group_id, None)
+        self.assertEqual(worker2.rank_index, 2)
+        self.assertEqual(worker2.status, NodeStatus.RUNNING)
 
     def test_convert_pod_event_to_node_event(self):
         event = {"object": None, "type": None}

--- a/dlrover/python/tests/test_pod_scaler.py
+++ b/dlrover/python/tests/test_pod_scaler.py
@@ -23,6 +23,7 @@ from dlrover.python.common.constants import (
     DistributionStrategy,
     NodeStatus,
     NodeType,
+    SchedulingLabel,
 )
 from dlrover.python.common.global_context import Context
 from dlrover.python.common.node import Node, NodeGroupResource, NodeResource
@@ -129,6 +130,9 @@ class PodScalerTest(unittest.TestCase):
         scaler._distribution_strategy = DistributionStrategy.PS
         resource = NodeResource(4, 8192)
         node = Node(NodeType.WORKER, 0, resource, rank_index=0)
+        node.group = 1024
+        node.group_size = 1
+        node.group_id = "rack-0"
 
         # mock field
         scaler._pod_stats = {
@@ -145,6 +149,10 @@ class PodScalerTest(unittest.TestCase):
         self.assertEqual(
             pod.metadata.name, "elasticjob-sample-edljob-worker-0"
         )
+        self.assertEqual(
+            pod.metadata.labels[SchedulingLabel.NODE_GROUP], str(node.group)
+        )
+
         main_container = pod.spec.containers[0]
         self.assertEqual(main_container.resources.limits["cpu"], 4)
         self.assertEqual(main_container.resources.limits["memory"], "8192Mi")


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. The process_node_list will update node the group information from k8s
2. The relaunch_node will update node group info into api server requests yaml

### Why are the changes needed?

During node relaunch, the pod meta should include the original node group information

### Does this PR introduce any user-facing change?

No

### How was this patch tested?

UT