### PR TITLE
Optimize check failed rejection.

### DIFF
--- a/dlrover/python/tests/test_worker_manager.py
+++ b/dlrover/python/tests/test_worker_manager.py
@@ -264,6 +264,11 @@ class WorkerManagerTest(unittest.TestCase):
                 self._job_resource.worker_num
             )
         )
+        self.assertFalse(
+            worker_manager.is_all_initial_workers_node_check_failed(
+                self._job_resource.worker_num, 100
+            )
+        )
 
     def test_is_training_hang_by_pending_workers(self):
         self.job_context.clear_job_nodes()


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add a worker-num judgement on method 'is_all_initial_workers_node_check_failed'.

### Why are the changes needed?

Will not intercept the job running if all node-check failed in few workers scenarios.

### Does this PR introduce any user-facing change?

No

### How was this patch tested?

UT