### PR TITLE
Feat: allow passing extra labels when creating k8s Service

### DIFF
--- a/dlrover/python/scheduler/kubernetes.py
+++ b/dlrover/python/scheduler/kubernetes.py
@@ -13,7 +13,7 @@
 
 import os
 import time
-from typing import Dict
+from typing import Dict, Optional
 
 from kubernetes import client, config
 from kubernetes.utils.quantity import parse_quantity
@@ -533,10 +533,16 @@ class k8sServiceFactory(object):
         owner_ref: client.V1OwnerReference,
         retry_num=5,
         patch_if_exists: bool = True,
+        labels: Optional[Dict[str, str]] = None,
     ):
         """
         Create a new service if the service dose not exist, otherwise
         the method patch the service with modifications.
+
+        Args:
+            labels: extra labels merged into the Service metadata (both
+                labels and annotations). Keys here override the default
+                labels. When None, only the default labels are applied.
         """
         service = self._create_service_obj(
             name=name,
@@ -544,6 +550,7 @@ class k8sServiceFactory(object):
             target_port=target_port,
             selector=selector,
             owner_ref=owner_ref,
+            new_labels=labels,
         )
 
         svc = self.get_service(name)
@@ -583,11 +590,17 @@ class k8sServiceFactory(object):
         selector: Dict[str, str],
         owner_ref: client.V1OwnerReference,
         port_name="grpc",
+        new_labels: Optional[Dict[str, str]] = None,
     ):
         labels = {
             "app": ElasticJobLabel.APP_NAME,
             ElasticJobLabel.JOB_KEY: self._job_name,
         }
+        # `new_labels` are merged on top of the defaults so callers (e.g. a
+        # vendor-specific ServiceFactory) can attach or override labels; keys
+        # in `new_labels` win over the defaults.
+        if new_labels:
+            labels = {**labels, **new_labels}
 
         metadata = client.V1ObjectMeta(
             name=name,

--- a/dlrover/python/tests/test_k8s_utils.py
+++ b/dlrover/python/tests/test_k8s_utils.py
@@ -109,6 +109,45 @@ class KubernetesTest(unittest.TestCase):
         self.assertTrue(succeed)
         self.assertEqual(svc.spec.ports[0].name, "http")
 
+    def test_service_obj_with_extra_labels(self):
+        fac = k8sServiceFactory("dlrover", "test")
+
+        default_labels = {
+            "app": "dlrover",
+            "elasticjob.dlrover/name": "test",
+        }
+
+        # Without new_labels, only the default labels are applied and the
+        # same dict is mirrored into annotations.
+        svc = fac._create_service_obj("svc", 12345, 12345, {}, None)
+        self.assertEqual(svc.metadata.labels, default_labels)
+        self.assertEqual(svc.metadata.annotations, default_labels)
+
+        # new_labels are merged on top; same-named keys override defaults.
+        extra = {
+            "ignore.extensions.k8s.alipay.com/dnsrr": "true",
+            "app": "custom",
+        }
+        svc = fac._create_service_obj(
+            "svc", 12345, 12345, {}, None, new_labels=extra
+        )
+        self.assertEqual(
+            svc.metadata.labels,
+            {
+                "app": "custom",
+                "elasticjob.dlrover/name": "test",
+                "ignore.extensions.k8s.alipay.com/dnsrr": "true",
+            },
+        )
+        self.assertEqual(svc.metadata.labels, svc.metadata.annotations)
+
+        # create_service forwards `labels` to _create_service_obj.
+        self.assertTrue(
+            fac.create_service("svc", 12345, 12345, {}, None, labels=extra)
+        )
+        # `labels` defaults to None -> no extra keys.
+        self.assertTrue(fac.create_service("svc", 12345, 12345, {}, None))
+
     def test_client(self):
         k8s_client = k8sClient.singleton_instance("default")
         succeed = k8s_client.cordon_node("test-node-0")


### PR DESCRIPTION
Background

  When DLRover (K8s path) creates a Pod it also creates a per-pod
  ClusterIP Service via k8sServiceFactory._create_service_obj. The
  Service metadata labels are currently hard-coded to app and
  elasticjob.dlrover/name, with no way for a downstream deployment to
  attach vendor-specific labels/annotations.

  In internal (Sigma) clusters we need every such Service to carry
  ignore.extensions.k8s.alipay.com/dnsrr=true so the cluster's k8s
  extension skips dns round-robin for these per-pod services. We don't
  want that vendor key baked into the open-source trunk.

  What this PR does

  Makes the Service labels extensible without changing default behavior.

  - k8sServiceFactory._create_service_obj gains an optional
  new_labels: Optional[Dict[str, str]] = None. When provided, it is
  merged on top of the default labels (app, elasticjob.dlrover/name);
  keys in new_labels override the defaults. When None, behavior is
  identical to before (same default dict, still mirrored into
  annotations per the existing shared-dict pattern).
  - k8sServiceFactory.create_service exposes the same as a labels
  kwarg (default None) and forwards it to _create_service_obj.
  - Removes the previously hard-coded
  ignore.extensions.k8s.alipay.com/dnsrr line; the open-source trunk
  carries no vendor keys.

  Usage

  Open-source path: unchanged — existing callers (dist_master.py,
  pod_scaler.py) don't pass labels, so Services keep the default
  labels only.

  Downstream vendor ServiceFactory (e.g. an internal SigmaServiceFactory
  in the dlrover-addon repo) injects its labels through new_labels:

  from dlrover.python.scheduler.kubernetes import k8sServiceFactory


  class SigmaServiceFactory(k8sServiceFactory):
      SIGMA_SERVICE_LABELS = {
          "ignore.extensions.k8s.alipay.com/dnsrr": "true",
      }

      def _create_service_obj(
          self,
          name,
          port,
          target_port,
          selector,
          owner_ref,
          port_name="grpc",
          new_labels=None,
      ):
          labels = dict(new_labels) if new_labels else {}
          labels.update(self.SIGMA_SERVICE_LABELS)
          return super()._create_service_obj(
              name=name,
              port=port,
              target_port=target_port,
              selector=selector,
              owner_ref=owner_ref,
              port_name=port_name,
              new_labels=labels,
          )

  Merge precedence (low → high): default app/elasticjob.dlrover/name
  < Sigma dnsrr (forced) < caller-provided new_labels (except for
  keys Sigma forces).

  Tests

  - New test_service_obj_with_extra_labels in
  dlrover/python/tests/test_k8s_utils.py:
    - default-only labels (and that labels == annotations),
    - new_labels merged with override (e.g. app overridden, dnsrr
  added),
    - create_service forwards labels; labels=None adds no extra keys.
  - Existing test_service_exists / test_service_factory still pass
  (default-None path unchanged).

  pre-commit run -a passes (ruff-check, ruff-format, mypy, copyright).

  Files

  - dlrover/python/scheduler/kubernetes.py
  - dlrover/python/tests/test_k8s_utils.py