### PR TITLE
Fix(master): don't stop all-reduce job when a live replacement exists

### DIFF
--- a/dlrover/python/master/node/dist_job_manager.py
+++ b/dlrover/python/master/node/dist_job_manager.py
@@ -296,6 +296,43 @@ class DistributedJobManager(JobManager):
             == DistributionStrategy.ALLREDUCE
         )
 
+    def _has_live_replacement(self, node: Node) -> bool:
+        """Whether another worker of the same rank is still alive or
+        coming up.
+
+        When a worker has already been relaunched, the trailing
+        ``FAILED -> DELETED`` event of its old pod must not stop an
+        all-reduce job, because the rank is still served by the
+        replacement. This is especially needed when the replacement pod
+        is not running yet (the scaler has not created it), so the
+        top-of-_process_event skip guard -- which queries K8s pods --
+        cannot see it. Here we look at the replacement node already
+        tracked in the job context for the same ``rank_index`` in a live
+        state (``INITIAL``/``PENDING``/``RUNNING``).
+        """
+        if node.type != NodeType.WORKER:
+            return False
+        live_states = {
+            NodeStatus.INITIAL,
+            NodeStatus.PENDING,
+            NodeStatus.RUNNING,
+        }
+        workers = self._job_context.dup_job_nodes_by_type(node.type)
+        for wid, worker in workers.items():
+            if wid == node.id:
+                continue
+            if (
+                worker.rank_index == node.rank_index
+                and worker.status in live_states
+            ):
+                logger.info(
+                    f"Skip stopping the job for {node.name} since a "
+                    f"live replacement {worker.name} (rank "
+                    f"{worker.rank_index}) already exists."
+                )
+                return True
+        return False
+
     def restart(self):
         if not self.is_all_reduce_type_job():
             logger.warning(
@@ -958,11 +995,18 @@ class DistributedJobManager(JobManager):
         if should_relaunch:
             self._relaunch_node(cur_node)
         elif new_status in [NodeStatus.FAILED, NodeStatus.DELETED]:
-            # stop if min rdzv nodes are not enough for all-reduce
+            # stop if min rdzv nodes are not enough for all-reduce. A node
+            # that has already been relaunched still owns a live replacement
+            # for its rank, so its trailing FAILED/DELETED event must not
+            # stop the whole job.
             if self.is_all_reduce_type_job():
-                if self._worker_manager.get_min_nodes_required() > 0 and (
-                    self.get_worker_num() - 1
-                    < self._worker_manager.get_min_nodes_required()
+                if (
+                    self._worker_manager.get_min_nodes_required() > 0
+                    and (
+                        self.get_worker_num() - 1
+                        < self._worker_manager.get_min_nodes_required()
+                    )
+                    and not self._has_live_replacement(cur_node)
                 ):
                     reason = f"Stop job because there isn't enough nodes available as {cur_node.name} can't be relaunch anymore."
                     logger.warning(reason)

--- a/dlrover/python/tests/test_job_manager.py
+++ b/dlrover/python/tests/test_job_manager.py
@@ -1579,6 +1579,94 @@ class DistributedJobManagerTest(unittest.TestCase):
 
         self.assertFalse(self.job_context.is_stopped())
 
+    def test_allreduce_not_stopped_when_replacement_pending(self):
+        """Regression: a failed worker that has already been relaunched
+        must not stop an all-reduce job when its old pod's trailing
+        FAILED->DELETED event arrives.
+
+        This mirrors the incident where a worker crashed (RUNNING->FAILED
+        via a genuine K8s MODIFIED event, relaunch decided) and then the
+        old crashed pod's deletion (FAILED->DELETED via MODIFIED) arrived
+        before the replacement pod was running. The top-of-_process_event
+        skip guard cannot help here because it queries K8s pods and the
+        replacement pod is not up yet; the all-reduce stop check must
+        instead see the replacement node already tracked in the job
+        context and skip the stop.
+        """
+        params = MockK8sAllreduceJobArgs()
+        params.initilize(worker_count=4)
+        manager = create_job_manager(params, PerfMonitor())
+        manager._init_nodes()
+        manager._scaler.scale = mock.MagicMock(return_value=None)
+        # No K8s pod for the replacement yet: the race window in which the
+        # top skip guard (which queries K8s pods) cannot find a running
+        # replacement pod.
+        manager._k8s_client.list_namespaced_pod = mock.MagicMock(
+            return_value=[]
+        )
+        # Fixed-size all-reduce world: min_nodes == worker_num, so losing
+        # one non-relaunchable worker with no replacement must stop the job.
+        manager._worker_manager.update_node_required_info((4, 4, 300))
+
+        worker0 = self.job_context.job_nodes()[NodeType.WORKER][0]
+        worker0.status = NodeStatus.RUNNING
+        worker0.relaunch_count = 0
+        self.job_context.update_job_node(worker0)
+
+        # The crash carries exit_reason "Error" (== FATAL_ERROR); the job
+        # is configured to relaunch fatal errors, so the worker relaunches.
+        old_relaunch_always = _dlrover_context.relaunch_always
+        _dlrover_context.relaunch_always = True
+        try:
+            # 1) worker-0 crashes: RUNNING -> FAILED (genuine K8s MODIFIED),
+            #    relaunch is decided and the replacement node is registered.
+            failed_node = Node(
+                NodeType.WORKER,
+                0,
+                NodeResource(1, 4096),
+                rank_index=0,
+                status=NodeStatus.FAILED,
+                name="test-worker-0",
+            )
+            failed_node.exit_reason = NodeExitReason.FATAL_ERROR
+            manager._process_event(
+                NodeEvent(NodeEventType.MODIFIED, failed_node)
+            )
+        finally:
+            _dlrover_context.relaunch_always = old_relaunch_always
+
+        # The replacement (rank 0) is now tracked, still INITIAL/PENDING,
+        # and worker-0 has been relaunched (count 0 -> 1).
+        persisted = self.job_context.job_nodes()[NodeType.WORKER][0]
+        self.assertEqual(persisted.relaunch_count, 1)
+        replacements = [
+            w
+            for wid, w in (manager.get_job_nodes()[NodeType.WORKER].items())
+            if wid != 0 and w.rank_index == 0
+        ]
+        self.assertTrue(replacements)
+        self.assertIn(
+            replacements[0].status,
+            [NodeStatus.INITIAL, NodeStatus.PENDING, NodeStatus.RUNNING],
+        )
+        self.assertFalse(self.job_context.is_stopped())
+
+        # 2) The old crashed pod's deletion arrives (FAILED -> DELETED via
+        #    MODIFIED) while the replacement pod is still not running. The
+        #    job must NOT stop, because the rank is still covered.
+        deleted_node = Node(
+            NodeType.WORKER,
+            0,
+            NodeResource(1, 4096),
+            rank_index=0,
+            status=NodeStatus.DELETED,
+            name="test-worker-0",
+        )
+        deleted_node.exit_reason = NodeExitReason.FATAL_ERROR
+        manager._process_event(NodeEvent(NodeEventType.MODIFIED, deleted_node))
+
+        self.assertFalse(self.job_context.is_stopped())
+
     def test_handle_training_failure_truncates_large_error_data(self):
         params = MockK8sAllreduceJobArgs()
         params.initilize()


### PR DESCRIPTION
For an all-reduce job whose min_nodes_required == worker_num, any worker that becomes non-relaunchable and reaches FAILED/DELETED stops the whole job (dist_job_manager stop check: get_worker_num()-1 <
  min_nodes_required). A worker that already failed and was relaunched still triggers this stop when its OLD pod's trailing FAILED -> DELETED event arrives — even though its replacement is already (or
  about to be) running.

  This is the genuine-K8s variant of the spurious stop that 7591f1f8 (#1734) targeted; 7591f1f8 only covered the no-heartbeat synthetic event (new_status==FAILED, event_type==DELETED) and never matched
  the real FAILED -> DELETED-via-MODIFIED path seen in production: worker-0 went Running -> Failed (relaunch decided) and then Failed -> Deleted by event MODIFIED, which stopped the job before the
  replacement pod came up.

  The top-of-_process_event skip guard could not help in the race: it queries K8s pods, and the replacement pod was not running yet. The fix targets the stop check instead — skip the all-reduce stop when
  the node already has a live same-rank replacement tracked in the job context, so a relaunched worker's trailing deletion does not stop the job while the replacement is still coming up. A rank with no
  live replacement still stops the job as before.

  A regression test reproduces the incident sequence (RUNNING -> FAILED via MODIFIED with relaunch, then FAILED -> DELETED via MODIFIED, no K8s replacement pod yet → job must not stop). The existing
  test_stop_job_when_insufficient_nodes_for_allreduce (no replacement → stop) still passes, confirming legitimate stops are not suppressed.

  What changes were proposed in this pull request?

  Skip the all-reduce "stop job due to insufficient nodes" check when the failed/deleted worker already has a live same-rank replacement tracked in the job context.

  - Add DistributedJobManager._has_live_replacement(node) — returns True when another worker with the same rank_index is in INITIAL/PENDING/RUNNING.
  - Gate the all-reduce stop check at _process_event on not self._has_live_replacement(cur_node), so a relaunched worker's stale FAILED → DELETED event does not stop the job while the replacement is still
  coming up. A rank with no live replacement still stops the job as before.
  - #1734 (7591f1f8) is left untouched; it remains a complementary defense for the no-heartbeat synthetic-event path.

  Why are the changes needed?

  For an all-reduce job whose min_nodes_required == worker_num, any worker that becomes non-relaunchable and reaches FAILED/DELETED stops the whole job (the check get_worker_num() - 1 < min_nodes_required
  is always true). That is intended for a permanently lost rank. But a worker that already failed and was already relaunched still triggers this stop when its old pod's trailing FAILED → DELETED event
  arrives — even though its replacement is already (or about to be) running. This spuriously kills the job on a transient event for a rank that is in fact still covered.

  The production sequence (genuine-K8s path, via MODIFIED events) was:

  worker-0: Running -> Failed   (event MODIFIED; relaunch decided -> replacement registered)
  worker-0: Failed  -> Deleted  (event MODIFIED; old crashed pod cleaned up)  => STOP JOB

  The top-of-_process_event "skip deleted event if a replacement pod is running" guard could not help in this race: it queries the K8s API for a running pod, and the replacement pod was not running yet
  when the old pod's deletion event arrived (the scaler had not created it). The fix targets the stop check itself, looking at the replacement node already tracked in the job context.

  Does this PR introduce any user-facing change?

  Yes — a behavior fix. All-reduce jobs that previously stopped with the reason Stop job because there isn't enough nodes available as <worker> can't be relaunch anymore. (because of a relaunched worker's
  trailing deletion event) now keep running while the replacement comes up. Jobs that genuinely lose a rank with no live replacement still stop as before.

  How was this patch tested?

  - New regression test test_allreduce_not_stopped_when_replacement_pending reproducing the incident sequence: RUNNING → FAILED via MODIFIED (relaunch registers a replacement), then FAILED → DELETED via
  MODIFIED while the replacement pod is not yet running (K8s pod list mocked empty) — asserts the job is not stopped.
  - Existing test_stop_job_when_insufficient_nodes_for_allreduce (no replacement → stop) still passes, confirming legitimate stops are not suppressed.
  - test_no_heartbeat_persists_terminal_deleted_status (#1734) still passes; #1734 remains complementary for the no-heartbeat path.
  - Full dlrover/python/tests/test_job_manager.py run: only pre-existing, order-dependent suite failures remain (unrelated to this change; present on unmodified master). The change adds one passing test
  and introduces no new failures.
  - Pre-commit: ruff check, ruff format, mypy, and the copyright-header check all pass.