### PR TITLE
Fix master oom from frequent error message report

### DIFF
--- a/dlrover/python/elastic_agent/master_client.py
+++ b/dlrover/python/elastic_agent/master_client.py
@@ -42,6 +42,11 @@ from dlrover.python.diagnosis.common.diagnosis_data import DiagnosisData
 from dlrover.python.util.common_util import find_free_port
 from dlrover.python.util.function_util import retry
 
+# Truncate error payloads before sending to the master to prevent the master
+# from allocating large gRPC receive buffers and accumulating data in Node
+# objects across relaunches.
+_MAX_ERROR_DATA_LEN = 2048
+
 
 class MasterClient(Singleton, ABC):
     """MasterClient provides some APIs connect with the master
@@ -450,6 +455,11 @@ class MasterClient(Singleton, ABC):
         return response.success
 
     def report_failures(self, error_data, restart_count=-1, level=""):
+        if (
+            isinstance(error_data, str)
+            and len(error_data) > _MAX_ERROR_DATA_LEN
+        ):
+            error_data = error_data[:_MAX_ERROR_DATA_LEN]
         message = comm.NodeFailure(error_data, restart_count, level)
         self._report(message)
 

--- a/dlrover/python/master/node/dist_job_manager.py
+++ b/dlrover/python/master/node/dist_job_manager.py
@@ -91,6 +91,11 @@ _master_evt = DLRoverMasterEvent().singleton_instance()
 job_ctx = get_job_context()
 
 _MAX_POD_RELAUNCH_COUNT = 5
+# Worker error dumps can be arbitrarily large. Storing the full payload in
+# Node.exit_reason (which is deep-copied into _job_nodes on every update)
+# causes unbounded master RSS growth across relaunches.  Truncate early so
+# the large string is released as soon as handle_training_failure returns.
+_MAX_ERROR_DATA_LEN = 2048
 
 
 def is_positive_exit(exit_reason):
@@ -1431,6 +1436,9 @@ class DistributedJobManager(JobManager):
     ):
         """Process the training failure reported by the node."""
         node = self._job_context.job_node(node_type, node_id)
+
+        if error_data and len(error_data) > _MAX_ERROR_DATA_LEN:
+            error_data = error_data[:_MAX_ERROR_DATA_LEN]
 
         if error_data:
             # self detected reason override the reason from k8s pod

--- a/dlrover/python/master/servicer.py
+++ b/dlrover/python/master/servicer.py
@@ -1096,9 +1096,9 @@ def create_master_service(
                 thread_name_prefix="grpc_master_service",
             ),
             options=[
-                ("comm.max_send_message_length", GRPC.MAX_SEND_MESSAGE_LENGTH),
+                ("grpc.max_send_message_length", GRPC.MAX_SEND_MESSAGE_LENGTH),
                 (
-                    "comm.max_receive_message_length",
+                    "grpc.max_receive_message_length",
                     GRPC.MAX_RECEIVE_MESSAGE_LENGTH,
                 ),
             ],

--- a/dlrover/python/tests/test_job_manager.py
+++ b/dlrover/python/tests/test_job_manager.py
@@ -1406,6 +1406,30 @@ class DistributedJobManagerTest(unittest.TestCase):
         # Verify that job was requested to stop
         self.assertTrue(self.job_context.is_stopped())
 
+    def test_handle_training_failure_truncates_large_error_data(self):
+        params = MockK8sAllreduceJobArgs()
+        params.initilize()
+        manager = create_job_manager(params, PerfMonitor())
+        manager._init_nodes()
+        manager._scaler.scale = MagicMock(return_value=None)
+
+        large_payload = "X" * (10 * 1024 * 1024)  # 10 MB
+
+        manager.handle_training_failure(
+            NodeType.WORKER,
+            0,
+            error_data=large_payload,
+            level=TrainingExceptionLevel.NODE_ERROR,
+        )
+
+        node = self.job_context.job_node(NodeType.WORKER, 0)
+        from dlrover.python.master.node.dist_job_manager import (
+            _MAX_ERROR_DATA_LEN,
+        )
+
+        self.assertLessEqual(len(node.exit_reason), _MAX_ERROR_DATA_LEN)
+        self.assertEqual(node.exit_reason, large_payload[:_MAX_ERROR_DATA_LEN])
+
 
 class JobContextTest(unittest.TestCase):
     def setUp(self):

--- a/dlrover/python/tests/test_master_client.py
+++ b/dlrover/python/tests/test_master_client.py
@@ -92,6 +92,35 @@ class MasterClientTest(unittest.TestCase):
         )
         self.assertIsNone(res)
 
+    def test_report_failures_truncates_large_error_data(self):
+        from dlrover.python.elastic_agent.master_client import (
+            _MAX_ERROR_DATA_LEN,
+        )
+
+        large_payload = "X" * (10 * 1024 * 1024)  # 10 MB
+
+        sent_messages = []
+
+        original_report = self._master_client._report
+
+        def capture_report(message):
+            sent_messages.append(message)
+            return original_report(message)
+
+        self._master_client._report = capture_report
+
+        self._master_client.report_failures(
+            large_payload, 0, TrainingExceptionLevel.WARNING
+        )
+
+        self.assertEqual(len(sent_messages), 1)
+        self.assertLessEqual(
+            len(sent_messages[0].error_data), _MAX_ERROR_DATA_LEN
+        )
+        self.assertEqual(
+            sent_messages[0].error_data, large_payload[:_MAX_ERROR_DATA_LEN]
+        )
+
     def test_ready_for_ps_relaunch(self):
         res = self._master_client.ready_for_ps_relaunch()
         self.assertTrue(res.success)

--- a/dlrover/python/tests/test_servicer.py
+++ b/dlrover/python/tests/test_servicer.py
@@ -123,6 +123,42 @@ class MasterServicerBasicTest(unittest.TestCase):
         self.server.start()
         self.server.stop(grace=None)
 
+    def test_grpc_server_uses_correct_option_keys(self):
+        import grpc
+
+        created_options = []
+        original_server = grpc.server
+
+        def capturing_server(executor, options=None, **kwargs):
+            created_options.extend(options or [])
+            return original_server(executor, options=options, **kwargs)
+
+        # patch.object targets the grpc module itself so the local alias
+        # `import grpc as grpc_lib` inside create_master_service picks it up.
+        with patch.object(grpc, "server", side_effect=capturing_server):
+            self.server = create_master_service(
+                TEST_SERVER_PORT,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+
+        option_keys = [k for k, _ in created_options]
+        self.assertIn("grpc.max_send_message_length", option_keys)
+        self.assertIn("grpc.max_receive_message_length", option_keys)
+        self.assertNotIn("comm.max_send_message_length", option_keys)
+        self.assertNotIn("comm.max_receive_message_length", option_keys)
+
+        # Must start before stop; stopping a never-started gRPC server blocks.
+        self.server.start()
+        self.server.stop(grace=None)
+
     def test_http_basic(self):
         context = Context.singleton_instance()
         context.master_service_type = "http"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This pr will fix the oom bug in the master when workers reports large size of error messages in a short-time period.

### Why are the changes needed?

When a large amount of workers fail at the same time, all of them may report large size of error message to the master and make the master oom.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

Unit test.