### PR TITLE
feat(master): support --group-affinity to partition workers into node…

### DIFF
--- a/dlrover/python/master/args.py
+++ b/dlrover/python/master/args.py
@@ -15,7 +15,11 @@ import argparse
 
 from dlrover.python.common.global_context import DefaultValues
 from dlrover.python.common.log import default_logger as logger
-from dlrover.python.util.args_util import parse_tuple_list, pos_int
+from dlrover.python.util.args_util import (
+    parse_group_affinity,
+    parse_tuple_list,
+    pos_int,
+)
 from dlrover.python.util.common_util import print_args
 
 
@@ -130,6 +134,16 @@ def _build_master_args_parser():
         default=8080,
         type=pos_int,
         help="The port of the DLRover dashboard.",
+    )
+    parser.add_argument(
+        "--group-affinity",
+        "--group_affinity",
+        default=None,
+        type=parse_group_affinity,
+        help='Node group sizes, e.g. --group-affinity="{0: 10, 1: 15}" '
+        "means group 0 has 10 pods and group 1 has 15 pods. The worker "
+        "replicas in the ElasticJob CRD must equal the sum of all group "
+        "sizes, otherwise the master fails to start.",
     )
     return parser
 

--- a/dlrover/python/master/main.py
+++ b/dlrover/python/master/main.py
@@ -73,6 +73,7 @@ def run(args):
     _dlrover_context.dashboard_port = args.dashboard_port
 
     job_args.training_elastic_mode = args.training_elastic_mode
+    job_args.group_affinity = args.group_affinity
     if args.xpu_type.lower() == "ascend":
         job_args.xpu_type = Accelerators.ASCEND_NPU
     elif args.xpu_type.lower() == "nvidia":

--- a/dlrover/python/master/node/dist_job_manager.py
+++ b/dlrover/python/master/node/dist_job_manager.py
@@ -136,6 +136,8 @@ class DistributedJobManager(JobManager):
             )
             node_restart_count[type] = node_args.restart_count
 
