### PR TITLE
drop out relaunched node group_id when group failover happened

### DIFF
--- a/dlrover/python/master/node/dist_job_manager.py
+++ b/dlrover/python/master/node/dist_job_manager.py
@@ -1085,6 +1085,7 @@ class DistributedJobManager(JobManager):
             # update node.group to max_group_idx
             old_node = copy.deepcopy(node)
             old_node.group = group_idx
+            old_node.group_id = ""
             launch_nodes.append(old_node)
 
         plan = self._worker_manager.relaunch_nodes(launch_nodes, True)

--- a/dlrover/python/tests/test_job_manager.py
+++ b/dlrover/python/tests/test_job_manager.py
@@ -403,6 +403,7 @@ class DistributedJobManagerTest(unittest.TestCase):
             status=NodeStatus.RUNNING,
             node_group=0,
             node_group_size=1,
+            node_group_id="rack0",
             relaunchable=True,
             name="test-0",
         )
@@ -413,6 +414,7 @@ class DistributedJobManagerTest(unittest.TestCase):
             status=NodeStatus.PENDING,
             node_group=0,
             node_group_size=1,
+            node_group_id="rack0",
             relaunchable=True,
             name="test-1",
         )
@@ -432,17 +434,25 @@ class DistributedJobManagerTest(unittest.TestCase):
         self.assertEqual(plan.launch_nodes[0].rank_index, 0)
         self.assertEqual(plan.launch_nodes[0].group, 1001)
         self.assertEqual(plan.launch_nodes[0].group_size, 1)
+        self.assertEqual(plan.launch_nodes[0].group_id, "")
 
         self.assertEqual(plan.launch_nodes[1].id, 3)
         self.assertEqual(plan.launch_nodes[1].rank_index, 1)
         self.assertEqual(plan.launch_nodes[1].group, 1001)
         self.assertEqual(plan.launch_nodes[1].group_size, 1)
+        self.assertEqual(plan.launch_nodes[1].group_id, "")
 
         self.assertEqual(plan.remove_nodes[0].id, 0)
         self.assertEqual(plan.remove_nodes[0].rank_index, 0)
+        self.assertEqual(plan.remove_nodes[0].group, 0)
+        self.assertEqual(plan.remove_nodes[0].group_size, 1)
+        self.assertEqual(plan.remove_nodes[0].group_id, "rack0")
 
         self.assertEqual(plan.remove_nodes[1].id, 1)
         self.assertEqual(plan.remove_nodes[1].rank_index, 1)
+        self.assertEqual(plan.remove_nodes[1].group, 0)
+        self.assertEqual(plan.remove_nodes[1].group_size, 1)
+        self.assertEqual(plan.remove_nodes[1].group_id, "rack0")
 
         self.job_context.clear_job_node_groups()
         self.job_context.clear_job_nodes()


### PR DESCRIPTION
### What changes were proposed in this pull request?

We should not pass on node group id when group failover happened, since the scheduler will assign a new one

### Why are the changes needed?

Make scheduler easy to differentiate it is a node group FO, or just a node FO in the same group

### Does this PR introduce any user-facing change?

NO

### How was this patch tested?

UT