### PR TITLE
Feat: add max_hang_downtime for inspect/eval/first-step hang detection

### DIFF
--- a/dlrover/dashboard/tests/test_run_dashboard.py
+++ b/dlrover/dashboard/tests/test_run_dashboard.py
@@ -182,6 +182,7 @@ class TestMasterDashboardIntegration(unittest.TestCase):
         mock_args.task_process_timeout = 3600
         mock_args.hang_detection = False
         mock_args.hang_downtime = 300
+        mock_args.max_hang_downtime = 300
         mock_args.pending_fail_strategy = ""
         mock_args.pending_timeout = 0
         mock_args.service_type = ""
@@ -254,6 +255,7 @@ class TestMasterDashboardIntegration(unittest.TestCase):
         mock_args.task_process_timeout = 3600
         mock_args.hang_detection = False
         mock_args.hang_downtime = 300
+        mock_args.max_hang_downtime = 300
         mock_args.pending_fail_strategy = ""
         mock_args.pending_timeout = 0
         mock_args.service_type = ""
@@ -330,6 +332,7 @@ class TestMasterDashboardIntegration(unittest.TestCase):
         mock_args.task_process_timeout = 3600
         mock_args.hang_detection = False
         mock_args.hang_downtime = 300
+        mock_args.max_hang_downtime = 300
         mock_args.pending_fail_strategy = ""
         mock_args.pending_timeout = 0
         mock_args.service_type = ""

--- a/dlrover/python/common/comm.py
+++ b/dlrover/python/common/comm.py
@@ -243,6 +243,10 @@ class AtorchEvent(Message):
     name: str = ""
     type: str = ""
     step: int = 0
+    # step_type is only meaningful for #step events, e.g. "train",
+    # "train,inspect", "eval", "train,eval". Empty for #save/#eval (legacy
+    # agents won't send it; consumers should read it defensively).
+    step_type: str = ""
 
 
 @dataclass

--- a/dlrover/python/common/event/context.py
+++ b/dlrover/python/common/event/context.py
@@ -29,6 +29,14 @@ from dlrover.python.training_event.event import EventTypeName
 _dlrover_context = Context.singleton_instance()
 
 
