### PR TITLE
Configure the timeout and retry count between the master and worker.

### DIFF
--- a/dlrover/python/master/args.py
+++ b/dlrover/python/master/args.py
@@ -104,6 +104,12 @@ def _build_master_args_parser():
         type=pos_int,
         help="The timeout value of worker task process(For PS type job).",
     )
+    parser.add_argument(
+        "--dead_node_timeout",
+        default=600,
+        type=int,
+        help="dead node timeout in seconds",
+    )
     return parser
 
 

--- a/dlrover/python/master/main.py
+++ b/dlrover/python/master/main.py
@@ -81,6 +81,7 @@ def run(args):
     else:
         from dlrover.python.master.dist_master import DistributedJobMaster
 
+        job_args.dead_node_timeout = args.dead_node_timeout
         update_context(job_args)
         master = DistributedJobMaster(_dlrover_context.master_port, job_args)
     master.prepare()

--- a/dlrover/python/master/node/dist_job_manager.py
+++ b/dlrover/python/master/node/dist_job_manager.py
@@ -475,7 +475,7 @@ class DistributedJobManager(JobManager):
     def _monitor_node_heart_beat(self):
         with self._lock:
             try:
-                events = self._get_dead_node_event()
+                events = self._get_dead_node_event(window_interval=self._job_args.dead_node_timeout)
             except Exception as e:
                 logger.warning(e)
                 events = []

--- a/dlrover/python/scheduler/job.py
+++ b/dlrover/python/scheduler/job.py
@@ -107,6 +107,7 @@ class JobArgs(JsonSerializable):
         self.cordon_fault_node = False
         self.xpu_type: Accelerators = Accelerators.GENERIC_CPU
         self.enable_suspended = False
+        self.dead_node_timeout = 600
 
     @abstractmethod
     def initilize(self):

--- a/dlrover/trainer/torch/elastic_run.py
+++ b/dlrover/trainer/torch/elastic_run.py
@@ -214,6 +214,22 @@ def parse_args(args):
         action=check_env,
         help="Whether to test the communication performance.",
     )
+    parser.add_argument(
+        "--connect-master-timeout",
+        "--connect_master_timeout",
+        type=int,
+        action=env,
+        default=30,
+        help="Connect master timeout in seconds.",
+    )
+    parser.add_argument(
+        "--connect-master-max-retry",
+        "--connect_master_max_retry",
+        type=int,
+        action=env,
+        default=2,
+        help="Connect master max retry times.",
+    )
     return parser.parse_args(args)
 
 
@@ -402,6 +418,8 @@ def _elastic_config_from_args(
     elastic_config.rdzv_endpoint = ""
     join_timeout = elastic_config.rdzv_configs.get("join_timeout", 600)
     elastic_config.rdzv_configs["timeout"] = join_timeout
+    elastic_config.connect_master_timeout = args.connect_master_max_retry
+    elastic_config.connect_master_max_retry = args.connect_master_max_retry
     return elastic_config, cmd, cmd_args
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Configure the below parameter which is constant before.

* the timeout of worker connect to master.
* the retry time of worker connect to master.
* the timeout of the master to check the node alive.

### Why are the changes needed?

In some scenarios, these non-configurable default values ​​are set too large, resulting in, for example, a 10-minute hang time.

### Does this PR introduce any user-facing change?

Add all config have default value. 

### How was this patch tested?

Real job.