### PR TITLE
Feat(master): ep_pp_dp node-group scheduling for MoE segment placement

### DIFF
--- a/dlrover/python/common/constants.py
+++ b/dlrover/python/common/constants.py
@@ -582,3 +582,22 @@ class KeyValueOps(object):
     GET = "get"
     SET = "set"
     DELETE = "delete"
+
+
+class NodeGroupStrategy(object):
+    """Strategy used to map worker nodes (ranked by creation order) into
+    node groups. A node group corresponds to a physical scheduling segment,
+    e.g. a super-node, where intra-group latency is much lower than
+    cross-group latency.
+
+    - CONTIGUOUS: the default. Groups are laid out as contiguous rank-index
+      ranges, in ascending group-id order, sized by ``group_affinity``.
+    - EP_PP_DP: designed for Megatron MoE (ep-dp-pp rank order, TP=CP=1).
+      Each pipeline stage is striped across all groups/segments so that EP
+      groups and PP stay intra-segment while only the dense DP collective
+      crosses segments. See ``resolve_group_id`` / ``validate_topology`` in
+      ``dlrover.python.master.resource.job``.
+    """
+
+    CONTIGUOUS = "contiguous"
+    EP_PP_DP = "ep_pp_dp"

--- a/dlrover/python/master/args.py
+++ b/dlrover/python/master/args.py
@@ -153,6 +153,56 @@ def _build_master_args_parser():
         "replicas in the ElasticJob CRD must equal the sum of all group "
         "sizes, otherwise the master fails to start.",
     )
+    parser.add_argument(
+        "--node-group-strategy",
+        "--node_group_strategy",
+        default="contiguous",
+        choices=["contiguous", "ep_pp_dp"],
+        help="Strategy used to map worker nodes (by creation order) into "
+        "node groups (== physical segments). 'contiguous' (default) keeps "
+        "the existing behavior: groups occupy contiguous rank ranges. "
+        "'ep_pp_dp' stripes one Megatron MoE pipeline stage across all "
+        "groups so EP groups and PP stay intra-segment while only the dense "
+        "DP collective crosses segments. Requires TP=1 and CP=1 and a "
+        "validated parallel topology (see --tp/--pp/--ep/--cp). When unset "
+        "or 'contiguous', the parallel sizes below are ignored.",
+    )
+    parser.add_argument(
+        "--tensor-model-parallel-size",
+        "--tensor_model_parallel_size",
+        "--tp",
+        default=1,
+        type=pos_int,
+        help="Tensor-parallel size. Only consulted (and required to be 1) "
+        "when --node-group-strategy=ep_pp_dp.",
+    )
+    parser.add_argument(
+        "--pipeline-model-parallel-size",
+        "--pipeline_model_parallel_size",
+        "--pp",
+        default=1,
+        type=pos_int,
+        help="Pipeline-parallel size. Consulted when "
+        "--node-group-strategy=ep_pp_dp.",
+    )
+    parser.add_argument(
+        "--expert-model-parallel-size",
+        "--expert_model_parallel_size",
+        "--ep",
+        default=1,
+        type=pos_int,
+        help="Expert-parallel size (EP group size). Consulted when "
+        "--node-group-strategy=ep_pp_dp.",
+    )
+    parser.add_argument(
+        "--context-parallel-size",
+        "--context_parallel_size",
+        "--cp",
+        default=1,
+        type=pos_int,
+        help="Context-parallel size. Only consulted (and required to be 1) "
+        "when --node-group-strategy=ep_pp_dp.",
+    )
     return parser
 
 

--- a/dlrover/python/master/elastic_training/rdzv_manager.py
+++ b/dlrover/python/master/elastic_training/rdzv_manager.py
@@ -525,13 +525,43 @@ class ElasticTrainingRendezvousManager(RendezvousManager):
                     ranks = list(self._rdzv_nodes.keys())
                     node_ips = []
                     node_ids = []
-                    for node_rank in ranks:
+                    world_parts = []
+                    for position, node_rank in enumerate(ranks):
                         node = self._rdzv_nodes[node_rank]
                         node_ips.append(node.node_ip)
                         node_ids.append(node.node_id)
+                        job_node = job_ctx.job_node(
+                            NodeType.WORKER, node.node_id
+                        )
+                        group = job_node.group_id if job_node else None
+                        world_parts.append(
+                            f"pos={position},rank={node_rank},"
+                            f"id={node.node_id},ip={node.node_ip},"
+                            f"nproc={node.process_num},group={group}"
+                        )
                     logger.info(
                         f"Node ids are {node_ids}.\n Node IPs are {node_ips}"
                     )
+                    mismatched = [
+                        f"pos={position}->rank={rank}"
+                        for position, rank in enumerate(ranks)
+                        if position != rank
+                    ]
+                    if mismatched:
+                        logger.warning(
+                            f"{len(mismatched)} rendezvous world ranks "
+                            "diverge from positions (topology sort or "
+                            "elastic compression); first: "
+                            f"{', '.join(mismatched[:10])}"
+                        )
+                    for i in range(0, len(world_parts), 40):
+                        logger.info(
+                            "World [%d-%d/%d]: %s",
+                            i + 1,
+                            min(i + 40, len(world_parts)),
+                            len(world_parts),
+                            "; ".join(world_parts[i : i + 40]),
+                        )
                     node_elapsed_time = time.time() - self._lastcall_time
 
                     if finished_rdzv_round in self.rendezvous_events.keys():

--- a/dlrover/python/master/main.py
+++ b/dlrover/python/master/main.py
@@ -88,6 +88,11 @@ def run(args):
 
     job_args.training_elastic_mode = args.training_elastic_mode
     job_args.group_affinity = args.group_affinity
+    job_args.node_group_strategy = args.node_group_strategy
+    job_args.tensor_model_parallel_size = args.tensor_model_parallel_size
+    job_args.pipeline_model_parallel_size = args.pipeline_model_parallel_size
+    job_args.expert_model_parallel_size = args.expert_model_parallel_size
+    job_args.context_parallel_size = args.context_parallel_size
     if args.xpu_type.lower() == "ascend":
         job_args.xpu_type = Accelerators.ASCEND_NPU
     elif args.xpu_type.lower() == "nvidia":