+        self._init_group_affinity(job_args)
+
         self._ps_is_critical = False
         if (
             job_args.distribution_strategy == DistributionStrategy.PS
@@ -202,6 +204,35 @@ class DistributedJobManager(JobManager):
         self._relaunched_groups: List[int] = []
         self._group_relaunch_count = 0
         self._max_group_relaunch_count = _dlrover_context.max_relaunch_count
+
+    def _init_group_affinity(self, job_args: JobArgs):
+        """Validate and apply the ``--group-affinity`` configuration.
+
+        When ``group_affinity`` is configured, the worker replicas declared
+        in the ElasticJob CRD must equal the sum of all group sizes; the
+        master fails to start otherwise. On success the mapping is forwarded
+        to the ``JobResource`` so that worker nodes are partitioned into the
+        configured node groups.
+        """
+        if not job_args.group_affinity:
+            return
+        worker_resource = self._job_resource.node_group_resources.get(
+            NodeType.WORKER
+        )
+        worker_count = worker_resource.count if worker_resource else 0
+        expected = sum(job_args.group_affinity.values())
+        if worker_count != expected:
+            raise ValueError(
+                f"--group-affinity requires worker replicas={expected}, "
+                f"but got CRD worker replicas={worker_count}"
+            )
+        self._job_resource.group_affinity = job_args.group_affinity
+        logger.info(
+            "Enable node group affinity: %s (total %d groups, %d workers)",
+            job_args.group_affinity,
+            len(job_args.group_affinity),
+            expected,
+        )
 
     def start(self):
         self._scaler.start()

--- a/dlrover/python/master/resource/job.py
+++ b/dlrover/python/master/resource/job.py
@@ -15,7 +15,7 @@ import copy
 import threading
 import time
 from abc import ABCMeta, abstractmethod
-from typing import Dict
+from typing import Dict, List, Optional
 
 from dlrover.python.brain.client import GlobalBrainClient
 from dlrover.python.common.constants import (
@@ -71,6 +71,7 @@ def new_ps_resource_optimizer(
 class JobResource(JsonSerializable):
     def __init__(self):
         self.node_group_resources: Dict[str, NodeGroupResource] = {}
+        self.group_affinity: Optional[Dict[int, int]] = None
 
     def get_node_group_resource(self, node_type):
         return self.node_group_resources.get(node_type, None)
@@ -130,7 +131,9 @@ class JobResource(JsonSerializable):
             group_resource = self.get_node_group_resource(node_type)
             config_resource = group_resource.node_resource
             group_nodes: Dict[int, Node] = {}
+            group_size = self._group_count()
             for i in range(group_resource.count):
+                group_id = self._resolve_group_id(node_type, i)
                 group_nodes[i] = Node(
                     node_type=node_type,
                     node_id=i,
@@ -139,12 +142,44 @@ class JobResource(JsonSerializable):
                     config_resource=copy.deepcopy(config_resource),
                     max_relaunch_count=relaunch_on_worker_failure,
                     service_addr=service_create_fn(node_type, i),
+                    node_group=group_id,
+                    node_group_size=group_size
+                    if group_id is not None
+                    else None,
                 )
             job_nodes[node_type] = group_nodes
         logger.info(
             "after initializing job node meta job_nodes are %s" % job_nodes
         )
         return job_nodes
+
+    def _group_count(self) -> Optional[int]:
+        """Return the total number of node groups, or None if group
+        affinity is not configured."""
+        if not self.group_affinity:
+            return None
+        return len(self.group_affinity)
+
+    def _resolve_group_id(
+        self, node_type: str, rank_index: int
+    ) -> Optional[int]:
+        """Resolve the node group id for a node by its rank index.
+
+        Only WORKER nodes are partitioned into node groups. The groups are
+        laid out in ascending group-id order, each occupying a contiguous
+        [start, end) rank range sized by ``group_affinity[group_id]``.
+        Returns None when group affinity is not configured.
+        """
+        if node_type != NodeType.WORKER or not self.group_affinity:
+            return None
+        ordered_groups: List[int] = sorted(self.group_affinity.keys())
+        start = 0
+        for group_id in ordered_groups:
+            size = self.group_affinity[group_id]
+            if start <= rank_index < start + size:
+                return group_id
+            start += size
+        return None
 
     def adjust_worker_for_estimator(self):
         if (

--- a/dlrover/python/scheduler/job.py
+++ b/dlrover/python/scheduler/job.py
@@ -12,7 +12,7 @@
 # limitations under the License.
 
 from abc import ABCMeta, abstractmethod
-from typing import Dict
+from typing import Dict, Optional
 
 from dlrover.python.common.constants import (
     Accelerators,
@@ -108,6 +108,7 @@ class JobArgs(JsonSerializable):
         self.xpu_type: Accelerators = Accelerators.GENERIC_CPU
         self.enable_suspended = False
         self.training_elastic_mode = "base"
+        self.group_affinity: Optional[Dict[int, int]] = None
 
     @abstractmethod
     def initilize(self):

--- a/dlrover/python/tests/test_args.py
+++ b/dlrover/python/tests/test_args.py
@@ -103,3 +103,44 @@ class ArgsTest(unittest.TestCase):
         with self.assertRaises(SystemExit) as cm:
             parse_master_args(original_args)
             self.assertEqual(cm.exception.code, 2)
+
+    def test_parse_group_affinity(self):
+        # default is None when the argument is absent
+        original_args = [
+            "--job_name",
+            "test",
+            "--namespace",
+            "default",
+        ]
+        parsed_args = parse_master_args(original_args)
+        self.assertIsNone(parsed_args.group_affinity)
+
+        # valid mapping with spaces inside the literal dict
+        original_args = [
+            "--job_name",
+            "test",
+            "--namespace",
+            "default",
+            "--group-affinity={0: 10, 1: 15}",
+        ]
+        parsed_args = parse_master_args(original_args)
+        self.assertEqual(parsed_args.group_affinity, {0: 10, 1: 15})
+
+        # the underscore alias is also accepted
+        original_args = [
+            "--job_name",
+            "test",
+            "--group_affinity={2: 3}",
+        ]
+        parsed_args = parse_master_args(original_args)
+        self.assertEqual(parsed_args.group_affinity, {2: 3})
+
+        # invalid mapping makes the parser exit with code 2
+        original_args = [
+            "--job_name",
+            "test",
+            "--group-affinity={0: 0}",
+        ]
+        with self.assertRaises(SystemExit) as cm:
+            parse_master_args(original_args)
+        self.assertEqual(cm.exception.code, 2)

--- a/dlrover/python/tests/test_args_util.py
+++ b/dlrover/python/tests/test_args_util.py
@@ -11,9 +11,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import argparse
 import unittest
 
 from dlrover.python.util.args_util import (
+    parse_group_affinity,
     parse_tuple_dict,
     parse_tuple_list,
     str2bool,
@@ -78,3 +80,32 @@ class ArgsUtilTest(unittest.TestCase):
             self.fail()
         except Exception:
             pass
+
+    def test_parse_group_affinity(self):
+        # empty / None -> None
+        self.assertIsNone(parse_group_affinity(None))
+        self.assertIsNone(parse_group_affinity(""))
+
+        # valid
+        self.assertEqual(
+            parse_group_affinity("{0: 10, 1: 15}"), {0: 10, 1: 15}
+        )
+        self.assertEqual(parse_group_affinity("{2: 3}"), {2: 3})
+        # keys are ordered by value usage, not by dict order
+        self.assertEqual(
+            parse_group_affinity("{1: 15, 0: 10}"), {1: 15, 0: 10}
+        )
+
+        # invalid
+        for bad in ["[1, 2]", "abc", "[]", "'not a dict'", "{0: 0}", "{}"]:
+            with self.assertRaises(argparse.ArgumentTypeError):
+                parse_group_affinity(bad)
+        # negative group id
+        with self.assertRaises(argparse.ArgumentTypeError):
+            parse_group_affinity("{-1: 5}")
+        # non-int value
+        with self.assertRaises(argparse.ArgumentTypeError):
+            parse_group_affinity("{0: 'x'}")
+        # bool value (True is an int subclass, must be rejected)
+        with self.assertRaises(argparse.ArgumentTypeError):
+            parse_group_affinity("{0: True}")

--- a/dlrover/python/tests/test_job_manager.py
+++ b/dlrover/python/tests/test_job_manager.py
@@ -16,6 +16,7 @@ import time
 import unittest
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta
+from types import SimpleNamespace
 from typing import Dict
 from unittest import mock
 from unittest.mock import MagicMock, patch
@@ -222,6 +223,73 @@ class DistributedJobManagerTest(unittest.TestCase):
             self.assertIsNone(node.group)
             self.assertIsNone(node.group_size)
             self.assertFalse(node.has_group())
+
+    def _new_manager_with_worker_count(self, count):
+        """Build a lightweight DistributedJobManager with only the job
+        resource populated, bypassing the heavy __init__ so that
+        _init_group_affinity can be exercised in isolation."""
+        manager = DistributedJobManager.__new__(DistributedJobManager)
+        job_resource = JobResource()
+        if count is not None:
+            job_resource.node_group_resources[NodeType.WORKER] = (
+                NodeGroupResource(count, NodeResource(1, 4096))
+            )
+        manager._job_resource = job_resource
+        return manager
+
+    def test_init_group_affinity_disabled(self):
+        # no group_affinity -> no-op, job_resource untouched
+        manager = self._new_manager_with_worker_count(3)
+        manager._init_group_affinity(SimpleNamespace(group_affinity=None))
+        self.assertIsNone(manager._job_resource.group_affinity)
+        # an empty mapping is also treated as disabled
+        manager._init_group_affinity(SimpleNamespace(group_affinity={}))
+        self.assertIsNone(manager._job_resource.group_affinity)
+
+    def test_init_group_affinity_matched(self):
+        # worker replicas == sum(values) -> apply and forward
+        manager = self._new_manager_with_worker_count(25)
+        manager._init_group_affinity(
+            SimpleNamespace(group_affinity={0: 10, 1: 15})
+        )
+        self.assertEqual(manager._job_resource.group_affinity, {0: 10, 1: 15})
+
+    def test_init_group_affinity_mismatched(self):
+        # worker replicas != sum(values) -> raise on start
+        manager = self._new_manager_with_worker_count(2)
+        with self.assertRaisesRegex(ValueError, "requires worker replicas=25"):
+            manager._init_group_affinity(
+                SimpleNamespace(group_affinity={0: 10, 1: 15})
+            )
+        # the mapping must not be applied when validation fails
+        self.assertIsNone(manager._job_resource.group_affinity)
+
+    def test_init_group_affinity_without_worker_resource(self):
+        # no WORKER resource at all -> worker_count defaults to 0 -> raise
+        manager = DistributedJobManager.__new__(DistributedJobManager)
+        manager._job_resource = JobResource()
+        with self.assertRaisesRegex(ValueError, "requires worker replicas=5"):
+            manager._init_group_affinity(
+                SimpleNamespace(group_affinity={0: 5})
+            )
+        self.assertIsNone(manager._job_resource.group_affinity)
+
+    def test_init_group_affinity_via_job_manager_init(self):
+        # Exercise the __init__ path: create_job_manager must call
+        # _init_group_affinity and apply a matching group_affinity.
+        params = MockK8sAllreduceJobArgs()
+        params.initilize(16)
+        params.group_affinity = {0: 8, 1: 8}
+        manager = create_job_manager(params, PerfMonitor())
+        self.assertEqual(manager._job_resource.group_affinity, {0: 8, 1: 8})
+
+    def test_init_group_affinity_via_job_manager_init_mismatch(self):
+        # A mismatched group_affinity must fail the manager construction.
+        params = MockK8sAllreduceJobArgs()
+        params.initilize(16)
+        params.group_affinity = {0: 10, 1: 15}
+        with self.assertRaisesRegex(ValueError, "requires worker replicas=25"):
+            create_job_manager(params, PerfMonitor())
         job = JobResource()
         job.node_group_resources[NodeType.PS] = NodeGroupResource(
             3, NodeResource(8, 10240, priority="high")

--- a/dlrover/python/tests/test_job_manager.py
+++ b/dlrover/python/tests/test_job_manager.py
@@ -182,7 +182,46 @@ class DistributedJobManagerTest(unittest.TestCase):
             nodes[NodeType.WORKER][0].config_resource.memory, 4096
         )
 
-    def test_node_priority(self):
+    def test_job_resource_group_affinity(self):
+        job = JobResource()
+        job.node_group_resources[NodeType.WORKER] = NodeGroupResource(
+            25, NodeResource(1, 4096)
+        )
+        job.group_affinity = {0: 10, 1: 15}
+
+        nodes = job.init_job_node_meta(1, get_service_fn, _get_node_name)
+        workers = nodes[NodeType.WORKER]
+        self.assertEqual(len(workers), 25)
+
+        # group 0 occupies index 0-9, group 1 occupies index 10-24
+        for i in range(10):
+            self.assertEqual(workers[i].group, 0, f"worker {i}")
+        for i in range(10, 25):
+            self.assertEqual(workers[i].group, 1, f"worker {i}")
+        # every worker carries the total group count
+        for node in workers.values():
+            self.assertEqual(node.group_size, 2)
+            self.assertTrue(node.has_group())
+
+        # group id ordering follows ascending group id, not dict order
+        job.group_affinity = {1: 15, 0: 10}
+        nodes = job.init_job_node_meta(1, get_service_fn, _get_node_name)
+        workers = nodes[NodeType.WORKER]
+        for i in range(10):
+            self.assertEqual(workers[i].group, 0)
+        for i in range(10, 25):
+            self.assertEqual(workers[i].group, 1)
+
+    def test_job_resource_without_group_affinity(self):
+        job = JobResource()
+        job.node_group_resources[NodeType.WORKER] = NodeGroupResource(
+            3, NodeResource(1, 4096)
+        )
+        nodes = job.init_job_node_meta(1, get_service_fn, _get_node_name)
+        for node in nodes[NodeType.WORKER].values():
+            self.assertIsNone(node.group)
+            self.assertIsNone(node.group_size)
+            self.assertFalse(node.has_group())
         job = JobResource()
         job.node_group_resources[NodeType.PS] = NodeGroupResource(
             3, NodeResource(8, 10240, priority="high")

--- a/dlrover/python/util/args_util.py
+++ b/dlrover/python/util/args_util.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 import argparse
 import ast
+from typing import Dict, Optional
 
 
 def pos_int(arg):
@@ -107,3 +108,41 @@ def parse_tuple_dict(value):
         raise argparse.ArgumentTypeError(
             "Invalid format. Expected format: {(v1, v2): ${boolean}, ...}"
         )
+
+
+def parse_group_affinity(value) -> Optional[Dict[int, int]]:
+    """
+    Format：{${group_id}: ${pod_num}, ...}
+    e.g. "{0: 10, 1: 15}" means group 0 has 10 pods and group 1 has 15 pods.
+
+    Returns a dict mapping a non-negative int group id to a positive int pod
+    number, or None when the argument is empty/not provided. The keys must be
+    non-negative ints and the values must be positive ints.
+    """
+    if value is None or value == "":
+        return None
+    try:
+        parsed_dict = ast.literal_eval(value)
+    except Exception:
+        raise argparse.ArgumentTypeError(
+            "Invalid format. Expected format: {0: 10, 1: 15}"
+        )
+
+    if not isinstance(parsed_dict, dict) or not parsed_dict:
+        raise argparse.ArgumentTypeError(
+            "Invalid format. Expected a non-empty dict like {0: 10, 1: 15}"
+        )
+
+    group_affinity: Dict[int, int] = {}
+    for k, v in parsed_dict.items():
+        if isinstance(k, bool) or not isinstance(k, int) or k < 0:
+            raise argparse.ArgumentTypeError(
+                f"Invalid group id {k!r}; expected a non-negative int."
+            )
+        if isinstance(v, bool) or not isinstance(v, int) or v <= 0:
+            raise argparse.ArgumentTypeError(
+                f"Invalid pod number {v!r} for group {k}; "
+                "expected a positive int."
+            )
+        group_affinity[k] = v
+    return group_affinity


### PR DESCRIPTION
Add a master startup argument `--group-affinity={0: 10, 1: 15}` that declares how many worker pods each node group contains. When configured, the worker replicas in the ElasticJob CRD must equal the sum of all group sizes; the master fails to start otherwise.

Each worker node is assigned a group id and a group size based on its rank index (group 0 occupies the first N ranks, group 1 the next M, and so on, laid out in ascending group-id order). The existing `pod_scaler._create_pod` then writes `scheduling/rack-group` (group id) and `scheduling/rack-group-num` (total group count) into every worker pod's labels, so an external scheduler can place same-group pods with high affinity.

Example: `--group-affinity={0: 10, 1: 15}` with `replicaSpecs.worker .replicas: 25` produces 25 worker pods, index 0-9 in group 0 and index 10-24 in group 1, all carrying `scheduling/rack-group-num=2`.

Changes:
- util/args_util.py: new `parse_group_affinity` parser/validator
- master/args.py: new `--group-affinity` argument
- scheduler/job.py: `JobArgs.group_affinity` field
- master/main.py: forward `args.group_affinity` to `job_args`
- master/resource/job.py: `JobResource.group_affinity` + assign `node.group/group_size` for WORKER nodes in `init_job_node_meta`
- master/node/dist_job_manager.py: validate CRD replicas == sum and forward the mapping to `JobResource`

### What changes were proposed in this pull request?

Please describe the changes you have made or proposed in this pull request.

### Why are the changes needed?

Explain the purpose or motivation behind these changes. What problem are you trying to solve?

### Does this PR introduce any user-facing change?

Specify whether this pull request introduces any changes that users will directly interact with or notice.

### How was this patch tested?

Detail the testing process you have undertaken to ensure the changes in this pull request are valid and working as intended.