+def _is_pure_train_step(step_type):
+    """A pure train step is one whose step_type is exactly "train". An empty
+    step_type (legacy agents / old logs without the field, or #save/#eval
+    events) is treated as a pure train step for hang detection, so that old
+    agents keep the original hang_timeout behavior (backward compatible)."""
+    return step_type in ("", "train")
+
+
 class StepEvents(object):
     def __init__(self, max_events=DefaultValues.MAX_TRAIN_STEPS):
         """
@@ -105,11 +113,25 @@ class StepEvents(object):
             elif len(keys) >= self._max_events:
                 self._step_events.popitem(last=False)
 
+            # step_type is optional (legacy agents / old logs don't send it);
+            # read defensively and treat empty as a pure train step.
+            step_type = getattr(event, "step_type", "") or ""
+
             if event.type == EventTypeName.BEGIN:
+                # The first BEGIN added after a store clear (rendezvous /
+                # failover) is the first step, which is usually slow due to
+                # compilation/warmup and is checked against max_hang_timeout.
+                is_first_step = len(keys) == 0
                 if len(keys) > 0:
                     last_event = self._step_events[keys[-1]]
+                    # Tolerate a forward gap in step number: non-pure-train
+                    # steps (inspect/eval) are now tracked (not dropped) and
+                    # still increment global_step, and a BEGIN can also be
+                    # lost in transit. A forward jump is acceptable; only a
+                    # backward/out-of-order step is rejected, so that one
+                    # missing BEGIN no longer deadlocks the whole chain.
                     if (
-                        event.step != last_event.step
+                        event.step < last_event.step
                         or last_event.event_state
                         != TrainEventState.TRAIN_EVT_END
                     ):
@@ -123,10 +145,14 @@ class StepEvents(object):
                         return
 
                 step_event = AtorchStepEvent(
-                    event.name, TrainEventState.TRAIN_EVT_BEGIN, event.step
+                    event.name,
+                    TrainEventState.TRAIN_EVT_BEGIN,
+                    event.step,
+                    step_type,
                 )
                 step_event.begin_timestamp = event.timestamp
                 step_event.localtime = int(time.time())
+                step_event.is_first_step = is_first_step
                 self._step_events[event.timestamp] = step_event
                 logger.debug(
                     f"Add BEGIN event with {event.timestamp}, {step_event}"
@@ -250,12 +276,18 @@ class JobEventContext(Singleton):
         self.ckpt_steps: StepEvents = StepEvents()
         self.eval_steps: StepEvents = StepEvents()
         self.hang_threshold = DefaultValues.HANG_DOWNTIME * 60
+        # max_hang_timeout is the ceiling for non-pure-train steps (inspect/
+        # eval) and the first step, derived from max_hang_downtime (minute).
+        self.max_hang_timeout = DefaultValues.MAX_HANG_DOWNTIME * 60
         self.ckpt_threshold = DefaultValues.MAX_CKPT_THRESHOLD * 60
 
     def check_job_step_hang(self):
         self.hang_threshold = _dlrover_context.hang_downtime * 60
         if self.hang_threshold < DefaultValues.MIN_HANG_DOWNTIME * 60:
             self.hang_threshold = DefaultValues.MIN_HANG_DOWNTIME * 60
+        self.max_hang_timeout = _dlrover_context.max_hang_downtime * 60
+        if self.max_hang_timeout < self.hang_threshold:
+            self.max_hang_timeout = self.hang_threshold
 
         now = int(datetime.now().timestamp())
 
@@ -265,15 +297,18 @@ class JobEventContext(Singleton):
             logger.warning("Skip step hang detection since no step collected")
             return False
         elif step.event_state == TrainEventState.TRAIN_EVT_BEGIN:
-            if now - step.localtime < self.hang_threshold:
-                logger.debug(
-                    f"No hang detected: {now} {self.hang_threshold} {step}"
-                )
+            # The first step (compile/warmup) and non-pure-train steps
+            # (inspect/eval) are legitimately slow; check them against the
+            # larger max_hang_timeout ceiling instead of hang_threshold.
+            if step.is_first_step or not _is_pure_train_step(step.step_type):
+                threshold = self.max_hang_timeout
+            else:
+                threshold = self.hang_threshold
+            if now - step.localtime < threshold:
+                logger.debug(f"No hang detected: {now} {threshold} {step}")
                 return False
             else:
-                logger.warning(
-                    f"Detect hang: {now} {self.hang_threshold} {step}"
-                )
+                logger.warning(f"Detect hang: {now} {threshold} {step}")
                 return True
         else:
             logger.debug(f"No new step: {now} {self.hang_threshold} {step}")
@@ -313,6 +348,10 @@ class JobEventContext(Singleton):
 
         step = self.train_steps.get_last_step_event()
         if step and step.event_state == TrainEventState.TRAIN_EVT_END:
+            # Non-pure-train steps (inspect/eval) and the first step are now
+            # visible to the master; while they are running the last step is in
+            # BEGIN state and this check is skipped below. So a genuine stall
+            # after the last END is still judged against hang_timeout.
             if now - step.localtime > self.hang_threshold:
                 ckpt_step = self.ckpt_steps.get_last_step_event()
                 if ckpt_step and ckpt_step.localtime > step.localtime:

--- a/dlrover/python/common/event/train_event.py
+++ b/dlrover/python/common/event/train_event.py
@@ -103,12 +103,19 @@ class AtorchPredictEvent(TrainEvent):
 
 
 class AtorchStepEvent(TrainEvent):
-    def __init__(self, evt_name, evt_state, step):
+    def __init__(self, evt_name, evt_state, step, step_type=""):
         super().__init__(evt_name, evt_state)
         self.event_state = evt_state
         self.event_name = evt_name
         self.step = step
         self.step_time = 0
+        # step_type of the #step event, e.g. "train", "train,inspect", "eval".
+        # Empty means unknown/legacy and is treated as a pure train step.
+        self.step_type = step_type
+        # Whether this step is the first step since the last rendezvous /
+        # store clear. The first step usually involves compilation/warmup and
+        # is legitimately slow, so it is checked against max_hang_timeout.
+        self.is_first_step = False
 
     def __repr__(self):
         attributes = [f"{k}={v!r}" for k, v in vars(self).items()]

--- a/dlrover/python/common/global_context.py
+++ b/dlrover/python/common/global_context.py
@@ -44,6 +44,7 @@ class ConfigKeys(object):
     SECONDS_TO_CHANGE_PS = "seconds_to_change_ps"
     SECONDS_TO_WAIT_FAILED_PS = "seconds_to_wait_failed_ps"
     HANG_CPU_USAGE_RATE = "hang_cpu_usage_rate"
+    MAX_HANG_DOWNTIME = "max_hang_downtime"
 
 
 class DefaultValues(object):
@@ -78,6 +79,10 @@ class DefaultValues(object):
     ]
     HANG_DOWNTIME = 10  # default downtime, unit is minute
     MIN_HANG_DOWNTIME = 2  # min downtime, unit is minute
+    # The max downtime as training hang for non-pure-train step (e.g.
+    # train,inspect / eval) and the first step, which are legitimate but
+    # long. Unit is minute.
+    MAX_HANG_DOWNTIME = 120
     MAX_CKPT_THRESHOLD = 15  # unit is minute
     FIRST_GROUP_IDX = 1000  # group idx initial value for group relaunch
     MAX_RELAUNCH_COUNT = 3  # maximum node relaunch count
@@ -142,6 +147,10 @@ class Context(Singleton):
         self.hang_detection = HangDetectionStrategy.DO_NOTIFY
         # The duration of downtime as training hang, unit is minute
         self.hang_downtime = DefaultValues.HANG_DOWNTIME
+        # The max downtime as training hang for non-pure-train step and the
+        # first step, unit is minute. Derived hang threshold is
+        # `max_hang_downtime * 60` (seconds).
+        self.max_hang_downtime = DefaultValues.MAX_HANG_DOWNTIME
         self.gpu_per_node = DefaultValues.GPU_NUM_PER_NODE
         self.npu_per_node = DefaultValues.NPU_NUM_PER_NODE
         # pre-check args
@@ -212,6 +221,11 @@ class Context(Singleton):
         self.hang_cpu_usage_percentage = self.get_param_value_from_brain(
             ConfigKeys.HANG_CPU_USAGE_RATE,
             DefaultValues.HANG_CPU_USAGE_RATE,
+        )
+        self.max_hang_downtime = self.get_param_value_from_brain(
+            ConfigKeys.MAX_HANG_DOWNTIME,
+            DefaultValues.MAX_HANG_DOWNTIME,
+            dtype=int,
         )
 
     def config_master_port(self, port=0):

--- a/dlrover/python/diagnosis/datacollector/atorch_event_collector.py
+++ b/dlrover/python/diagnosis/datacollector/atorch_event_collector.py
@@ -60,13 +60,13 @@ class AtorchEventCollector(Singleton):
         self._retry_timeout = retry_timeout
         self._ranks = local_world_size
         self._threads = []
-        self._first_step = None
 
     def reset_first_step(self):
-        logger.info(
-            f"AtorchEventCollector: reset first step {self._first_step} to None"
-        )
-        self._first_step = None
+        # Deprecated: first-step detection now happens on the master side.
+        # The first BEGIN added after a train_steps clear is treated as the
+        # first step and checked against max_hang_downtime. Kept as a no-op so
+        # existing callers (e.g. after rendezvous) do not break.
+        logger.debug("AtorchEventCollector: reset_first_step is a no-op now")
 
     def parse_line(self, line):
         match = re.findall(self._prefix_pattern, line)
@@ -110,22 +110,18 @@ class AtorchEventCollector(Singleton):
             logger.debug(f"Invalid event type {event_type} in line {line}")
             raise AtorchNotFoundException()
 
+        event_step_type = ""
         if event_name == TrainEventName.TRAIN_EVT_STEP:
             text = literal_eval(re.sub(self._prefix_pattern, "", line))
             if isinstance(text, dict):
                 event_step = int(text["global_step"])
-                if "step_type" in text:  # backward compatible
-                    event_step_type = text["step_type"]
-                    if (
-                        event_type == EventTypeName.BEGIN
-                        and event_target == EventTargetName.TRAINER
-                        and event_name == TrainEventName.TRAIN_EVT_STEP
-                        and event_step_type != "train"
-                    ):
-                        logger.debug(
-                            f"Invalid step type {event_step_type} in line {line}"
-                        )
-                        raise AtorchInvalidException()
+                # step_type is optional (backward compatible). Non-pure-train
+                # steps (e.g. "train,inspect" / "eval" / "train,eval") are
+                # legit but slow; they MUST stay visible to the master so that
+                # hang detection can apply max_hang_timeout instead of being
+                # silently skipped (which used to break the master's step
+                # pairing chain).
+                event_step_type = str(text.get("step_type", "") or "")
             else:
                 logger.warning(f"Invalid text format {text} in line {line}")
                 raise ValueError
@@ -144,11 +140,20 @@ class AtorchEventCollector(Singleton):
                 )
                 raise e
 
-        return event_ts, event_target, event_name, event_type, event_step
+        return (
+            event_ts,
+            event_target,
+            event_name,
+            event_type,
+            event_step,
+            event_step_type,
+        )
 
-    def _report_event(self, ts, target, event_name, event_type, step):
+    def _report_event(
+        self, ts, target, event_name, event_type, step, step_type=""
+    ):
         self._client.report_atorch_event(
-            ts, target, event_name, event_type, step
+            ts, target, event_name, event_type, step, step_type
         )
 
     def _monitor_file(self, filepath):
@@ -167,12 +172,18 @@ class AtorchEventCollector(Singleton):
                     continue
 
                 try:
-                    ts, target, event_name, event_type, step = self.parse_line(
-                        line
-                    )
+                    (
+                        ts,
+                        target,
+                        event_name,
+                        event_type,
+                        step,
+                        step_type,
+                    ) = self.parse_line(line)
                     logger.info(
                         f"Parse line output: "
-                        f"{ts} {target} {event_name} {event_type} {step}"
+                        f"{ts} {target} {event_name} {event_type} {step} "
+                        f"{step_type}"
                     )
                 except (AtorchNotFoundException, AtorchInvalidException):
                     continue
@@ -183,24 +194,16 @@ class AtorchEventCollector(Singleton):
                     logger.warning(f"Parse {line} unexpected error: {e}")
                     continue
 
-                if (
-                    self._first_step is None
-                    and target == EventTargetName.TRAINER
-                    and event_name == TrainEventName.TRAIN_EVT_STEP
-                    and event_type == EventTypeName.BEGIN
-                ):
-                    logger.info(
-                        f"Collect first step since last rendezvous: {step}"
-                    )
-                    self._first_step = step
-
-                if self._first_step is not None and step != self._first_step:
-                    logger.info(
-                        f"Report event: {ts} {target} {event_name} {event_type} {step}"
-                    )
-                    self._report_event(
-                        ts, target, event_name, event_type, step
-                    )
+                # Report every event. The first step and non-pure-train steps
+                # (inspect/eval) are no longer skipped here; the master keeps
+                # them visible and applies max_hang_timeout for hang detection.
+                logger.info(
+                    f"Report event: {ts} {target} {event_name} {event_type} "
+                    f"{step} {step_type}"
+                )
+                self._report_event(
+                    ts, target, event_name, event_type, step, step_type
+                )
 
     def collect_events(self, rank: int):
         filepath = os.path.join(self._filepath, f"events_{rank}.log")

--- a/dlrover/python/elastic_agent/master_client.py
+++ b/dlrover/python/elastic_agent/master_client.py
@@ -298,6 +298,7 @@ class MasterClient(Singleton, ABC):
         event_name,
         event_type,
         event_step,
+        step_type="",
     ):
         message = comm.AtorchEvent(
             timestamp=event_ts,
@@ -305,6 +306,7 @@ class MasterClient(Singleton, ABC):
             target=event_target,
             name=event_name,
             type=event_type,
+            step_type=step_type,
         )
 
         return self._report(message)

--- a/dlrover/python/master/args.py
+++ b/dlrover/python/master/args.py
@@ -97,6 +97,14 @@ def _build_master_args_parser():
         help="Training downtime to detect job hang, unit is minute",
     )
     parser.add_argument(
+        "--max_hang_downtime",
+        default=DefaultValues.MAX_HANG_DOWNTIME,
+        type=pos_int,
+        help="The max downtime to detect job hang for non-pure-train step "
+        "(e.g. train,inspect / eval) and the first step, unit is minute. "
+        "Should be no less than --hang_downtime.",
+    )
+    parser.add_argument(
         "--xpu_type",
         default="nvidia",
         type=str,

--- a/dlrover/python/master/main.py
+++ b/dlrover/python/master/main.py
@@ -58,6 +58,20 @@ def run(args):
     if _dlrover_context.hang_downtime < DefaultValues.MIN_HANG_DOWNTIME:
         _dlrover_context.hang_downtime = DefaultValues.MIN_HANG_DOWNTIME
 
+    _dlrover_context.max_hang_downtime = args.max_hang_downtime
+    if _dlrover_context.max_hang_downtime < DefaultValues.MIN_HANG_DOWNTIME:
+        _dlrover_context.max_hang_downtime = DefaultValues.MIN_HANG_DOWNTIME
+    # max_hang_downtime is a ceiling for non-pure-train/first step and should
+    # be no less than hang_downtime; otherwise the corner case is stricter than
+    # the normal case, which defeats the purpose.
+    if _dlrover_context.max_hang_downtime < _dlrover_context.hang_downtime:
+        logger.warning(
+            f"max_hang_downtime({_dlrover_context.max_hang_downtime}) is "
+            f"less than hang_downtime({_dlrover_context.hang_downtime}), "
+            "fallback to hang_downtime."
+        )
+        _dlrover_context.max_hang_downtime = _dlrover_context.hang_downtime
+
     _dlrover_context.pending_fail_strategy = args.pending_fail_strategy
     _dlrover_context.pending_timeout = args.pending_timeout
     _dlrover_context.master_service_type = args.service_type

--- a/dlrover/python/tests/test_master.py
+++ b/dlrover/python/tests/test_master.py
@@ -256,6 +256,7 @@ class MasterMainXpuTypeTest(unittest.TestCase):
         self.mock_args.task_process_timeout = 600
         self.mock_args.hang_detection = True
         self.mock_args.hang_downtime = 300
+        self.mock_args.max_hang_downtime = 300
         self.mock_args.pending_fail_strategy = "restart"
         self.mock_args.pending_timeout = 60
         self.mock_args.service_type = "ClusterIP"

--- a/dlrover/python/tests/test_master_client.py
+++ b/dlrover/python/tests/test_master_client.py
@@ -285,11 +285,14 @@ class MasterClientTest(unittest.TestCase):
         time.sleep(1)
         collector.stop_collectors()
 
-        self.assertEqual(_event_context.train_steps.size(), 2)
+        # The first step (177018->177019, a long ~22min step) is now tracked
+        # (no longer skipped by the collector), so train_steps holds 3 steps.
+        self.assertEqual(_event_context.train_steps.size(), 3)
         first_step = _event_context.train_steps.get_first_step_event()
         last_step = _event_context.train_steps.get_last_step_event()
-        self.assertEqual(first_step.step, 177020)
+        self.assertEqual(first_step.step, 177019)
         self.assertEqual(last_step.step, 177021)
+        self.assertTrue(first_step.is_first_step)
 
         self.assertEqual(_event_context.ckpt_steps.size(), 2)
         first_step = _event_context.ckpt_steps.get_first_step_event()
@@ -308,6 +311,7 @@ class MasterClientTest(unittest.TestCase):
             event_name=TrainEventName.TRAIN_EVT_STEP,
             event_type=EventTypeName.BEGIN,
             event_step=1,
+            step_type="train",
         )
         last_step = _event_context.train_steps.get_last_step_event()
         self.assertEqual(last_step.step, 1)
@@ -315,6 +319,8 @@ class MasterClientTest(unittest.TestCase):
             last_step.event_state, TrainEventState.TRAIN_EVT_BEGIN
         )
         self.assertEqual(last_step.begin_timestamp, now)
+        self.assertEqual(last_step.step_type, "train")
+        self.assertTrue(last_step.is_first_step)
 
         self._master_client.report_atorch_event(
             event_ts=now + 1,

--- a/dlrover/python/tests/test_training_events.py
+++ b/dlrover/python/tests/test_training_events.py
@@ -144,12 +144,17 @@ class TrainingEventTest(unittest.TestCase):
 
     def test_atorch_parse_line(self):
         collector = AtorchEventCollector()
-        with self.assertRaises(AtorchInvalidException):
-            line = (
-                "[2025-01-22T19:01:19.422454] [2044] [322] [AtorchTrainerV2] "
-                '[#step] [BEGIN] {"global_step": 30, "epoch": 0.004, "step_type": "train,inspect" }'
-            )
-            collector.parse_line(line)
+        # Non-pure-train BEGIN (e.g. train,inspect) must NOT be rejected
+        # anymore; it is reported so the master can apply max_hang_timeout
+        # instead of silently dropping it (which used to break the master's
+        # step pairing chain).
+        line = (
+            "[2025-01-22T19:01:19.422454] [2044] [322] [AtorchTrainerV2] "
+            '[#step] [BEGIN] {"global_step": 30, "epoch": 0.004, "step_type": "train,inspect" }'
+        )
+        events = collector.parse_line(line)
+        self.assertEqual(events[4], 30)
+        self.assertEqual(events[5], "train,inspect")
 
         line = (
             "[2025-01-22T19:01:19.422454] [2044] [322] [AtorchTrainerV2] "
@@ -164,6 +169,7 @@ class TrainingEventTest(unittest.TestCase):
         self.assertEqual(events[2], TrainerEventName.TRAIN_STEP.value)
         self.assertEqual(events[3], EventTypeName.BEGIN)
         self.assertEqual(events[4], 30)
+        self.assertEqual(events[5], "train")
 
         with self.assertRaises(ValueError):
             line = (
@@ -233,13 +239,16 @@ class TrainingEventTest(unittest.TestCase):
         events = StepEvents()
         ckpts = StepEvents()
 
-        def mock_report_event(self, ts, target, event_name, event_type, step):
+        def mock_report_event(
+            self, ts, target, event_name, event_type, step, step_type=""
+        ):
             evt = AtorchEvent(
                 timestamp=ts,
                 step=step,
                 target=target,
                 name=event_name,
                 type=event_type,
+                step_type=step_type,
             )
             if event_name == TrainEventName.TRAIN_EVT_STEP:
                 events.add_step_event(evt)
@@ -258,9 +267,19 @@ class TrainingEventTest(unittest.TestCase):
             time.sleep(1)
             collector.stop_collectors()
 
+            # The first step (177018->177019, a long ~22min step) is now
+            # tracked (no longer skipped); it is the first step since the
+            # store is empty, so is_first_step is True.
+            _, step = events.pop_step_event()
+            self.assertEqual(step.step, 177019)
+            self.assertEqual(step.step_time, 1346)
+            self.assertTrue(step.is_first_step)
+            self.assertEqual(step.event_name, TrainEventName.TRAIN_EVT_STEP)
+            self.assertEqual(step.event_state, TrainEventState.TRAIN_EVT_END)
             _, step = events.pop_step_event()
             self.assertEqual(step.step, 177020)
             self.assertEqual(step.step_time, 21)
+            self.assertFalse(step.is_first_step)
             self.assertEqual(step.event_name, TrainEventName.TRAIN_EVT_STEP)
             self.assertEqual(step.event_state, TrainEventState.TRAIN_EVT_END)
             _, step = events.pop_step_event()
@@ -871,3 +890,159 @@ class TrainingEventTest(unittest.TestCase):
         )
         _event_context.eval_steps.add_eval_event(eval)
         self.assertEqual(_event_context.check_event_block(), False)
+
+    def test_atorch_step_event_step_type_and_first_step(self):
+        test_events = StepEvents(max_events=10)
+        now = int(datetime.now().timestamp())
+
+        # The first BEGIN is the first step (store empty); step_type is stored.
+        evt = AtorchEvent(
+            timestamp=now,
+            target=EventTargetName.TRAINER,
+            name=TrainEventName.TRAIN_EVT_STEP,
+            type=EventTypeName.BEGIN,
+            step=1,
+            step_type="train,inspect",
+        )
+        test_events.add_step_event(evt)
+        last = test_events.get_last_step_event()
+        self.assertEqual(last.step_type, "train,inspect")
+        self.assertTrue(last.is_first_step)
+
+        # After END, the next BEGIN is not the first step anymore.
+        test_events.add_step_event(
+            AtorchEvent(
+                timestamp=now + 1,
+                target=EventTargetName.TRAINER,
+                name=TrainEventName.TRAIN_EVT_STEP,
+                type=EventTypeName.END,
+                step=2,
+                step_type="train,inspect",
+            )
+        )
+        test_events.add_step_event(
+            AtorchEvent(
+                timestamp=now + 2,
+                target=EventTargetName.TRAINER,
+                name=TrainEventName.TRAIN_EVT_STEP,
+                type=EventTypeName.BEGIN,
+                step=2,
+                step_type="train",
+            )
+        )
+        last = test_events.get_last_step_event()
+        self.assertEqual(last.step_type, "train")
+        self.assertFalse(last.is_first_step)
+
+        # Legacy agent event without step_type attribute is treated as a pure
+        # train step (empty step_type), i.e. backward compatible.
+        legacy = StepEvents(max_events=10)
+        evt_legacy = AtorchEvent(
+            timestamp=now,
+            target=EventTargetName.TRAINER,
+            name=TrainEventName.TRAIN_EVT_STEP,
+            type=EventTypeName.BEGIN,
+            step=1,
+        )
+        # Mimic an old pickle whose __dict__ lacks the step_type field.
+        delattr(evt_legacy, "step_type")
+        legacy.add_step_event(evt_legacy)
+        last = legacy.get_last_step_event()
+        self.assertEqual(last.step_type, "")
+        self.assertTrue(last.is_first_step)
+
+    def test_atorch_step_event_forward_gap_tolerance(self):
+        test_events = StepEvents(max_events=10)
+        now = int(datetime.now().timestamp())
+
+        def _evt(event_type, step, ts):
+            return AtorchEvent(
+                timestamp=ts,
+                target=EventTargetName.TRAINER,
+                name=TrainEventName.TRAIN_EVT_STEP,
+                type=event_type,
+                step=step,
+            )
+
+        # Build a completed step: BEGIN(1) -> END(2). Each event gets a distinct
+        # timestamp since the store is keyed by the BEGIN timestamp.
+        test_events.add_step_event(_evt(EventTypeName.BEGIN, 1, now))
+        test_events.add_step_event(_evt(EventTypeName.END, 2, now + 1))
+        self.assertEqual(test_events.size(), 1)
+
+        # A forward jump (BEGIN step 5 after END step 2) is now tolerated:
+        # the missing BEGINs (e.g. an inspect step that was skipped/lost, or a
+        # lost event) no longer deadlock the whole chain. Previously this was
+        # rejected because 5 != 2.
+        test_events.add_step_event(_evt(EventTypeName.BEGIN, 5, now + 2))
+        self.assertEqual(test_events.size(), 2)
+        last = test_events.get_last_step_event()
+        self.assertEqual(last.step, 5)
+        self.assertEqual(last.event_state, TrainEventState.TRAIN_EVT_BEGIN)
+
+        # A backward jump (BEGIN step 3 while the last step is 5) is still
+        # rejected as out-of-order.
+        test_events.add_step_event(_evt(EventTypeName.BEGIN, 3, now + 3))
+        self.assertEqual(test_events.size(), 2)
+
+    @patch(
+        "dlrover.python.common.global_context.DefaultValues.MIN_HANG_DOWNTIME",
+        0,
+    )
+    def test_step_hang_max_hang_timeout(self):
+        _event_context.train_steps.clear_step_events()
+        # hang_downtime=1 -> hang_threshold=60s; max_hang_downtime=2 ->
+        # max_hang_timeout=120s. The latter is the ceiling for the first step
+        # and non-pure-train steps.
+        _dlrover_context.hang_downtime = 1
+        _dlrover_context.max_hang_downtime = 2
+
+        now = int(datetime.now().timestamp())
+
+        def _begin(step, step_type):
+            _event_context.train_steps.add_step_event(
+                AtorchEvent(
+                    timestamp=now,
+                    target=EventTargetName.TRAINER,
+                    name=TrainEventName.TRAIN_EVT_STEP,
+                    type=EventTypeName.BEGIN,
+                    step=step,
+                    step_type=step_type,
+                )
+            )
+            # Simulate the step started 90 seconds ago.
+            last = _event_context.train_steps.get_last_step_event()
+            last.localtime = now - 90
+            return last
+
+        def _end(step):
+            _event_context.train_steps.add_step_event(
+                AtorchEvent(
+                    timestamp=now,
+                    target=EventTargetName.TRAINER,
+                    name=TrainEventName.TRAIN_EVT_STEP,
+                    type=EventTypeName.END,
+                    step=step,
+                )
+            )
+
+        # First step (pure train, is_first_step=True) -> max_hang_timeout(120s).
+        # 90s < 120s -> not hang (would be hang under hang_timeout=60s).
+        _begin(0, "train")
+        self.assertEqual(_event_context.check_job_step_hang(), False)
+
+        # A later normal pure-train step -> hang_timeout(60s).
+        # 90s > 60s -> hang.
+        _end(1)
+        _begin(1, "train")
+        self.assertEqual(_event_context.check_job_step_hang(), True)
+
+        # A non-pure-train (inspect) step -> max_hang_timeout(120s).
+        # 90s < 120s -> not hang (the slow inspect step is tolerated).
+        _end(2)
+        _begin(2, "train,inspect")
+        self.assertEqual(_event_context.check_job_step_hang(), False)
+
+        # restore defaults
+        _dlrover_context.hang_downtime = 10
+        _dlrover_context.max_hang_downtime = 120


### PR DESCRIPTION
## Motivation
  The master step-hang detection (`check_job_step_hang`) treats every step
  with a single `hang_downtime` threshold. Legitimately slow steps — the first
  step (compile/warmup) and non-pure-train steps (`train,inspect` / `eval` /
  `train,eval`) — either get falsely flagged or, worse, were silently skipped
  by the collector. The skip itself was buggy: dropping only the `BEGIN` of a
  `train,inspect` step broke the master's strict sequential pairing, which
  deadlocked the whole step-tracking chain at the previous `END`, disabling
  hang detection entirely for the rest of the run.

  ## Changes
  - **New config `--max_hang_downtime`** (default `120` min). Derives
    `max_hang_timeout = max_hang_downtime * 60` (sec), analogous to
    `hang_threshold = hang_downtime * 60`. Floored at `MIN_HANG_DOWNTIME` and
    at `hang_downtime`; also wired into `set_params_from_brain`.
  - **`step_type` is propagated end-to-end** (`AtorchEvent` / `AtorchStepEvent`).
    inspect/eval steps and the first step are no longer dropped — they are
    visible to the master. `check_job_step_hang` now applies `max_hang_timeout`
    to the first step / non-pure-train steps and `hang_threshold` to normal
    pure-train steps. Empty/legacy `step_type` (old agents) is treated as pure
    train (backward compatible).
  - **Forward step-gap tolerance** in `StepEvents.add_step_event`: the BEGIN
    pairing now accepts a forward jump in `step` number and only rejects a
    backward/out-of-order one, so one missing BEGIN (or a skipped/lost step)
    no longer deadlocks the chain — the root cause of the inspect deadlock.
  - **Collector**: removed the `step_type != "train"` BEGIN rejection and the
    `_first_step` skip; `reset_first_step` is now a no-op. `AtorchStepEvent`
    records `is_first_step` (first BEGIN added after a store clear).
  - **`check_ckpt_hang` unchanged**; **`check_event_block` keeps
    `hang_threshold`** — it judges the inter-step gap (a different concern
    from single-step execution; long ckpt/eval/inspect are visible as BEGIN
    and/or suppressed by their own stores).

  ## How to use
  --hang_downtime 5        # normal pure-train step + ckpt threshold (min)
  --max_hang_downtime 120  # ceiling for first step / inspect / eval (min)

  ## Tests
  - `test_training_events.py`: 15/15. Updated `test_atorch_parse_line`
    (inspect BEGIN no longer rejected), `test_atorch_parse_log` (first step is
    now tracked → 3 steps). Added cases for `step_type`/`is_first_step`
    storage (incl. legacy-agent compat), forward-gap tolerance, and
    `max_hang_timeout` threshold selection (first/inspect → 120s, normal train
    → 60s).
  - `test_master_client.py`: updated `test_event_log` (2→3 steps) and
    `test_report_atorch_events` (step_type end-to-end). These need `ray` which
    is absent locally; import failure is pre-existing on `HEAD` and unrelated
    to this change.