### PR TITLE
Fix(master): persist terminal DELETED status for no-heartbeat nodes

### DIFF
--- a/dlrover/python/master/node/dist_job_manager.py
+++ b/dlrover/python/master/node/dist_job_manager.py
@@ -920,7 +920,15 @@ class DistributedJobManager(JobManager):
             ):
                 return
 
-            # Update the node status
+            # Update the node status. A synthetic event (e.g. no-heartbeat)
+            # may carry a FAILED status while the state machine resolves to
+            # DELETED; persist the resolved terminal status to avoid leaving
+            # the node in a non-terminal FAILED state.
+            if (
+                new_status == NodeStatus.FAILED
+                and status_change_flow.to_status == NodeStatus.DELETED
+            ):
+                new_status = status_change_flow.to_status
             cur_node.update_status(new_status)
             new_status = status_change_flow.to_status
             cur_node.set_exit_reason(event.node.exit_reason)

--- a/dlrover/python/tests/test_job_manager.py
+++ b/dlrover/python/tests/test_job_manager.py
@@ -1513,6 +1513,72 @@ class DistributedJobManagerTest(unittest.TestCase):
         # Verify that job was requested to stop
         self.assertTrue(self.job_context.is_stopped())
 
+    def test_no_heartbeat_persists_terminal_deleted_status(self):
+        """Regression for BUG#1.
+
+        A no-heartbeat synthetic event carries status=FAILED with
+        event_type=DELETED (see DistributedJobManager._get_dead_node_event).
+        The state machine resolves it to the terminal DELETED status, so the
+        node must be persisted as DELETED rather than left in the non-terminal
+        FAILED state. Otherwise, when the stuck terminating pod later
+        re-emits a DELETED event, the node transitions FAILED->DELETED
+        (should_relaunch=False) and spuriously stops an all-reduce job even
+        though the worker has already been relaunched.
+        """
+        params = MockK8sAllreduceJobArgs()
+        params.initilize(worker_count=4)
+        manager = create_job_manager(params, PerfMonitor())
+        manager._init_nodes()
+        manager._scaler.scale = mock.MagicMock(return_value=None)
+        manager._k8s_client.list_namespaced_pod = mock.MagicMock(
+            return_value=client.V1PodList(items=[])
+        )
+
+        # Fixed-size all-reduce world: min_nodes == worker_num, so losing one
+        # non-relaunchable worker must stop the job.
+        manager._worker_manager.update_node_required_info((4, 4, 300))
+
+        worker0 = self.job_context.job_nodes()[NodeType.WORKER][0]
+        worker0.status = NodeStatus.RUNNING
+        worker0.relaunch_count = 0
+        self.job_context.update_job_node(worker0)
+
+        # 1) no-heartbeat synthetic event (status=FAILED, event DELETED),
+        #    exactly as built by _get_dead_node_event.
+        dead_node = Node(
+            NodeType.WORKER,
+            0,
+            NodeResource(1, 4096),
+            rank_index=0,
+            status=NodeStatus.FAILED,
+            name="test-worker-0",
+        )
+        dead_node.exit_reason = NodeExitReason.NO_HEARTBEAT
+        manager._process_event(NodeEvent(NodeEventType.DELETED, dead_node))
+
+        persisted = self.job_context.job_nodes()[NodeType.WORKER][0]
+        # The node must be in the terminal DELETED status, not FAILED.
+        self.assertEqual(persisted.status, NodeStatus.DELETED)
+        # The dead node has been relaunched (count 0 -> 1) and is not
+        # relaunchable anymore.
+        self.assertEqual(persisted.relaunch_count, 1)
+        self.assertFalse(persisted.relaunchable)
+
+        # 2) The stuck terminating pod re-emits a DELETED event later. Since
+        #    the node is already terminal DELETED, this must be a no-op and
+        #    must NOT stop the job (its replacement is already running).
+        reemit_node = Node(
+            NodeType.WORKER,
+            0,
+            NodeResource(1, 4096),
+            rank_index=0,
+            status=NodeStatus.DELETED,
+            name="test-worker-0",
+        )
+        manager._process_event(NodeEvent(NodeEventType.DELETED, reemit_node))
+
+        self.assertFalse(self.job_context.is_stopped())
+
     def test_handle_training_failure_truncates_large_error_data(self):
         params = MockK8sAllreduceJobArgs()
         params.initilize()