--- a/dlrover/python/master/node/dist_job_manager.py
+++ b/dlrover/python/master/node/dist_job_manager.py
@@ -31,6 +31,7 @@ from dlrover.python.common.constants import (
     NodeEventType,
     NodeExitReason,
     NodeResourceLimit,
+    NodeGroupStrategy,
     NodeStatus,
     NodeType,
     TrainingExceptionLevel,
@@ -73,7 +74,9 @@ from dlrover.python.master.node.worker import (
 from dlrover.python.master.resource.job import (
     AllreduceJobResourceOptimizer,
     JobResourceOptimizer,
+    NodeGroupSchedule,
     PSJobResourceOptimizer,
+    validate_topology,
 )
 from dlrover.python.master.scaler.base_scaler import ScalePlan, Scaler
 from dlrover.python.master.scaler.factory import new_job_scaler
@@ -197,9 +200,13 @@ class DistributedJobManager(JobManager):
         )
         self._scaler: Scaler = job_scaler
         # _init_group_affinity (above) has already applied --group-affinity
-        # onto self._job_resource; forward it to the scaler so newly created
-        # pods can be labeled with their node group.
+        # (and the optional ep_pp_dp node-group schedule) onto
+        # self._job_resource; forward them to the scaler so newly created
+        # pods can be labeled with their node group via the right strategy.
         self._scaler.set_group_affinity(self._job_resource.group_affinity)
+        self._scaler.set_node_group_schedule(
+            self._job_resource.node_group_schedule
+        )
         self._init_training_node_manager()
         self._relaunched_groups: List[int] = []
         self._group_relaunch_count = 0
@@ -213,8 +220,25 @@ class DistributedJobManager(JobManager):
         master fails to start otherwise. On success the mapping is forwarded
         to the ``JobResource`` so that worker nodes are partitioned into the
         configured node groups.
+
+        When ``node_group_strategy == ep_pp_dp`` the parallel topology is
+        additionally validated via :func:`validate_topology` and a
+        :class:`NodeGroupSchedule` is attached to the ``JobResource`` so that
+        the scaler stripes pipeline stages across segments (EP/PP
+        intra-segment, DP cross-segment). The parallel sizes are read from
+        ``job_args``; when the strategy is unset or ``contiguous`` they are
+        ignored, preserving the existing behavior.
         """
+        strategy = getattr(
+            job_args, "node_group_strategy", NodeGroupStrategy.CONTIGUOUS
+        )
+        ep_pp_dp = strategy == NodeGroupStrategy.EP_PP_DP
         if not job_args.group_affinity:
+            if ep_pp_dp:
+                raise ValueError(
+                    "node-group-strategy=ep_pp_dp requires --group-affinity "
+                    "to be set (groups == physical segments)."
+                )
             return
         worker_resource = self._job_resource.node_group_resources.get(
             NodeType.WORKER
@@ -226,6 +250,29 @@ class DistributedJobManager(JobManager):
                 f"--group-affinity requires worker replicas={expected}, "
                 f"but got CRD worker replicas={worker_count}"
             )
+
+        # For ep_pp_dp, validate the full parallel topology BEFORE mutating any
+        # JobResource state so a violation leaves the resource untouched and
+        # the master fails to start cleanly.
+        schedule = None
+        if ep_pp_dp:
+            ranks_per_node = (
+                worker_resource.node_resource.gpu_num
+                if worker_resource is not None
+                and worker_resource.node_resource is not None
+                else 0
+            )
+            schedule = NodeGroupSchedule(
+                strategy=NodeGroupStrategy.EP_PP_DP,
+                tp=getattr(job_args, "tensor_model_parallel_size", 1),
+                pp=getattr(job_args, "pipeline_model_parallel_size", 1),
+                ep=getattr(job_args, "expert_model_parallel_size", 1),
+                cp=getattr(job_args, "context_parallel_size", 1),
+                num_nodes=worker_count,
+                ranks_per_node=ranks_per_node,
+            )
+            validate_topology(job_args.group_affinity, schedule)
+
         self._job_resource.group_affinity = job_args.group_affinity
         logger.info(
             "Enable node group affinity: %s (total %d groups, %d workers)",
@@ -233,6 +280,23 @@ class DistributedJobManager(JobManager):
             len(job_args.group_affinity),
             expected,
         )
+
+        if schedule is not None:
+            self._job_resource.node_group_schedule = schedule
+            logger.info(
+                "Enable ep_pp_dp node-group schedule "
+                "(tp=%d, pp=%d, ep=%d, cp=%d, N=%d, R=%d, G=%d): "
+                "each pipeline stage striped across %d segments "
+                "(EP/PP intra-segment, DP cross-segment).",
+                schedule.tp,
+                schedule.pp,
+                schedule.ep,
+                schedule.cp,
+                schedule.num_nodes,
+                schedule.ranks_per_node,
+                len(job_args.group_affinity),
+                len(job_args.group_affinity),
+            )
 
     def start(self):
         self._scaler.start()

--- a/dlrover/python/master/resource/job.py
+++ b/dlrover/python/master/resource/job.py
@@ -20,6 +20,7 @@ from typing import Dict, List, Optional
 from dlrover.python.brain.client import GlobalBrainClient
 from dlrover.python.common.constants import (
     JobOptStage,
+    NodeGroupStrategy,
     NodeResourceLimit,
     NodeType,
     OptimizeMode,
@@ -38,6 +39,7 @@ from dlrover.python.master.resource.optimizer import (
     SimpleOptimizer,
 )
 from dlrover.python.scheduler.job import ResourceLimits
+from dlrover.python.util.args_util import validate_group_affinity_equal_size
 
 _WORKER_OPTIMIZE_PHASE = "optimizer.worker.optimize-phase"
 
@@ -68,21 +70,98 @@ def new_ps_resource_optimizer(
         return SimpleOptimizer(job_uuid, resource_limits)
 
 
+class NodeGroupSchedule(object):
+    """Strategies + parallel sizes used to map a worker node (ranked by its
+    creation order, i.e. its ``rank_index`` at the node granularity) into a
+    node group. A node group corresponds to a physical scheduling segment.
+
+    Only ``strategy`` is meaningful by itself. The parallel sizes are used by
+    the :func:`validate_topology` and :func:`_resolve_stripe_group_id` helpers
+    when ``strategy == NodeGroupStrategy.EP_PP_DP``.
+
+    Args:
+        strategy: one of :class:`NodeGroupStrategy`. Defaults to
+            ``CONTIGUOUS`` (current behavior).
+        tp / pp / ep / cp: Megatron tensor/pipeline/expert/context parallel
+            sizes. Only ``tp == 1`` and ``cp == 1`` are supported today.
+        num_nodes: total number of worker nodes (``N``).
+        ranks_per_node: number of ranks per worker node (``R``), i.e.
+            ``NodeResource.gpu_num``.
+    """
+
+    def __init__(
+        self,
+        strategy: str = NodeGroupStrategy.CONTIGUOUS,
+        tp: int = 1,
+        pp: int = 1,
+        ep: int = 1,
+        cp: int = 1,
+        num_nodes: int = 0,
+        ranks_per_node: int = 0,
+    ):
+        self.strategy = strategy
+        self.tp = tp
+        self.pp = pp
+        self.ep = ep
+        self.cp = cp
+        self.num_nodes = num_nodes
+        self.ranks_per_node = ranks_per_node
+
+
+def _resolve_stripe_group_id(
+    group_affinity: Dict[int, int],
+    rank_index: int,
+    schedule: NodeGroupSchedule,
+) -> int:
+    """Resolve the node group when ``strategy == ep_pp_dp``.
+
+    One pipeline stage (a dense-DP group, ``dense_dp`` ranks) is striped
+    across all groups/segments so that EP groups and PP stay intra-segment,
+    while only the dense DP collective crosses segments. Working at the
+    node granularity (``rank_index`` = node creation order):
+
+        DP_nodes = N / (TP*PP*CP)          # nodes per pipeline stage
+        seg      = DP_nodes / G            # nodes per segment per stage
+        group(k) = (k % DP_nodes) // seg
+
+    The caller is responsible for having validated the topology via
+    :func:`validate_topology`, which guarantees the divisions are integral
+    and ``seg >= 1``.
+    """
+    g = len(group_affinity)
+    dp_nodes = schedule.num_nodes // (schedule.tp * schedule.pp * schedule.cp)
+    seg = dp_nodes // g
+    return (rank_index % dp_nodes) // seg
+
+
 def resolve_group_id(
     group_affinity: Optional[Dict[int, int]],
     node_type: str,
     rank_index: int,
+    schedule: Optional[NodeGroupSchedule] = None,
 ) -> Optional[int]:
     """Resolve the node group id for a node by its rank index.
 
-    Only WORKER nodes are partitioned into node groups. The groups are
-    laid out in ascending group-id order, each occupying a contiguous
-    ``[start, end)`` rank range sized by ``group_affinity[group_id]``.
+    Only WORKER nodes are partitioned into node groups.
+
+    - With the default ``schedule`` (None) or its strategy being
+      :data:`NodeGroupStrategy.CONTIGUOUS`, groups are laid out in ascending
+      group-id order, each occupying a contiguous ``[start, end)`` rank range
+      sized by ``group_affinity[group_id]``. This is the existing behavior.
+    - With strategy :data:`NodeGroupStrategy.EP_PP_DP`, the stripe mapping in
+      :func:`_resolve_stripe_group_id` is used instead. This requires a
+      validated topology (see :func:`validate_topology`).
+
     Returns ``None`` when group affinity is not configured or the rank
     falls outside the declared worker range.
     """
     if node_type != NodeType.WORKER or not group_affinity:
         return None
+    if (
+        schedule is not None
+        and schedule.strategy == NodeGroupStrategy.EP_PP_DP
+    ):
+        return _resolve_stripe_group_id(group_affinity, rank_index, schedule)
     ordered_groups: List[int] = sorted(group_affinity.keys())
     start = 0
     for group_id in ordered_groups:
@@ -93,10 +172,144 @@ def resolve_group_id(
     return None
 
 
+def validate_topology(
+    group_affinity: Optional[Dict[int, int]],
+    schedule: Optional[NodeGroupSchedule],
+) -> None:
+    """Validate ``group_affinity`` against the parallel topology when the
+    ``ep_pp_dp`` node-group strategy is enabled. Raises ``ValueError`` (and
+    leaves ``group_affinity`` unapplied) whenever any constraint is violated.
+
+    Constraints (``N`` = #worker nodes, ``R`` = ranks/node, ``G`` =
+    ``len(group_affinity)``, ``dense_dp = N*R / (TP*PP*CP)``,
+    ``S = dense_dp / G`` ranks per segment per stage):
+
+      - scope: ``TP == 1`` and ``CP == 1``;
+      - A: ``dense_dp % G == 0`` (each segment gets an integer #ranks/stage);
+      - B: ``S % R == 0`` equiv ``N % (TP*PP*CP*G) == 0`` (a node's ``R``
+            ranks do not cross a segment-per-stage block, and nodes/stages
+            are whole);
+      - C: ``S % EP == 0`` (an EP group does not cross a segment, which also
+            makes ``de`` divisible across the ``G`` segments);
+      - D: ``N % G == 0`` and all ``group_affinity`` values are equal to
+            ``N/G`` (equal-size groups, the platform hard requirement), and
+            the group ids are exactly ``{0, 1, ..., G-1}``;
+      - E: ``EP % R == 0`` (an EP group is composed of whole nodes);
+      - implicit: ``dense_dp`` and ``dp_nodes`` are integral and ``seg >= 1``.
+    """
+    if schedule is None or schedule.strategy != NodeGroupStrategy.EP_PP_DP:
+        return
+    if not group_affinity:
+        raise ValueError(
+            "node-group-strategy=ep_pp_dp requires --group-affinity to be set"
+        )
+
+    g = len(group_affinity)
+    tp, pp, ep, cp = schedule.tp, schedule.pp, schedule.ep, schedule.cp
+    n, r = schedule.num_nodes, schedule.ranks_per_node
+
+    if tp != 1:
+        raise ValueError(
+            "node-group-strategy=ep_pp_dp currently requires TP=1 "
+            f"(got tp={tp}); TP>1 support is planned for a later phase."
+        )
+    if cp != 1:
+        raise ValueError(
+            "node-group-strategy=ep_pp_dp currently requires CP=1 "
+            f"(got cp={cp}); CP>1 support is planned for a later phase."
+        )
+    if r <= 0:
+        raise ValueError(
+            "node-group-strategy=ep_pp_dp requires ranks_per_node>0 "
+            f"(NodeResource.gpu_num), got {r}."
+        )
+
+    model_parallel = tp * pp * cp
+    # DP_nodes = N / (TP*PP*CP) must be whole; this also guarantees dense_dp
+    # (= N*R/(TP*PP*CP)) is integral since R is integer.
+    if n % model_parallel != 0:
+        raise ValueError(
+            "node-group-strategy=ep_pp_dp requires the worker node count N "
+            f"to be divisible by TP*PP*CP={model_parallel}, got N={n}."
+        )
+
+    # Constraint A: dense_dp is divisible by G (each segment gets an integer
+    # number of ranks per pipeline stage).
+    dense_dp = (n * r) // model_parallel
+    if dense_dp % g != 0:
+        raise ValueError(
+            "node-group-strategy=ep_pp_dp requires dense_dp="
+            f"{dense_dp} (N*R/(TP*PP*CP)) to be divisible by G={g} segments."
+        )
+    s = dense_dp // g
+
+    # Constraint B: a node's R ranks do not straddle a segment-per-stage block;
+    # equivalently the nodes per segment per stage are integral
+    # (N % (TP*PP*CP*G) == 0).
+    if s % r != 0:
+        raise ValueError(
+            "node-group-strategy=ep_pp_dp requires S=dense_dp/G={s} ranks "
+            f"per segment per stage to be divisible by ranks_per_node R={r} "
+            "(equivalently N % (TP*PP*CP*G) == 0)."
+        )
+    seg_nodes = s // r
+    if seg_nodes < 1:
+        raise ValueError(
+            "node-group-strategy=ep_pp_dp requires at least one node per "
+            f"segment per stage, got {seg_nodes}."
+        )
+
+    # Constraint C: an EP group fits and aligns inside a segment-per-stage
+    # block (also guarantees de=S/EP is integral across the G segments).
+    if ep <= 0:
+        raise ValueError(
+            f"node-group-strategy=ep_pp_dp requires EP>0, got ep={ep}."
+        )
+    if s % ep != 0:
+        raise ValueError(
+            "node-group-strategy=ep_pp_dp requires the EP size "
+            f"({ep}) to divide S=dense_dp/G={s} so each EP group stays "
+            "inside a segment."
+        )
+
+    # Constraint E: an EP group is composed of whole nodes.
+    if ep % r != 0:
+        raise ValueError(
+            "node-group-strategy=ep_pp_dp requires EP="
+            f"{ep} to be divisible by ranks_per_node R={r} so an EP "
+            "group spans whole nodes."
+        )
+
+    # Constraint D: equal-size groups, group ids == {0..G-1}, each == N/G.
+    if n % g != 0:
+        raise ValueError(
+            "node-group-strategy=ep_pp_dp requires the worker node count "
+            f"N={n} to be divisible by G={g} segments (equal group sizes)."
+        )
+    expected_size = n // g
+    # Raises ValueError when the group sizes are not all equal.
+    equal_size = validate_group_affinity_equal_size(group_affinity)
+    if equal_size != expected_size:
+        raise ValueError(
+            "node-group-strategy=ep_pp_dp requires all group_affinity sizes "
+            f"to be equal to N/G={expected_size}, got {equal_size}."
+        )
+    keys = sorted(group_affinity.keys())
+    if keys != list(range(g)):
+        raise ValueError(
+            "node-group-strategy=ep_pp_dp requires contiguous group ids "
+            f"{{0,1,...,{g - 1}}}, got {keys}."
+        )
+
+
 class JobResource(JsonSerializable):
     def __init__(self):
         self.node_group_resources: Dict[str, NodeGroupResource] = {}
         self.group_affinity: Optional[Dict[int, int]] = None
+        # Node-group schedule (strategy + parallel sizes). Defaults to None,
+        # i.e. ``CONTIGUOUS`` behavior; set to a NodeGroupSchedule(strategy=
+        # ep_pp_dp, ...) when the ep_pp_dp strategy is enabled and validated.
+        self.node_group_schedule: Optional[NodeGroupSchedule] = None
 
     def get_node_group_resource(self, node_type):
         return self.node_group_resources.get(node_type, None)
@@ -192,11 +405,18 @@ class JobResource(JsonSerializable):
         """Resolve the node group id for a node by its rank index.
 
         Only WORKER nodes are partitioned into node groups. The groups are
-        laid out in ascending group-id order, each occupying a contiguous
-        [start, end) rank range sized by ``group_affinity[group_id]``.
+        laid out according to ``self.node_group_schedule``: by default
+        (None / contiguous) this is the ascending-group-id contiguous
+        [start, end) rank range sized by ``group_affinity[group_id]``; when an
+        ep_pp_dp schedule is configured, the stripe mapping is used.
         Returns None when group affinity is not configured.
         """
-        return resolve_group_id(self.group_affinity, node_type, rank_index)
+        return resolve_group_id(
+            self.group_affinity,
+            node_type,
+            rank_index,
+            self.node_group_schedule,
+        )
 
     def adjust_worker_for_estimator(self):
         if (

--- a/dlrover/python/master/resource/job.py
+++ b/dlrover/python/master/resource/job.py
@@ -396,10 +396,109 @@ class JobResource(JsonSerializable):
                     node_group_id=group_id,
                 )
             job_nodes[node_type] = group_nodes
+        self._log_ep_pp_dp_groups()
         logger.info(
             "after initializing job node meta job_nodes are %s" % job_nodes
         )
         return job_nodes
+
+    def _log_ep_pp_dp_groups(self):
+        """Log the worker ranges of every parallel-group granularity when
+        the ``ep_pp_dp`` strategy is enabled. Ranges refer to worker indices
+        (node ``rank_index``). The families, printed from the finest to the
+        coarsest:
+
+        - ``group ep``: one EP group = ``EP/R`` consecutive workers inside
+          one pipeline stage (the EP collective never leaves it).
+        - ``group ep_pp``: one EP-group slot across ALL pipeline stages;
+          it is the domain where EP and PP communication stay local, and
+          each segment (node group) contains ``S/EP`` such groups.
+        - ``group ep_dp``: the dense-DP allreduce domain == a whole
+          pipeline stage (the only collective that crosses segments).
+        - ``group pp_stage``: the pipeline stages themselves.
+        """
+        schedule = self.node_group_schedule
+        if schedule is None or schedule.strategy != NodeGroupStrategy.EP_PP_DP:
+            return
+        g = len(self.group_affinity)
+        pp, ep, r = schedule.pp, schedule.ep, schedule.ranks_per_node
+        if g <= 0 or pp <= 0 or ep <= 0 or r <= 0:
+            return
+        dp_nodes = schedule.num_nodes // pp  # workers per pipeline stage
+        ep_nodes = ep // r  # workers per EP group
+        if dp_nodes <= 0 or ep_nodes <= 0:
+            return
+        slots = dp_nodes // ep_nodes  # EP-group slots per pipeline stage
+        seg_nodes = dp_nodes // g  # workers per segment per stage
+        seg_slots = seg_nodes // ep_nodes  # EP-group slots per segment
+        if slots <= 0 or seg_nodes <= 0 or seg_slots <= 0:
+            return
+
+        ep_entries = []
+        for s in range(pp):
+            for j in range(slots):
+                start = s * dp_nodes + j * ep_nodes
+                ep_entries.append(
+                    f"{{'group_id': 'ep{s * slots + j}', "
+                    f"'world_size': {ep_nodes}, "
+                    f"'members_ranges': '{start}-{start + ep_nodes - 1}', "
+                    f"'num_members': {ep_nodes}}}"
+                )
+        ep_pp_entries = []
+        for j in range(slots):
+            ranges = []
+            for s in range(pp):
+                start = s * dp_nodes + j * ep_nodes
+                ranges.append(f"{start}-{start + ep_nodes - 1}")
+            members = pp * ep_nodes
+            ep_pp_entries.append(
+                f"{{'group_id': 'ep_pp{j}', "
+                f"'world_size': {members}, "
+                f"'members_ranges': '{','.join(ranges)}', "
+                f"'num_members': {members}}}"
+            )
+        ep_dp_entries = []
+        pp_entries = []
+        for s in range(pp):
+            start = s * dp_nodes
+            ranges = f"{start}-{start + dp_nodes - 1}"
+            ep_dp_entries.append(
+                f"{{'group_id': 'ep_dp{s}', "
+                f"'world_size': {dp_nodes}, "
+                f"'members_ranges': '{ranges}', "
+                f"'num_members': {dp_nodes}}}"
+            )
+            pp_entries.append(
+                f"{{'group_id': 'pp{s}', "
+                f"'world_size': {dp_nodes}, "
+                f"'members_ranges': '{ranges}', "
+                f"'num_members': {dp_nodes}}}"
+            )
+
+        families = [
+            ("ep", ep_entries),
+            (
+                f"ep_pp (groups per segment: {seg_slots})",
+                ep_pp_entries,
+            ),
+            ("ep_dp (dense-DP, crosses segments)", ep_dp_entries),
+            ("pp_stage", pp_entries),
+        ]
+        batch = 16
+        for name, entries in families:
+            for i in range(0, len(entries), batch):
+                chunk = ", ".join(entries[i : i + batch])
+                if len(entries) <= batch:
+                    logger.info("group %s: [%s]", name, chunk)
+                else:
+                    logger.info(
+                        "group %s [%d-%d/%d]: [%s]",
+                        name,
+                        i + 1,
+                        min(i + batch, len(entries)),
+                        len(entries),
+                        chunk,
+                    )
 
     def _group_count(self) -> Optional[int]:
         """Return the total number of node groups, or None if group

--- a/dlrover/python/master/resource/job.py
+++ b/dlrover/python/master/resource/job.py
@@ -150,10 +150,14 @@ def resolve_group_id(
       sized by ``group_affinity[group_id]``. This is the existing behavior.
     - With strategy :data:`NodeGroupStrategy.EP_PP_DP`, the stripe mapping in
       :func:`_resolve_stripe_group_id` is used instead. This requires a
-      validated topology (see :func:`validate_topology`).
+      validated topology (see :func:`validate_topology`); as the topology
+      is fixed-size, the rank is asserted to be within
+      ``schedule.num_nodes``.
 
     Returns ``None`` when group affinity is not configured or the rank
-    falls outside the declared worker range.
+    falls outside the declared worker range. For ``ep_pp_dp``, an
+    out-of-range rank (e.g. an unexpected scale-up beyond ``N``) raises
+    ``AssertionError`` instead of silently wrapping into a segment.
     """
     if node_type != NodeType.WORKER or not group_affinity:
         return None
@@ -161,6 +165,11 @@ def resolve_group_id(
         schedule is not None
         and schedule.strategy == NodeGroupStrategy.EP_PP_DP
     ):
+        assert 0 <= rank_index < schedule.num_nodes, (
+            f"rank_index={rank_index} is outside the validated "
+            f"ep_pp_dp topology (num_nodes={schedule.num_nodes}); "
+            "scale-up beyond the fixed world is not supported."
+        )
         return _resolve_stripe_group_id(group_affinity, rank_index, schedule)
     ordered_groups: List[int] = sorted(group_affinity.keys())
     start = 0

--- a/dlrover/python/master/scaler/base_scaler.py
+++ b/dlrover/python/master/scaler/base_scaler.py
@@ -98,3 +98,13 @@ class Scaler(metaclass=ABCMeta):
         no-op keeps the base scaler agnostic of group affinity.
         """
         pass
+
+    def set_node_group_schedule(self, node_group_schedule):
+        """Set the node-group schedule (strategy + parallel sizes).
+
+        Scalers that compute the group id per created worker (e.g. PodScaler,
+        via ``resolve_group_id``) can override this to forward the schedule
+        so a ``ep_pp_dp`` strategy is honored. The default no-op keeps the
+        base scaler agnostic of the schedule.
+        """
+        pass

--- a/dlrover/python/master/scaler/pod_scaler.py
+++ b/dlrover/python/master/scaler/pod_scaler.py
@@ -39,7 +39,10 @@ from dlrover.python.common.global_context import Context
 from dlrover.python.common.log import default_logger as logger
 from dlrover.python.common.node import Node, NodeResource
 from dlrover.python.master.node.job_context import get_job_context
-from dlrover.python.master.resource.job import resolve_group_id
+from dlrover.python.master.resource.job import (
+    NodeGroupSchedule,
+    resolve_group_id,
+)
 from dlrover.python.master.scaler.base_scaler import ScalePlan, Scaler
 from dlrover.python.scheduler.kubernetes import (
     NODE_SERVICE_PORTS,
@@ -121,10 +124,20 @@ class PodScaler(Scaler):
         # newly created worker pods are labeled with their group so the
         # scheduler can place them by affinity.
         self._group_affinity: Optional[Dict[int, int]] = None
+        # Node-group schedule (strategy + parallel sizes) injected by
+        # DistributedJobManager; consulted by resolve_group_id so the
+        # ep_pp_dp stripe mapping is applied when labeling created pods.
+        self._node_group_schedule: Optional[NodeGroupSchedule] = None
 
     def set_group_affinity(self, group_affinity):
         """Store the group affinity mapping for labeling created pods."""
         self._group_affinity = group_affinity
+
+    def set_node_group_schedule(self, node_group_schedule):
+        """Store the node-group schedule (strategy + parallel sizes) so
+        resolve_group_id can apply the ep_pp_dp stripe mapping when
+        labeling created worker pods."""
+        self._node_group_schedule = node_group_schedule
 
     def start(self):
         self._job = self._retry_to_get_job()
@@ -468,7 +481,12 @@ class PodScaler(Scaler):
         for i in range(up_num):
             node_id = max_pod_id + 1 + i
             task_id = cur_num + i
-            group_id = resolve_group_id(self._group_affinity, type, task_id)
+            group_id = resolve_group_id(
+                self._group_affinity,
+                type,
+                task_id,
+                self._node_group_schedule,
+            )
             group_size = (
                 len(self._group_affinity)
                 if group_id is not None and self._group_affinity

--- a/dlrover/python/scheduler/job.py
+++ b/dlrover/python/scheduler/job.py
@@ -109,6 +109,18 @@ class JobArgs(JsonSerializable):
         self.enable_suspended = False
         self.training_elastic_mode = "base"
         self.group_affinity: Optional[Dict[int, int]] = None
+        # Node-group scheduling strategy for worker nodes; defaults to the
+        # existing contiguous behavior. See NodeGroupStrategy in
+        # dlrover.python.common.constants and NodeGroupSchedule/
+        # resolve_group_id in dlrover.python.master.resource.job.
+        self.node_group_strategy: str = "contiguous"
+        # Megatron parallel sizes, consulted only when
+        # node_group_strategy == "ep_pp_dp" (and validated by
+        # validate_topology in master.resource.job). TP/CP must be 1 today.
+        self.tensor_model_parallel_size: int = 1
+        self.pipeline_model_parallel_size: int = 1
+        self.expert_model_parallel_size: int = 1
+        self.context_parallel_size: int = 1
 
     @abstractmethod
     def initilize(self):

--- a/dlrover/python/tests/test_args.py
+++ b/dlrover/python/tests/test_args.py
@@ -144,3 +144,43 @@ class ArgsTest(unittest.TestCase):
         with self.assertRaises(SystemExit) as cm:
             parse_master_args(original_args)
         self.assertEqual(cm.exception.code, 2)
+
+    def test_parse_node_group_strategy(self):
+        # defaults: contiguous + all parallel sizes == 1
+        parsed = parse_master_args(["--job_name", "test"])
+        self.assertEqual(parsed.node_group_strategy, "contiguous")
+        self.assertEqual(parsed.tensor_model_parallel_size, 1)
+        self.assertEqual(parsed.pipeline_model_parallel_size, 1)
+        self.assertEqual(parsed.expert_model_parallel_size, 1)
+        self.assertEqual(parsed.context_parallel_size, 1)
+
+        # ep_pp_dp with parallel sizes (long and short aliases)
+        parsed = parse_master_args(
+            [
+                "--job_name",
+                "test",
+                "--node-group-strategy=ep_pp_dp",
+                "--group-affinity={0: 128, 1: 128}",
+                "--tp",
+                "1",
+                "--pp",
+                "16",
+                "--ep",
+                "32",
+                "--cp",
+                "1",
+            ]
+        )
+        self.assertEqual(parsed.node_group_strategy, "ep_pp_dp")
+        self.assertEqual(parsed.group_affinity, {0: 128, 1: 128})
+        self.assertEqual(parsed.tensor_model_parallel_size, 1)
+        self.assertEqual(parsed.pipeline_model_parallel_size, 16)
+        self.assertEqual(parsed.expert_model_parallel_size, 32)
+        self.assertEqual(parsed.context_parallel_size, 1)
+
+        # invalid strategy choice -> argparse exits with code 2
+        with self.assertRaises(SystemExit) as cm:
+            parse_master_args(
+                ["--job_name", "test", "--node-group-strategy=bogus"]
+            )
+        self.assertEqual(cm.exception.code, 2)

--- a/dlrover/python/tests/test_args_util.py
+++ b/dlrover/python/tests/test_args_util.py
@@ -19,6 +19,7 @@ from dlrover.python.util.args_util import (
     parse_tuple_dict,
     parse_tuple_list,
     str2bool,
+    validate_group_affinity_equal_size,
 )
 
 
@@ -109,3 +110,18 @@ class ArgsUtilTest(unittest.TestCase):
         # bool value (True is an int subclass, must be rejected)
         with self.assertRaises(argparse.ArgumentTypeError):
             parse_group_affinity("{0: True}")
+
+    def test_validate_group_affinity_equal_size(self):
+        # None / empty -> None (not applicable)
+        self.assertIsNone(validate_group_affinity_equal_size(None))
+        self.assertIsNone(validate_group_affinity_equal_size({}))
+
+        # equal sizes -> the single size
+        self.assertEqual(validate_group_affinity_equal_size({0: 8, 1: 8}), 8)
+        self.assertEqual(
+            validate_group_affinity_equal_size({2: 128, 0: 128, 1: 128}), 128
+        )
+
+        # unequal sizes -> ValueError
+        with self.assertRaisesRegex(ValueError, "equal"):
+            validate_group_affinity_equal_size({0: 10, 1: 15})

--- a/dlrover/python/tests/test_job_manager.py
+++ b/dlrover/python/tests/test_job_manager.py
@@ -38,6 +38,7 @@ from dlrover.python.common.constants import (
     JobStage,
     NodeEventType,
     NodeExitReason,
+    NodeGroupStrategy,
     NodeStatus,
     NodeType,
     PreCheckStatus,
@@ -79,7 +80,7 @@ from dlrover.python.master.node.training_node import (
     set_critical_node,
     update_nodes_priority,
 )
-from dlrover.python.master.resource.job import JobResource
+from dlrover.python.master.resource.job import JobResource, NodeGroupSchedule
 from dlrover.python.master.scaler.base_scaler import ScalePlan
 from dlrover.python.master.watcher.base_watcher import Node
 from dlrover.python.scheduler.job import LocalJobArgs
@@ -226,7 +227,33 @@ class DistributedJobManagerTest(unittest.TestCase):
             self.assertIsNone(node.group_size)
             self.assertFalse(node.has_group())
 
-    def _new_manager_with_worker_count(self, count):
+    def test_job_resource_ep_pp_dp_init_node_meta_stripe(self):
+        # Compact topology: N=4, R=8, EP=8, PP=2, G=2 -> group(k)=(k%2)//1.
+        # init_job_node_meta must assign groups via _resolve_group_id (stripe),
+        # so worker nodes 0,2 -> group 0 and 1,3 -> group 1.
+        job = JobResource()
+        job.node_group_resources[NodeType.WORKER] = NodeGroupResource(
+            4, NodeResource(1, 4096, "a100", 8)
+        )
+        job.group_affinity = {0: 2, 1: 2}
+        job.node_group_schedule = NodeGroupSchedule(
+            strategy=NodeGroupStrategy.EP_PP_DP,
+            tp=1,
+            pp=2,
+            ep=8,
+            cp=1,
+            num_nodes=4,
+            ranks_per_node=8,
+        )
+        nodes = job.init_job_node_meta(1, get_service_fn, _get_node_name)
+        workers = nodes[NodeType.WORKER]
+        self.assertEqual(len(workers), 4)
+        self.assertEqual([workers[i].group for i in range(4)], [0, 1, 0, 1])
+        for node in workers.values():
+            self.assertEqual(node.group_size, 2)
+            self.assertEqual(node.group_id, node.group)
+
+    def _new_manager_with_worker_count(self, count, gpu_num=0):
         """Build a lightweight DistributedJobManager with only the job
         resource populated, bypassing the heavy __init__ so that
         _init_group_affinity can be exercised in isolation."""
@@ -234,7 +261,9 @@ class DistributedJobManagerTest(unittest.TestCase):
         job_resource = JobResource()
         if count is not None:
             job_resource.node_group_resources[NodeType.WORKER] = (
-                NodeGroupResource(count, NodeResource(1, 4096))
+                NodeGroupResource(
+                    count, NodeResource(1, 4096, "a100", gpu_num)
+                )
             )
         manager._job_resource = job_resource
         return manager
@@ -275,6 +304,94 @@ class DistributedJobManagerTest(unittest.TestCase):
                 SimpleNamespace(group_affinity={0: 5})
             )
         self.assertIsNone(manager._job_resource.group_affinity)
+
+    def test_init_group_affinity_contiguous_leaves_schedule_unset(self):
+        # With the default/contiguous strategy no schedule is attached.
+        manager = self._new_manager_with_worker_count(25)
+        manager._init_group_affinity(
+            SimpleNamespace(
+                group_affinity={0: 10, 1: 15},
+                node_group_strategy=NodeGroupStrategy.CONTIGUOUS,
+            )
+        )
+        self.assertEqual(manager._job_resource.group_affinity, {0: 10, 1: 15})
+        self.assertIsNone(manager._job_resource.node_group_schedule)
+
+    def test_init_group_affinity_ep_pp_dp_ok(self):
+        # Valid 4-node topology: R=8, EP=8, PP=2, G=2 -> schedule attached.
+        manager = self._new_manager_with_worker_count(4, gpu_num=8)
+        manager._init_group_affinity(
+            SimpleNamespace(
+                group_affinity={0: 2, 1: 2},
+                node_group_strategy=NodeGroupStrategy.EP_PP_DP,
+                tensor_model_parallel_size=1,
+                pipeline_model_parallel_size=2,
+                expert_model_parallel_size=8,
+                context_parallel_size=1,
+            )
+        )
+        self.assertEqual(manager._job_resource.group_affinity, {0: 2, 1: 2})
+        schedule = manager._job_resource.node_group_schedule
+        self.assertIsNotNone(schedule)
+        self.assertEqual(schedule.strategy, NodeGroupStrategy.EP_PP_DP)
+        self.assertEqual(
+            (schedule.tp, schedule.pp, schedule.ep, schedule.cp), (1, 2, 8, 1)
+        )
+        self.assertEqual((schedule.num_nodes, schedule.ranks_per_node), (4, 8))
+
+    def test_init_group_affinity_ep_pp_dp_invalid_topology(self):
+        # Invalid topology (EP=24 > S=16) must raise and leave the resource
+        # untouched (neither group_affinity nor schedule applied).
+        manager = self._new_manager_with_worker_count(4, gpu_num=8)
+        with self.assertRaisesRegex(ValueError, "EP"):
+            manager._init_group_affinity(
+                SimpleNamespace(
+                    group_affinity={0: 2, 1: 2},
+                    node_group_strategy=NodeGroupStrategy.EP_PP_DP,
+                    tensor_model_parallel_size=1,
+                    pipeline_model_parallel_size=1,
+                    expert_model_parallel_size=24,
+                    context_parallel_size=1,
+                )
+            )
+        self.assertIsNone(manager._job_resource.group_affinity)
+        self.assertIsNone(manager._job_resource.node_group_schedule)
+
+    def test_init_group_affinity_ep_pp_dp_requires_group_affinity(self):
+        # ep_pp_dp without group_affinity is a hard error.
+        manager = self._new_manager_with_worker_count(4, gpu_num=8)
+        with self.assertRaisesRegex(ValueError, "requires --group-affinity"):
+            manager._init_group_affinity(
+                SimpleNamespace(
+                    group_affinity=None,
+                    node_group_strategy=NodeGroupStrategy.EP_PP_DP,
+                    tensor_model_parallel_size=1,
+                    pipeline_model_parallel_size=2,
+                    expert_model_parallel_size=8,
+                    context_parallel_size=1,
+                )
+            )
+        self.assertIsNone(manager._job_resource.group_affinity)
+        self.assertIsNone(manager._job_resource.node_group_schedule)
+
+    def test_init_group_affinity_ep_pp_dp_via_job_manager_init(self):
+        # End-to-end via create_job_manager with a valid topology:
+        # MockK8sAllreduceJobArgs worker = NodeResource gpu_num=8, count=16.
+        params = MockK8sAllreduceJobArgs()
+        params.initilize(16)
+        params.node_group_strategy = NodeGroupStrategy.EP_PP_DP
+        params.group_affinity = {0: 8, 1: 8}
+        params.tensor_model_parallel_size = 1
+        params.pipeline_model_parallel_size = 2
+        params.expert_model_parallel_size = 8
+        params.context_parallel_size = 1
+        manager = create_job_manager(params, PerfMonitor())
+        self.assertEqual(manager._job_resource.group_affinity, {0: 8, 1: 8})
+        self.assertIsNotNone(manager._job_resource.node_group_schedule)
+        self.assertEqual(
+            manager._job_resource.node_group_schedule.strategy,
+            NodeGroupStrategy.EP_PP_DP,
+        )
 
     def test_init_group_affinity_via_job_manager_init(self):
         # Exercise the __init__ path: create_job_manager must call

--- a/dlrover/python/tests/test_job_manager.py
+++ b/dlrover/python/tests/test_job_manager.py
@@ -245,13 +245,43 @@ class DistributedJobManagerTest(unittest.TestCase):
             num_nodes=4,
             ranks_per_node=8,
         )
-        nodes = job.init_job_node_meta(1, get_service_fn, _get_node_name)
+        with self.assertLogs("dlrover.logger", level="INFO") as logs:
+            nodes = job.init_job_node_meta(1, get_service_fn, _get_node_name)
         workers = nodes[NodeType.WORKER]
         self.assertEqual(len(workers), 4)
         self.assertEqual([workers[i].group for i in range(4)], [0, 1, 0, 1])
         for node in workers.values():
             self.assertEqual(node.group_size, 2)
             self.assertEqual(node.group_id, node.group)
+        # the per-parallel-group worker ranges are logged once, from the
+        # finest (ep) to the coarsest (ep_dp == dense-DP, pp_stage).
+        # For N=4, R=8, EP=8, PP=2: EP group = 1 worker, ep_pp group = the
+        # same EP slot across both stages, ep_dp/pp = the whole stage.
+        joined = " ".join(logs.output)
+        self.assertIn("group ep: [", joined)
+        self.assertIn(
+            "{'group_id': 'ep0', 'world_size': 1, "
+            "'members_ranges': '0-0', 'num_members': 1}",
+            joined,
+        )
+        self.assertIn("group ep_pp (groups per segment: 1): [", joined)
+        self.assertIn(
+            "{'group_id': 'ep_pp0', 'world_size': 2, "
+            "'members_ranges': '0-0,2-2', 'num_members': 2}",
+            joined,
+        )
+        self.assertIn("group ep_dp (dense-DP, crosses segments): [", joined)
+        self.assertIn(
+            "{'group_id': 'ep_dp0', 'world_size': 2, "
+            "'members_ranges': '0-1', 'num_members': 2}",
+            joined,
+        )
+        self.assertIn("group pp_stage: [", joined)
+        self.assertIn(
+            "{'group_id': 'pp1', 'world_size': 2, "
+            "'members_ranges': '2-3', 'num_members': 2}",
+            joined,
+        )
 
     def _new_manager_with_worker_count(self, count, gpu_num=0):
         """Build a lightweight DistributedJobManager with only the job

--- a/dlrover/python/tests/test_node_group_strategy.py
+++ b/dlrover/python/tests/test_node_group_strategy.py
@@ -91,6 +91,21 @@ class ResolveGroupIdStripeTest(unittest.TestCase):
             [0, 1, 0, 1],
         )
 
+    def test_stripe_out_of_range_rank_raises(self):
+        # A validated ep_pp_dp topology is fixed-size: a rank beyond
+        # num_nodes (e.g. an unexpected scale-up) must fail loudly
+        # instead of wrapping back into an already-full segment.
+        ga = {0: 2, 1: 2}
+        sched = _ep_pp_dp(
+            tp=1, pp=2, ep=8, cp=1, num_nodes=4, ranks_per_node=8
+        )
+        with self.assertRaises(AssertionError):
+            resolve_group_id(ga, NodeType.WORKER, 4, sched)
+        with self.assertRaises(AssertionError):
+            resolve_group_id(ga, NodeType.WORKER, -1, sched)
+        # The last in-range rank still resolves normally.
+        self.assertEqual(resolve_group_id(ga, NodeType.WORKER, 3, sched), 1)
+
     def test_stripe_matches_formula_helper_on_9216_job(self):
         # N=1152, R=8, TP=1, PP=16, EP=32, CP=1, G=9.
         N, R, PP, EP, G = 1152, 8, 16, 32, 9

--- a/dlrover/python/tests/test_node_group_strategy.py
+++ b/dlrover/python/tests/test_node_group_strategy.py
@@ -1,0 +1,293 @@
+# Copyright 2026 The DLRover Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from dlrover.python.common.constants import NodeGroupStrategy, NodeType
+from dlrover.python.master.resource.job import (
+    NodeGroupSchedule,
+    _resolve_stripe_group_id,
+    resolve_group_id,
+    validate_topology,
+)
+
+
+def _ep_pp_dp(tp=1, pp=1, ep=1, cp=1, num_nodes=0, ranks_per_node=0):
+    return NodeGroupSchedule(
+        strategy=NodeGroupStrategy.EP_PP_DP,
+        tp=tp,
+        pp=pp,
+        ep=ep,
+        cp=cp,
+        num_nodes=num_nodes,
+        ranks_per_node=ranks_per_node,
+    )
+
+
+class NodeGroupScheduleTest(unittest.TestCase):
+    def test_defaults_are_contiguous_unsized(self):
+        sched = NodeGroupSchedule()
+        self.assertEqual(sched.strategy, NodeGroupStrategy.CONTIGUOUS)
+        self.assertEqual(
+            (sched.tp, sched.pp, sched.ep, sched.cp), (1, 1, 1, 1)
+        )
+        self.assertEqual((sched.num_nodes, sched.ranks_per_node), (0, 0))
+
+    def test_ep_pp_dp_carry_fields(self):
+        sched = _ep_pp_dp(
+            tp=1, pp=16, ep=32, cp=1, num_nodes=1152, ranks_per_node=8
+        )
+        self.assertEqual(sched.strategy, NodeGroupStrategy.EP_PP_DP)
+        self.assertEqual((sched.pp, sched.ep), (16, 32))
+        self.assertEqual((sched.num_nodes, sched.ranks_per_node), (1152, 8))
+
+
+class ResolveGroupIdStripeTest(unittest.TestCase):
+    def test_no_affinity_or_non_worker_returns_none(self):
+        self.assertIsNone(resolve_group_id(None, NodeType.WORKER, 0, None))
+        self.assertIsNone(resolve_group_id({}, NodeType.WORKER, 0, None))
+        self.assertIsNone(resolve_group_id({0: 2}, NodeType.PS, 0, None))
+
+    def test_schedule_none_falls_back_to_contiguous(self):
+        ga = {0: 2, 1: 2}
+        self.assertEqual(
+            [resolve_group_id(ga, NodeType.WORKER, k, None) for k in range(4)],
+            [0, 0, 1, 1],
+        )
+
+    def test_contiguous_explicit_schedule(self):
+        ga = {0: 2, 1: 2}
+        sched = NodeGroupSchedule(strategy=NodeGroupStrategy.CONTIGUOUS)
+        self.assertEqual(
+            [
+                resolve_group_id(ga, NodeType.WORKER, k, sched)
+                for k in range(4)
+            ],
+            [0, 0, 1, 1],
+        )
+
+    def test_stripe_formula_small(self):
+        # R=8, EP=8, PP=2, G=2, TP=CP=1: DP_nodes = N/(1*2*1) = 2; seg = 1.
+        # group(k) = (k % 2) // 1 = k % 2.
+        ga = {0: 2, 1: 2}
+        sched = _ep_pp_dp(
+            tp=1, pp=2, ep=8, cp=1, num_nodes=4, ranks_per_node=8
+        )
+        self.assertEqual(
+            [
+                resolve_group_id(ga, NodeType.WORKER, k, sched)
+                for k in range(4)
+            ],
+            [0, 1, 0, 1],
+        )
+
+    def test_stripe_matches_formula_helper_on_9216_job(self):
+        # N=1152, R=8, TP=1, PP=16, EP=32, CP=1, G=9.
+        N, R, PP, EP, G = 1152, 8, 16, 32, 9
+        ga = {i: N // G for i in range(G)}
+        sched = _ep_pp_dp(
+            tp=1, pp=PP, ep=EP, cp=1, num_nodes=N, ranks_per_node=R
+        )
+        dp_nodes = N // (1 * PP * 1)
+        seg = dp_nodes // G
+        for k in range(N):
+            self.assertEqual(
+                resolve_group_id(ga, NodeType.WORKER, k, sched),
+                _resolve_stripe_group_id(ga, k, sched),
+            )
+            self.assertEqual(
+                resolve_group_id(ga, NodeType.WORKER, k, sched),
+                (k % dp_nodes) // seg,
+            )
+        # boundary checks: first 8 nodes -> seg0; node 8 -> seg1; node 71 -> seg8;
+        # node 72 (head of the next pipeline stage) -> seg0 again.
+        self.assertEqual(
+            [
+                resolve_group_id(ga, NodeType.WORKER, k, sched)
+                for k in range(8)
+            ],
+            [0] * 8,
+        )
+        self.assertEqual(resolve_group_id(ga, NodeType.WORKER, 8, sched), 1)
+        self.assertEqual(resolve_group_id(ga, NodeType.WORKER, 71, sched), 8)
+        self.assertEqual(resolve_group_id(ga, NodeType.WORKER, 72, sched), 0)
+
+
+class ValidateTopologyTest(unittest.TestCase):
+    def test_ok_9216_job(self):
+        ga = {i: 128 for i in range(9)}
+        validate_topology(
+            ga,
+            _ep_pp_dp(
+                tp=1, pp=16, ep=32, cp=1, num_nodes=1152, ranks_per_node=8
+            ),
+        )
+
+    def test_ok_small(self):
+        ga = {0: 2, 1: 2}
+        validate_topology(
+            ga,
+            _ep_pp_dp(tp=1, pp=2, ep=8, cp=1, num_nodes=4, ranks_per_node=8),
+        )
+
+    def test_contiguous_or_none_is_noop(self):
+        # A deliberately unequal/invalid-for-ep_pp_dp mapping is NOT checked at
+        # all when the strategy is contiguous or the schedule is None.
+        ga = {0: 10, 1: 5}
+        validate_topology(
+            ga, NodeGroupSchedule(strategy=NodeGroupStrategy.CONTIGUOUS)
+        )
+        validate_topology(ga, None)
+
+    def _assert_raises_msg(self, ga, sched, needle):
+        with self.assertRaises(ValueError) as ctx:
+            validate_topology(ga, sched)
+        self.assertIn(needle, str(ctx.exception))
+
+    def test_requires_group_affinity(self):
+        s = _ep_pp_dp(num_nodes=10, ranks_per_node=8)
+        self._assert_raises_msg(None, s, "requires --group-affinity")
+        self._assert_raises_msg({}, s, "requires --group-affinity")
+
+    def test_tp_must_be_one(self):
+        ga = {0: 128, 1: 128, 2: 128}
+        sched = _ep_pp_dp(
+            tp=2, pp=4, ep=8, cp=1, num_nodes=384, ranks_per_node=8
+        )
+        self._assert_raises_msg(ga, sched, "requires TP=1")
+
+    def test_cp_must_be_one(self):
+        ga = {0: 128, 1: 128, 2: 128}
+        sched = _ep_pp_dp(
+            tp=1, pp=4, ep=8, cp=2, num_nodes=384, ranks_per_node=8
+        )
+        with self.assertRaises(ValueError):
+            validate_topology(ga, sched)
+
+    def test_ranks_per_node_positive(self):
+        ga = {0: 64, 1: 64}
+        sched = _ep_pp_dp(
+            tp=1, pp=2, ep=8, cp=1, num_nodes=128, ranks_per_node=0
+        )
+        self._assert_raises_msg(ga, sched, "ranks_per_node>0")
+
+    def test_dense_dp_must_divide_G(self):
+        # N=1152, R=8, PP=16 -> dense_dp=576; G=5 -> 576%5 != 0 (constraint A).
+        ga = {
+            i: 230 for i in range(5)
+        }  # sizes irrelevant: A is checked before D
+        sched = _ep_pp_dp(
+            tp=1, pp=16, ep=32, cp=1, num_nodes=1152, ranks_per_node=8
+        )
+        self._assert_raises_msg(ga, sched, "divisible by G=5")
+
+    def test_segment_block_not_node_aligned(self):
+        # N=3, R=8, PP=1, G=2: dense_dp=24, S=12; 12%8 != 0 (constraint B).
+        ga = {0: 1, 1: 1}
+        sched = _ep_pp_dp(
+            tp=1, pp=1, ep=8, cp=1, num_nodes=3, ranks_per_node=8
+        )
+        self._assert_raises_msg(ga, sched, "divisible by ranks_per_node R=8")
+
+    def test_ep_too_large_for_segment(self):
+        # N=4, R=8, PP=1, G=2, EP=24: dense_dp=32, S=16; 16%24 != 0 (constraint C).
+        ga = {0: 2, 1: 2}
+        sched = _ep_pp_dp(
+            tp=1, pp=1, ep=24, cp=1, num_nodes=4, ranks_per_node=8
+        )
+        self._assert_raises_msg(ga, sched, "EP size (24) to")
+
+    def test_ep_not_whole_nodes(self):
+        # N=12, R=8, PP=1, G=2, EP=12: dense_dp=96, S=48; S%EP=0 (C ok),
+        # S%R=0 (B ok), but EP%R=12%8 != 0 (constraint E).
+        ga = {0: 6, 1: 6}
+        sched = _ep_pp_dp(
+            tp=1, pp=1, ep=12, cp=1, num_nodes=12, ranks_per_node=8
+        )
+        self._assert_raises_msg(ga, sched, "divisible by ranks_per_node R=8")
+
+    def test_unequal_group_sizes_fail(self):
+        # N=12, R=8, PP=1, G=2, EP=8: dense_dp=96, S=48; A/B/C/E all pass,
+        # N%G=0, N/G=6. Unequal sizes -> constraint D fails.
+        ga = {0: 7, 1: 5}
+        sched = _ep_pp_dp(
+            tp=1, pp=1, ep=8, cp=1, num_nodes=12, ranks_per_node=8
+        )
+        self._assert_raises_msg(ga, sched, "equal")
+
+    def test_wrong_equal_size_fail(self):
+        # Equal sizes but not N/G.
+        ga = {0: 5, 1: 5}
+        sched = _ep_pp_dp(
+            tp=1, pp=1, ep=8, cp=1, num_nodes=12, ranks_per_node=8
+        )
+        self._assert_raises_msg(ga, sched, "N/G=6")
+
+    def test_non_contiguous_group_ids_fail(self):
+        ga = {0: 4, 1: 4, 3: 4}  # missing group id 2
+        sched = _ep_pp_dp(
+            tp=1, pp=1, ep=8, cp=1, num_nodes=12, ranks_per_node=8
+        )
+        self._assert_raises_msg(ga, sched, "contiguous group ids")
+
+
+class StripeInvariantsTest(unittest.TestCase):
+    """Rank-level invariants for a validated topology: EP groups and PP
+    columns stay inside one segment; each DP group spans every segment."""
+
+    def _check_invariants(self, N, R, TP, PP, EP, CP, G):
+        ga = {i: N // G for i in range(G)}
+        sched = _ep_pp_dp(
+            tp=TP, pp=PP, ep=EP, cp=CP, num_nodes=N, ranks_per_node=R
+        )
+        validate_topology(ga, sched)
+
+        def seg_of_rank(rank):
+            return resolve_group_id(ga, NodeType.WORKER, rank // R, sched)
+
+        dense_dp = (N * R) // (TP * PP * CP)
+
+        # EP group: fixed (pp, de), vary ep over [0, EP) -> one segment.
+        for pp in range(PP):
+            for de in range(dense_dp // EP):
+                segs = set(
+                    seg_of_rank(pp * dense_dp + de * EP + e) for e in range(EP)
+                )
+                self.assertEqual(len(segs), 1, f"EP group pp={pp} de={de}")
+
+        # PP column: fixed dp, vary pp over [0, PP) -> one segment.
+        for dp in range(dense_dp):
+            segs = set(seg_of_rank(dp + pp * dense_dp) for pp in range(PP))
+            self.assertEqual(len(segs), 1, f"PP column dp={dp}")
+
+        # DP group: fixed pp, vary dp over [0, dense_dp) -> all G segments.
+        for pp in range(PP):
+            segs = set(
+                seg_of_rank(pp * dense_dp + dp) for dp in range(dense_dp)
+            )
+            self.assertEqual(segs, set(range(G)), f"DP group pp={pp}")
+
+    def test_9216_job(self):
+        self._check_invariants(N=1152, R=8, TP=1, PP=16, EP=32, CP=1, G=9)
+
+    def test_small_compact(self):
+        # 1 node / EP group / segment per stage.
+        self._check_invariants(N=4, R=8, TP=1, PP=2, EP=8, CP=1, G=2)
+
+    def test_two_segments_more_stages(self):
+        # DP_nodes=2, seg=1 node per segment per stage.
+        self._check_invariants(N=8, R=8, TP=1, PP=4, EP=8, CP=1, G=2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/dlrover/python/tests/test_pod_scaler.py
+++ b/dlrover/python/tests/test_pod_scaler.py
@@ -27,6 +27,7 @@ from dlrover.python.common.constants import (
 )
 from dlrover.python.common.global_context import Context
 from dlrover.python.common.node import Node, NodeGroupResource, NodeResource
+from dlrover.python.master.resource.job import NodeGroupSchedule
 from dlrover.python.master.scaler.base_scaler import ScalePlan
 from dlrover.python.master.scaler.pod_scaler import PodScaler, new_tf_config
 from dlrover.python.tests.test_utils import mock_k8s_client
@@ -387,6 +388,40 @@ class PodScalerTest(unittest.TestCase):
         self.assertEqual(rank1.group, 1)
         self.assertEqual(rank1.group_size, 2)
         self.assertEqual(rank1.group_id, 1)
+
+    def test_scale_up_pods_with_ep_pp_dp(self):
+        """The ep_pp_dp schedule stripes nodes across groups so EP/PP stay
+        intra-group: with the compact topology below,
+        group(k) = (k % 2) // 1. Nodes 0,2 -> group 0; nodes 1,3 -> group 1."""
+        scaler = PodScaler("elasticjob-sample", "default")
+        scaler._distribution_strategy = DistributionStrategy.PS
+        scaler.set_group_affinity({0: 2, 1: 2})
+        scaler.set_node_group_schedule(
+            NodeGroupSchedule(
+                strategy="ep_pp_dp",
+                tp=1,
+                pp=2,
+                ep=8,
+                cp=1,
+                num_nodes=4,
+                ranks_per_node=8,
+            )
+        )
+        resource = NodeResource(4, 8192)
+        scale_plan = ScalePlan()
+        scale_plan.node_group_resources = {
+            NodeType.WORKER: NodeGroupResource(4, resource),
+        }
+        scaler._scale_up_pods(NodeType.WORKER, scale_plan, [], 0)
+        self.assertEqual(len(scaler._create_node_queue), 4)
+        # node 0,2 -> group 0 (segment 0); node 1,3 -> group 1 (segment 1)
+        groups = [n.group for n in scaler._create_node_queue]
+        ids = [n.rank_index for n in scaler._create_node_queue]
+        self.assertEqual(ids, [0, 1, 2, 3])
+        self.assertEqual(groups, [0, 1, 0, 1])
+        for n in scaler._create_node_queue:
+            self.assertEqual(n.group_size, 2)
+            self.assertEqual(n.group_id, n.group)
 
     def test_update_job_pods(self):
         scaler = PodScaler("elasticjob-sample", "default")

--- a/dlrover/python/tests/test_rdzv_manager.py
+++ b/dlrover/python/tests/test_rdzv_manager.py
@@ -19,7 +19,11 @@ from unittest.mock import patch
 
 import dlrover.python.util.store_util as store_util
 from dlrover.python.common.global_context import Context
-from dlrover.python.common.constants import NetworkFailureReason, NodeEventType
+from dlrover.python.common.constants import (
+    NetworkFailureReason,
+    NodeEventType,
+    NodeType,
+)
 from dlrover.python.common.node import Node
 from dlrover.python.elastic_agent.master_client import (
     MasterClient,
@@ -38,6 +42,7 @@ from dlrover.python.master.elastic_training.rdzv_manager import (
     UcpRdzvManager,
     create_training_rdzv_manager,
 )
+from dlrover.python.master.node.job_context import get_job_context
 from dlrover.python.tests.test_utils import start_local_master
 
 
@@ -302,6 +307,41 @@ class ElasticTrainingRendezvousManagerTest(unittest.TestCase):
         self.assertEqual(len(callback_results), 1)
         self.assertEqual(callback_results[0][0], 0)
         self.assertListEqual(callback_results[0][1], [0, 1])
+
+    def test_world_log_and_rank_divergence_warning(self):
+        job_context = get_job_context()
+        workers = {
+            0: Node(NodeType.WORKER, 0, node_group=0, node_group_id=0),
+            2: Node(NodeType.WORKER, 2, node_group=1, node_group_id=1),
+        }
+        job_context.update_job_nodes_by_type(NodeType.WORKER, workers)
+        try:
+            rdzv_manager = ElasticTrainingRendezvousManager()
+            rdzv_manager.update_rdzv_params(2, 3, 0.1, 1)
+            for worker in workers.values():
+                rdzv_manager.add_alive_node(worker)
+            # rank 1 never joins: the rendezvous completes on the min-nodes
+            # timeout with ranks {0, 2}, so rank 2 sits at world position 1.
+            rdzv_manager.join_rendezvous(0, 0, 8, "10.0.0.1")
+            rdzv_manager.join_rendezvous(2, 2, 8, "10.0.0.3")
+            time.sleep(0.2)
+            with self.assertLogs("dlrover.logger", level="INFO") as logs:
+                round, _, world = rdzv_manager.get_comm_world(2)
+            self.assertEqual(round, 1)
+            self.assertListEqual(list(world.keys()), [0, 2])
+            joined = " ".join(logs.output)
+            self.assertIn("World [1-2/2]:", joined)
+            self.assertIn(
+                "pos=0,rank=0,id=0,ip=10.0.0.1,nproc=8,group=0", joined
+            )
+            self.assertIn(
+                "pos=1,rank=2,id=2,ip=10.0.0.3,nproc=8,group=1", joined
+            )
+            warnings = [o for o in logs.output if "diverge" in o]
+            self.assertTrue(warnings)
+            self.assertIn("pos=1->rank=2", warnings[0])
+        finally:
+            job_context.clear_job_nodes()
 
     def test_min_nodes_with_unit(self):
         rdzv_manager = ElasticTrainingRendezvousManager()

--- a/dlrover/python/util/args_util.py
+++ b/dlrover/python/util/args_util.py
@@ -146,3 +146,25 @@ def parse_group_affinity(value) -> Optional[Dict[int, int]]:
             )
         group_affinity[k] = v
     return group_affinity
+
+
+def validate_group_affinity_equal_size(
+    group_affinity: Optional[Dict[int, int]],
+) -> Optional[int]:
+    """Return the single group size shared by all groups, or None when group
+    affinity is not configured.
+
+    Raises ``ValueError`` when the groups are present but their sizes are not
+    all equal. This is the hard platform requirement (equal-size segments)
+    that the ``ep_pp_dp`` node-group strategy relies on.
+    """
+    if not group_affinity:
+        return None
+    sizes = set(group_affinity.values())
+    if len(sizes) != 1:
+        raise ValueError(
+            "group_affinity requires all group sizes to be equal, got "
+            f"{sorted(sizes)}; ep_pp_dp node-group strategy needs equal-size "
+            "segments."
+        )
+    return next(iter(sizes))


### PR DESCRIPTION
## What
  Adds --node-group-strategy (contiguous | ep_pp_dp) plus --tp/--pp/--ep/--cp master args, so dlrover places Megatron MoE worker nodes onto node groups (== physical segments) with EP groups and PP kept
  intra-segment while only the dense DP allreduce crosses segments.

  ## Why
  Default ep-dp-pp + contiguous scheduling makes PP (latency-critical, sequential) span all segments — worst case. Megatron forces Order.endswith(pp) when EP>1 (parallel_state.py assert) and NCCL
  --use-tp-pp-dp-mapping is incompatible with EP, so the fix lives at the scheduling layer.

  ## How
  group(node_rank) = (node_rank % DP_nodes) // (DP_nodes // G), DP_nodes = N/(TP*PP*CP). Each pipeline stage is striped across all G segments identically, so adjacent PP stages same-position nodes share a
  segment. validate_topology fails fast on TP/CP>1, dense_dp%G!=0, node not segment-aligned, EP not dividing a segment-per-stage block, EP not whole-nodes, unequal group sizes, group ids != {0..G-1}.
  resolve_group_id takes an optional NodeGroupSchedule; None/contiguous keeps existing behavior.

  ## Backward compat
  Unset / contiguous (default) unchanged; parallel sizes read and validated only under ep_pp_dp.

  ## Tests
  New test_node_group_strategy.py (24): stripe formula, every validate_topology constraint pass/fail, rank-level EP/PP-intra & DP-cross invariants on the 9216-card job (N=1152,R=8,TP=1,PP=16,EP=32,G=9)
  plus smaller topologies. Extended test_args, test_args_util, test_pod_scaler, test_job_manager.