### PR TITLE
Feat(master): record nodecheck-failed node host IP before relaunch

### DIFF
--- a/dlrover/python/master/node/dist_job_manager.py
+++ b/dlrover/python/master/node/dist_job_manager.py
@@ -1175,6 +1175,15 @@ class DistributedJobManager(JobManager):
         return should_relaunch
 
     def _relaunch_node(self, node: Node):
+        # Record the host IP of a nodecheck-failed node before relaunching,
+        # so that the relaunch pod (and later pods) get scheduled away from
+        # it via node affinity in the scaler.
+        if node.exit_reason == NodeExitReason.CHECK_FAIL and node.host_ip:
+            self._scaler.add_failed_node_ip(node.host_ip)
+            logger.info(
+                f"Record nodecheck-failed node {node.name} with host IP "
+                f"{node.host_ip} to avoid relaunching onto it."
+            )
         if node.type == NodeType.WORKER:
             plan = self._worker_manager.relaunch_node(
                 node, self._remove_exited_node

--- a/dlrover/python/master/scaler/base_scaler.py
+++ b/dlrover/python/master/scaler/base_scaler.py
@@ -11,6 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import threading
 from abc import ABCMeta, abstractmethod
 from typing import Dict, List
 
@@ -56,6 +57,11 @@ class Scaler(metaclass=ABCMeta):
         self._job_name = job_name
         self._job = None
         self._job_uid = ""
+        # Host IPs of nodes that failed node check. Pods created afterward
+        # can be scheduled away from these nodes via node affinity by scalers
+        # that support it (e.g. the sigma PodScaler in dlrover-addon).
+        self._failed_node_ips = set()
+        self._failed_node_lock = threading.Lock()
 
     @abstractmethod
     def start(self):
@@ -66,6 +72,23 @@ class Scaler(metaclass=ABCMeta):
     def scale(self, plan: ScalePlan, **kwargs):
         """Scale the job with the plan."""
         pass
+
+    def add_failed_node_ip(self, host_ip: str):
+        """Record the host IP of a nodecheck-failed node.
+
+        Subsequent pod creations should avoid being scheduled onto this
+        node. The affinity injection is scaler-specific and implemented by
+        subclasses; the base scaler only keeps the accumulated list.
+        """
+        if not host_ip:
+            return
+        with self._failed_node_lock:
+            self._failed_node_ips.add(host_ip)
+
+    def get_failed_node_ips(self):
+        """Return the sorted list of failed node host IPs."""
+        with self._failed_node_lock:
+            return sorted(self._failed_node_ips)
 
     def set_group_affinity(self, group_affinity):
         """Set the node group affinity mapping for the scaler.

--- a/dlrover/python/tests/test_base_scaler.py
+++ b/dlrover/python/tests/test_base_scaler.py
@@ -1,0 +1,56 @@
+# Copyright 2026 The DLRover Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from dlrover.python.master.scaler.base_scaler import Scaler
+
+
+class _StubScaler(Scaler):
+    """Minimal concrete Scaler for base-class unit testing."""
+
+    def start(self):
+        pass
+
+    def scale(self, plan, **kwargs):
+        pass
+
+
+class ScalerFailedNodeIPTest(unittest.TestCase):
+    def setUp(self):
+        self._scaler = _StubScaler("test-job")
+
+    def test_get_failed_node_ips_empty_initially(self):
+        self.assertEqual(self._scaler.get_failed_node_ips(), [])
+
+    def test_add_failed_node_ip_records_and_dedupes(self):
+        self._scaler.add_failed_node_ip("10.0.0.2")
+        self._scaler.add_failed_node_ip("10.0.0.1")
+        self._scaler.add_failed_node_ip("10.0.0.1")
+
+        # Duplicates are dropped and the result is sorted.
+        self.assertEqual(
+            self._scaler.get_failed_node_ips(), ["10.0.0.1", "10.0.0.2"]
+        )
+
+    def test_add_failed_node_ip_ignores_empty_and_none(self):
+        self._scaler.add_failed_node_ip("10.0.0.1")
+        self._scaler.add_failed_node_ip("")
+        self._scaler.add_failed_node_ip(None)
+
+        # Only the non-empty IP is recorded.
+        self.assertEqual(self._scaler.get_failed_node_ips(), ["10.0.0.1"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/dlrover/python/tests/test_job_manager.py
+++ b/dlrover/python/tests/test_job_manager.py
@@ -79,6 +79,7 @@ from dlrover.python.master.node.training_node import (
     update_nodes_priority,
 )
 from dlrover.python.master.resource.job import JobResource
+from dlrover.python.master.scaler.base_scaler import ScalePlan
 from dlrover.python.master.watcher.base_watcher import Node
 from dlrover.python.scheduler.job import LocalJobArgs
 from dlrover.python.tests.test_utils import (
@@ -458,6 +459,42 @@ class DistributedJobManagerTest(unittest.TestCase):
 
         node.exit_reason = NodeExitReason.RELAUNCHED
         self.assertFalse(manager._should_relaunch(node, NODE_STATE_FLOWS[6]))
+
+    def test_relaunch_node_records_failed_node_ip(self):
+        params = MockK8sPSJobArgs()
+        params.initilize()
+        manager = create_job_manager(params, PerfMonitor())
+        manager._worker_manager.relaunch_node = MagicMock(
+            return_value=ScalePlan()
+        )
+        manager._scaler = MagicMock()
+
+        node = Node(
+            node_type=NodeType.WORKER,
+            node_id=1,
+            status=NodeStatus.RUNNING,
+            config_resource=NodeResource(1, 4096),
+            max_relaunch_count=1,
+        )
+
+        # A nodecheck-failed node records its host IP before relaunch.
+        node.exit_reason = NodeExitReason.CHECK_FAIL
+        node.host_ip = "10.0.0.1"
+        manager._relaunch_node(node)
+        manager._scaler.add_failed_node_ip.assert_called_once_with("10.0.0.1")
+
+        # Other exit reasons must not record the host IP.
+        manager._scaler.add_failed_node_ip.reset_mock()
+        node.exit_reason = NodeExitReason.HARDWARE_ERROR
+        manager._relaunch_node(node)
+        manager._scaler.add_failed_node_ip.assert_not_called()
+
+        # A nodecheck failure without a host IP is skipped.
+        manager._scaler.add_failed_node_ip.reset_mock()
+        node.exit_reason = NodeExitReason.CHECK_FAIL
+        node.host_ip = ""
+        manager._relaunch_node(node)
+        manager._scaler.add_failed_node_ip.assert_not_called()
 
     def test_relaunch_node_group(self):
         params = MockK8sAllreduceJobArgs()


### PR DESCRIPTION
## Motivation
  When a node fails the network/node check, the elastic agent reports
  `NodeExitReason.CHECK_FAIL` and the master relaunches it. Today nothing
  prevents the replacement pod (or later pods) from being scheduled back
  onto the same bad physical machine. We want subsequent pods to avoid
  nodecheck-failed nodes via node affinity.

  ## What this changes (upstream side, scheduler-agnostic)
  - `dist_job_manager._relaunch_node`: right before producing the
    replacement pod, if `node.exit_reason == NodeExitReason.CHECK_FAIL` and
    `node.host_ip` is set, record the host IP on the scaler.
    (`node.host_ip` comes from `pod.status.hostIP` via the k8s watcher; on
    hostNetwork pods it equals the physical machine IP.)
  - `Scaler` (base_scaler): owns the accumulated failed-node-IP set plus
    thread-safe `add_failed_node_ip()` / `get_failed_node_ips()`. The base
    scaler is kept free of any scheduler-specific label.

  Only `CHECK_FAIL` relaunches are recorded; OOM / hardware-error / etc. are
  unaffected.

  ## Test
  Adds `test_relaunch_node_records_failed_node_ip` covering:
  - CHECK_FAIL node records its host IP and relaunch still proceeds;
  - non-CHECK_FAIL exit reasons do not record;
  - CHECK_FAIL without a host IP is skipped.