### PR DESCRIPTION
A no-heartbeat synthetic event (DistributedJobManager._get_dead_node_event) carries status=FAILED with event_type=DELETED, which the state machine resolves to the terminal DELETED status
  (RUNNING->DELETED). _process_event wrote the event's raw FAILED status to the node instead of the resolved DELETED, leaving the node in a non-terminal FAILED state while logging "Running to Deleted"
  (memory/log mismatch).

  For all-reduce jobs whose min_nodes_required == worker_num, this enables a spurious stop job: when the stuck terminating pod (e.g. node container runtime broken, pod stuck in Terminating) re-emits a
  DELETED event, the node transitions FAILED->DELETED (should_relaunch=False) and the get_worker_num()-1 < min_nodes_required check fires, stopping the whole job even though the worker had already been
  relaunched.

  Fix: when new_status == FAILED but status_change_flow.to_status == DELETED, persist the resolved terminal DELETED status. Minimal change scoped to this single divergence; all genuine K8s events keep
  identical behavior (new_status == to_status). With the node terminal DELETED, repeated DELETED events short-circuit in get_node_state_flow and no longer reach the stop check.

  What changes were proposed in this pull request?

  - In DistributedJobManager._process_event (dlrover/python/master/node/dist_job_manager.py), persist the state-machine-resolved terminal status instead of the event's raw status for the one case where
  they diverge:

  if (
      new_status == NodeStatus.FAILED
      and status_change_flow.to_status == NodeStatus.DELETED
  ):
      new_status = status_change_flow.to_status
  cur_node.update_status(new_status)

  - This only affects the no-heartbeat synthetic event (_get_dead_node_event, built with status=FAILED + event_type=DELETED, resolved by get_node_state_flow to RUNNING->DELETED). For every genuine K8s
  event new_status == status_change_flow.to_status, so behavior is unchanged.
  - Add regression test test_no_heartbeat_persists_terminal_deleted_status in dlrover/python/tests/test_job_manager.py.

  Why are the changes needed?

  For a fixed-size all-reduce job (min_nodes_required == worker_num), a single worker whose pod gets stuck in Terminating (e.g. the node's container runtime is broken, so kubelet cannot kill the
  containers for ~10+ minutes) triggers a spurious stop job, even though the worker was already relaunched.

  The failure chain:

  1. A worker loses heartbeat → _get_dead_node_event synthesizes a DELETED event with status=FAILED. The state machine resolves RUNNING->DELETED and relaunches a replacement worker (same rank_index, new
  id).
  2. _process_event persisted the raw FAILED (bug) instead of the resolved terminal DELETED, leaving the node non-terminal — while the log printed "Running to Deleted" (memory/log mismatch).
  3. Because the old pod is stuck in Terminating, K8s keeps re-emitting events; a later DELETED event drives the node FAILED->DELETED with should_relaunch=False.
  4. The all-reduce stop guard then fires:

  if self.get_worker_num() - 1 < self._worker_manager.get_min_nodes_required():
      job_ctx.request_stop(1, reason)   # e.g. 384 - 1 < 384 -> True

  4. and stops the entire job — even though the replacement worker is already running.

  The guard is correct in spirit (a non-replaceable worker loss should stop an all-reduce job), but its correctness relies on already-replaced workers not being re-processed. Leaving the node non-terminal
  breaks that assumption. Persisting terminal DELETED makes later re-emitted DELETED events no-ops (get_node_state_flow returns None), so the stop guard is never reached for an already-replaced worker.
  The node then behaves identically to a genuine pod-deletion event, and the relaunch/remove path is unaffected (_relaunch_node still force-appends the node to remove_nodes).

  Does this PR introduce any user-facing change?

  No. No config, CLI, or API change. The only behavioral change is that a no-heartbeat node is now recorded with the terminal DELETED status (consistent with genuine pod-deletion events) instead of
  lingering in the non-terminal FAILED status, which prevents the spurious stop job described above.

  How was this patch tested?

  - Added unit test test_no_heartbeat_persists_terminal_deleted_status — an all-reduce job with min_nodes == worker_num. It asserts:
    - a no-heartbeat synthetic event (FAILED + DELETED) persists the node as terminal DELETED (relaunch count 0 -> 1, relaunchable=False), and
    - a later re-emitted DELETED event does not stop the job.
  - Verified the test fails on the unpatched code (AssertionError: 'Failed' != 'Deleted') and passes with the fix.
  - Re-ran the related existing tests test_stop_job_when_insufficient_nodes_for_allreduce and test_relaunch_under_deleted_event — still green.
  - Pre-commit hooks (ruff check/ruff format, mypy, copyright header) pass.