### PR TITLE
add torch 2.8 compatibility in _stop_workers

### DIFF
--- a/dlrover/python/elastic_agent/torch/training.py
+++ b/dlrover/python/elastic_agent/torch/training.py
@@ -108,6 +108,7 @@ from dlrover.python.util.time_util import timestamp_diff_in_seconds
 from dlrover.trainer.torch.utils import (
     version_less_than_230,
     version_less_than_240,
+    version_less_than_280,
 )
 
 _agent_evt = DLRoverAgentEvent().singleton_instance()
@@ -918,8 +919,10 @@ class ElasticTrainingAgent(LocalElasticAgent):
             else:
                 if version_less_than_240():
                     super()._stop_workers(worker_group)
-                else:
+                elif version_less_than_280():
                     super()._stop_workers(worker_group, is_restart)
+                else:
+                    super()._stop_workers(worker_group)
                 self._stop_orphan_workers(worker_group)
 
             signal.alarm(0)

--- a/dlrover/trainer/tests/torch/util_test.py
+++ b/dlrover/trainer/tests/torch/util_test.py
@@ -17,6 +17,7 @@ from unittest.mock import patch
 from dlrover.trainer.torch.utils import (
     version_less_than_230,
     version_less_than_240,
+    version_less_than_280,
 )
 
 
@@ -61,4 +62,14 @@ class TestTorchVersionFunctions(unittest.TestCase):
         with patch("torch.__version__", "2.4.0+cu111"):
             self.assertFalse(
                 version_less_than_240(), "Expected False for version > 2.3.1"
+            )
+
+        with patch("torch.__version__", "2.7.1"):
+            self.assertTrue(
+                version_less_than_280(), "Expected True for version <= 2.7.1"
+            )
+
+        with patch("torch.__version__", "2.9.0.dev20250724+cu126"):
+            self.assertFalse(
+                version_less_than_280(), "Expected False for version >= 2.8.0"
             )

--- a/dlrover/trainer/torch/utils.py
+++ b/dlrover/trainer/torch/utils.py
@@ -23,3 +23,8 @@ def version_less_than_230():
 def version_less_than_240():
     current_version = version.parse(torch.__version__).base_version
     return version.parse(current_version) <= version.parse("2.3.1")
+
+
+def version_less_than_280():
+    current_version = version.parse(torch.__version__).base_version
+    return version.parse(current_version) <= version.parse("2.7.1")


### PR DESCRIPTION
### What changes were proposed in this pull request?

The torch 2.8 changed _stop_workers so thath dlrover need to be compatible with it

### Why are the changes needed?

if torch >= 2.8, only call super()._stop_workers(worker_group)

### Does this PR introduce any user-facing change?

NO

### How was this patch tested?

UT