### PR TITLE
rm _monitor_scale_plan_crd

### DIFF
--- a/dlrover/python/master/node/dist_job_manager.py
+++ b/dlrover/python/master/node/dist_job_manager.py
@@ -231,12 +231,6 @@ class DistributedJobManager(JobManager):
             name="node_heartbeat_monitor",
             daemon=True,
         ).start()
-        if os.getenv("KUBERNETES_SERVICE_HOST"):
-            threading.Thread(
-                target=self._monitor_scale_plan_crd,
-                name="scaleplan_monitor",
-                daemon=True,
-            ).start()
 
     def _has_running_workers(self):
         nodes = self._node_watcher.list()
@@ -579,29 +573,6 @@ class DistributedJobManager(JobManager):
                 result[node.id] = result_dict
 
         return result
-
-    def _monitor_scale_plan_crd(self):
-        """Monitor the Scaler CRD from users to adjust the job resource"""
-        logger.info("Start to monitor Scaler CRD")
-        while True:
-            try:
-                if self._stopped:
-                    logger.info("Stop monitoring Scaler CRDs.")
-                    break
-                for plan in self._scaler_watcher.watch():
-                    try:
-                        self._job_autoscaler.execute_job_optimization_plan(
-                            plan
-                        )
-                    except Exception as e:
-                        logger.warning(e)
-                        detail_trace_back = traceback.format_exc()
-                        logger.warning(detail_trace_back)
-            except Exception as e:
-                logger.warning(e)
-                detail_trace_back = traceback.format_exc()
-                logger.warning(detail_trace_back)
-                time.sleep(5)
 
     def _process_list_nodes(self, nodes: List[Node]):
         """Callback with node list by the list api of k8s."""


### PR DESCRIPTION
### What changes were proposed in this pull request?

remove _monitor_scale_plan_crd() in dist_job_manager.py

### Why are the changes needed?

the scaleplans crd has been planned for removal, but _monitor_scale_plan_crd() is still present in dist_job_manager .py, which results in the error: "scaleplans.elastic.iml.github.io is forbidden."

<img width="2101" height="135" alt="image" src="https://github.com/user-attachments/assets/55c440e7-a5ca-4761-b641-d2b3d3fbcbae" />

### Does this PR introduce any user-facing change?

No

### How was this patch tested?

training test