### PR TITLE
Update worker error msg size to 8k

### DIFF
--- a/dlrover/python/common/constants.py
+++ b/dlrover/python/common/constants.py
@@ -455,6 +455,9 @@ class CheckpointConstant(object):
 
 
 class JobConstant(object):
+    # Maximum number of characters retained in a reported training failure.
+    MAX_ERROR_DATA_LEN = 8 * 1024
+
     RDZV_JOIN_TIMEOUT_DEFAULT = 600
     INSUFFICIENT_NODE_TIMEOUT_DEFAULT_MIN = 600
     INSUFFICIENT_NODE_TIMEOUT_DEFAULT_MAX = 3600

--- a/dlrover/python/elastic_agent/master_client.py
+++ b/dlrover/python/elastic_agent/master_client.py
@@ -42,11 +42,6 @@ from dlrover.python.diagnosis.common.diagnosis_data import DiagnosisData
 from dlrover.python.util.common_util import find_free_port
 from dlrover.python.util.function_util import retry
 
-# Truncate error payloads before sending to the master to prevent the master
-# from allocating large gRPC receive buffers and accumulating data in Node
-# objects across relaunches.
-_MAX_ERROR_DATA_LEN = 8 * 1024
-
 
 class MasterClient(Singleton, ABC):
     """MasterClient provides some APIs connect with the master
@@ -459,9 +454,9 @@ class MasterClient(Singleton, ABC):
     def report_failures(self, error_data, restart_count=-1, level=""):
         if (
             isinstance(error_data, str)
-            and len(error_data) > _MAX_ERROR_DATA_LEN
+            and len(error_data) > JobConstant.MAX_ERROR_DATA_LEN
         ):
-            error_data = error_data[:_MAX_ERROR_DATA_LEN]
+            error_data = error_data[: JobConstant.MAX_ERROR_DATA_LEN]
         message = comm.NodeFailure(error_data, restart_count, level)
         self._report(message)
 

--- a/dlrover/python/elastic_agent/master_client.py
+++ b/dlrover/python/elastic_agent/master_client.py
@@ -45,7 +45,7 @@ from dlrover.python.util.function_util import retry
 # Truncate error payloads before sending to the master to prevent the master
 # from allocating large gRPC receive buffers and accumulating data in Node
 # objects across relaunches.
-_MAX_ERROR_DATA_LEN = 2048
+_MAX_ERROR_DATA_LEN = 8 * 1024
 
 
 class MasterClient(Singleton, ABC):

--- a/dlrover/python/master/node/dist_job_manager.py
+++ b/dlrover/python/master/node/dist_job_manager.py
@@ -95,7 +95,7 @@ _MAX_POD_RELAUNCH_COUNT = 5
 # Node.exit_reason (which is deep-copied into _job_nodes on every update)
 # causes unbounded master RSS growth across relaunches.  Truncate early so
 # the large string is released as soon as handle_training_failure returns.
-_MAX_ERROR_DATA_LEN = 2048
+_MAX_ERROR_DATA_LEN = 8 * 1024
 
 
 def is_positive_exit(exit_reason):

--- a/dlrover/python/master/node/dist_job_manager.py
+++ b/dlrover/python/master/node/dist_job_manager.py
@@ -25,6 +25,7 @@ from dlrover.python.common.constants import (
     DistributionStrategy,
     ElasticJobLabel,
     EventReportConstants,
+    JobConstant,
     JobExitReason,
     JobStage,
     NodeEventType,
@@ -91,11 +92,6 @@ _master_evt = DLRoverMasterEvent().singleton_instance()
 job_ctx = get_job_context()
 
 _MAX_POD_RELAUNCH_COUNT = 5
-# Worker error dumps can be arbitrarily large. Storing the full payload in
-# Node.exit_reason (which is deep-copied into _job_nodes on every update)
-# causes unbounded master RSS growth across relaunches.  Truncate early so
-# the large string is released as soon as handle_training_failure returns.
-_MAX_ERROR_DATA_LEN = 8 * 1024
 
 
 def is_positive_exit(exit_reason):
@@ -1533,8 +1529,8 @@ class DistributedJobManager(JobManager):
         """Process the training failure reported by the node."""
         node = self._job_context.job_node(node_type, node_id)
 
-        if error_data and len(error_data) > _MAX_ERROR_DATA_LEN:
-            error_data = error_data[:_MAX_ERROR_DATA_LEN]
+        if error_data and len(error_data) > JobConstant.MAX_ERROR_DATA_LEN:
+            error_data = error_data[: JobConstant.MAX_ERROR_DATA_LEN]
 
         if error_data:
             # self detected reason override the reason from k8s pod

--- a/dlrover/python/tests/test_job_manager.py
+++ b/dlrover/python/tests/test_job_manager.py
@@ -1725,6 +1725,7 @@ class DistributedJobManagerTest(unittest.TestCase):
             _MAX_ERROR_DATA_LEN,
         )
 
+        self.assertEqual(_MAX_ERROR_DATA_LEN, 8 * 1024)
         self.assertLessEqual(len(node.exit_reason), _MAX_ERROR_DATA_LEN)
         self.assertEqual(node.exit_reason, large_payload[:_MAX_ERROR_DATA_LEN])
 

--- a/dlrover/python/tests/test_job_manager.py
+++ b/dlrover/python/tests/test_job_manager.py
@@ -33,6 +33,7 @@ from dlrover.python.common.comm import (
 from dlrover.python.common.constants import (
     DistributionStrategy,
     ElasticJobLabel,
+    JobConstant,
     JobExitReason,
     JobStage,
     NodeEventType,
@@ -1721,13 +1722,14 @@ class DistributedJobManagerTest(unittest.TestCase):
         )
 
         node = self.job_context.job_node(NodeType.WORKER, 0)
-        from dlrover.python.master.node.dist_job_manager import (
-            _MAX_ERROR_DATA_LEN,
+        self.assertEqual(JobConstant.MAX_ERROR_DATA_LEN, 8 * 1024)
+        self.assertLessEqual(
+            len(node.exit_reason), JobConstant.MAX_ERROR_DATA_LEN
         )
-
-        self.assertEqual(_MAX_ERROR_DATA_LEN, 8 * 1024)
-        self.assertLessEqual(len(node.exit_reason), _MAX_ERROR_DATA_LEN)
-        self.assertEqual(node.exit_reason, large_payload[:_MAX_ERROR_DATA_LEN])
+        self.assertEqual(
+            node.exit_reason,
+            large_payload[: JobConstant.MAX_ERROR_DATA_LEN],
+        )
 
 
 class JobContextTest(unittest.TestCase):

--- a/dlrover/python/tests/test_master_client.py
+++ b/dlrover/python/tests/test_master_client.py
@@ -30,6 +30,7 @@ from dlrover.python.common.comm import (
 )
 from dlrover.python.common.constants import (
     CommunicationType,
+    JobConstant,
     NodeEnv,
     NodeEventType,
     NodeType,
@@ -93,11 +94,7 @@ class MasterClientTest(unittest.TestCase):
         self.assertIsNone(res)
 
     def test_report_failures_truncates_large_error_data(self):
-        from dlrover.python.elastic_agent.master_client import (
-            _MAX_ERROR_DATA_LEN,
-        )
-
-        self.assertEqual(_MAX_ERROR_DATA_LEN, 8 * 1024)
+        self.assertEqual(JobConstant.MAX_ERROR_DATA_LEN, 8 * 1024)
         large_payload = "X" * (10 * 1024 * 1024)  # 10 MB
 
         sent_messages = []
@@ -116,10 +113,12 @@ class MasterClientTest(unittest.TestCase):
 
         self.assertEqual(len(sent_messages), 1)
         self.assertLessEqual(
-            len(sent_messages[0].error_data), _MAX_ERROR_DATA_LEN
+            len(sent_messages[0].error_data),
+            JobConstant.MAX_ERROR_DATA_LEN,
         )
         self.assertEqual(
-            sent_messages[0].error_data, large_payload[:_MAX_ERROR_DATA_LEN]
+            sent_messages[0].error_data,
+            large_payload[: JobConstant.MAX_ERROR_DATA_LEN],
         )
 
     def test_ready_for_ps_relaunch(self):

--- a/dlrover/python/tests/test_master_client.py
+++ b/dlrover/python/tests/test_master_client.py
@@ -97,6 +97,7 @@ class MasterClientTest(unittest.TestCase):
             _MAX_ERROR_DATA_LEN,
         )
 
+        self.assertEqual(_MAX_ERROR_DATA_LEN, 8 * 1024)
         large_payload = "X" * (10 * 1024 * 1024)  # 10 MB
 
         sent_messages = []


### PR DESCRIPTION
### What changes were proposed in this pull request?

Reset the error message size from 1k to 8k.

### Why are the changes needed?

Previously, we found when many workers failed during a short time period, those workers will report error messages to the master. It may end up with master oom. We limit the error message size to 1k to avoid this problem. However, 1k may miss some important error information. So we set it to be 8k now.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

Unit test.