### PR TITLE
Feat(master): validate reported local_world_size vs ep_pp_dp ranks_per_node

### DIFF
--- a/dlrover/python/master/dist_master.py
+++ b/dlrover/python/master/dist_master.py
@@ -152,6 +152,15 @@ class DistributedJobMaster(JobMaster):
             RendezvousName.TRAINING: create_training_rdzv_manager(),
             RendezvousName.NETWORK_CHECK: NetworkCheckRendezvousManager(),
         }
+        if self.job_manager is not None:
+            # The ep_pp_dp ranks_per_node is inferred from the requested
+            # GPU count at startup; re-validate it against the actual
+            # local_world_size reported by trainers at rendezvous time.
+            expected_ranks = self.job_manager.get_expected_ranks_per_node()
+            if expected_ranks is not None:
+                self.rdzv_managers[
+                    RendezvousName.TRAINING
+                ].set_expected_local_world_size(expected_ranks)
         self.diagnosis_manager = DiagnosisMaster(args)
         self._event_reporter = get_event_reporter()
         self.job_metric_collector = self._create_metric_collector_if_needed(

--- a/dlrover/python/master/elastic_training/rdzv_manager.py
+++ b/dlrover/python/master/elastic_training/rdzv_manager.py
@@ -92,6 +92,11 @@ class RendezvousManager(metaclass=ABCMeta):
         self._rdzv_blocked = False
         self._rdzv_block_reason = ""
         self._rdzv_completed_callbacks = []
+        # Expected local world size (ranks per node); None disables the
+        # join-time re-validation. e.g. the ep_pp_dp schedule infers
+        # ranks_per_node from the requested GPU count and re-validates it
+        # here against the --nproc_per_node reported by each trainer.
+        self._expected_local_world_size: Optional[int] = None
 
     def get_min_nodes(self):
         return self._rdzv_params.min_nodes
@@ -310,6 +315,18 @@ class RendezvousManager(metaclass=ABCMeta):
                     nodes.append(node_id)
         return nodes
 
+    def set_expected_local_world_size(self, local_world_size):
+        """Set the expected local world size (ranks per node) to
+        re-validate every node joining this rendezvous. None disables the
+        check. The ep_pp_dp node-group placement is validated at startup
+        with a ranks_per_node inferred from the requested GPU count; the
+        actual per-node process number (dlrover-run --nproc_per_node) only
+        reaches the master here, at rendezvous time, so the topology is
+        re-checked before the world freezes.
+        """
+        with self._lock:
+            self._expected_local_world_size = local_world_size
+
     def join_rendezvous(
         self,
         node_id,
@@ -326,6 +343,22 @@ class RendezvousManager(metaclass=ABCMeta):
             int: the number of rendezvous round.
         """
         with self._lock:
+            if (
+                self._expected_local_world_size is not None
+                and local_world_size != self._expected_local_world_size
+            ):
+                msg = (
+                    f"Node {node_id} (rank {node_rank}, ip {node_ip}) "
+                    f"reports local_world_size={local_world_size}, but "
+                    "the validated ep_pp_dp topology requires "
+                    f"ranks_per_node={self._expected_local_world_size}. "
+                    "The node-group placement was computed from "
+                    "ranks_per_node (inferred from the requested GPU "
+                    "count). Align the dlrover-run --nproc_per_node (or "
+                    "the GPU requests) with the validated topology."
+                )
+                logger.error(msg)
+                raise ValueError(msg)
             if not self._waiting_nodes:
                 self._start_rdzv_ts = time.time()
             if node_rank in self._waiting_nodes:

--- a/dlrover/python/master/node/dist_job_manager.py
+++ b/dlrover/python/master/node/dist_job_manager.py
@@ -298,6 +298,15 @@ class DistributedJobManager(JobManager):
                 len(job_args.group_affinity),
             )
 
+    def get_expected_ranks_per_node(self) -> Optional[int]:
+        """Return the validated ``ranks_per_node`` of the ep_pp_dp topology
+        (or None when the strategy is not enabled) so other components can
+        re-validate it against the trainer-reported local_world_size."""
+        schedule = self._job_resource.node_group_schedule
+        if schedule is None or schedule.strategy != NodeGroupStrategy.EP_PP_DP:
+            return None
+        return schedule.ranks_per_node
+
     def start(self):
         self._scaler.start()
         self._job_optimizer.update_job_uuid(self._job_args.job_uuid)

--- a/dlrover/python/tests/test_job_manager.py
+++ b/dlrover/python/tests/test_job_manager.py
@@ -307,6 +307,25 @@ class DistributedJobManagerTest(unittest.TestCase):
         manager._init_group_affinity(SimpleNamespace(group_affinity={}))
         self.assertIsNone(manager._job_resource.group_affinity)
 
+    def test_get_expected_ranks_per_node(self):
+        # None without the ep_pp_dp schedule (check disabled), the
+        # validated ranks_per_node with it.
+        manager = self._new_manager_with_worker_count(4, gpu_num=8)
+        self.assertIsNone(manager.get_expected_ranks_per_node())
+        manager._job_resource.node_group_schedule = NodeGroupSchedule(
+            strategy=NodeGroupStrategy.EP_PP_DP,
+            num_nodes=4,
+            ranks_per_node=8,
+        )
+        self.assertEqual(manager.get_expected_ranks_per_node(), 8)
+        # a contiguous schedule is not ep_pp_dp either
+        manager._job_resource.node_group_schedule = NodeGroupSchedule(
+            strategy=NodeGroupStrategy.CONTIGUOUS,
+            num_nodes=4,
+            ranks_per_node=8,
+        )
+        self.assertIsNone(manager.get_expected_ranks_per_node())
+
     def test_init_group_affinity_matched(self):
         # worker replicas == sum(values) -> apply and forward
         manager = self._new_manager_with_worker_count(25)

--- a/dlrover/python/tests/test_node_group_strategy.py
+++ b/dlrover/python/tests/test_node_group_strategy.py
@@ -295,6 +295,81 @@ class StripeInvariantsTest(unittest.TestCase):
     def test_9216_job(self):
         self._check_invariants(N=1152, R=8, TP=1, PP=16, EP=32, CP=1, G=9)
 
+    def test_9216_job_ep_and_pp_worlds_intra_segment(self):
+        # Worker-level view of the 9216-card job: G=9 segments x 128
+        # nodes, R=8, PP=16, EP=32. After the ep_pp_dp stripe placement,
+        # every EP world (32 ranks = 4 workers) and every PP world (the
+        # same 4-worker slot across all pipeline stages) stay inside one
+        # segment. E.g. the first ep-pp column gathers workers 0-3 (pp0),
+        # 72-75 (pp1), 144-147 (pp2), ..., 1080-1083 (pp15), all on
+        # segment 0.
+        N, R, PP, EP, G = 1152, 8, 16, 32, 9
+        ga = {i: N // G for i in range(G)}
+        sched = _ep_pp_dp(
+            tp=1, pp=PP, ep=EP, cp=1, num_nodes=N, ranks_per_node=R
+        )
+        validate_topology(ga, sched)
+
+        def seg(worker):
+            return resolve_group_id(ga, NodeType.WORKER, worker, sched)
+
+        dp_nodes = N // PP  # 72 workers per pipeline stage
+        seg_nodes = dp_nodes // G  # 8 workers per segment per stage
+        ep_workers = EP // R  # 4 workers per EP world
+        slots = dp_nodes // ep_workers  # 18 EP-group slots per stage
+
+        # every segment holds exactly 128 workers, covering the same
+        # within-stage slot in all PP stages
+        for g in range(G):
+            members = [w for w in range(N) if seg(w) == g]
+            self.assertEqual(len(members), N // G, f"segment {g}")
+            expected_positions = [
+                p
+                for p in range(g * seg_nodes, (g + 1) * seg_nodes)
+                for _ in range(PP)
+            ]
+            self.assertEqual(
+                sorted(w % dp_nodes for w in members), expected_positions
+            )
+
+        # every EP world (4 consecutive workers in one stage) is inside
+        # a single segment
+        for s in range(PP):
+            for j in range(slots):
+                members = [
+                    s * dp_nodes + j * ep_workers + k
+                    for k in range(ep_workers)
+                ]
+                self.assertEqual(
+                    len(set(seg(w) for w in members)), 1, f"pp={s} j={j}"
+                )
+
+        # every PP world (the same slot across all stages) is inside a
+        # single segment
+        for j in range(slots):
+            members = [
+                s * dp_nodes + j * ep_workers + k
+                for s in range(PP)
+                for k in range(ep_workers)
+            ]
+            self.assertEqual(len(set(seg(w) for w in members)), 1, f"slot {j}")
+
+        # the first PP world matches the expected layout literally:
+        # pp0: 0-3, pp1: 72-75, ..., pp15: 1080-1083, all on segment 0.
+        first = [
+            s * dp_nodes + k for s in range(PP) for k in range(ep_workers)
+        ]
+        self.assertEqual([seg(w) for w in first], [0] * len(first))
+        ranges = [
+            (first[s * ep_workers], first[(s + 1) * ep_workers - 1])
+            for s in range(PP)
+        ]
+        self.assertEqual(ranges[0], (0, 3))
+        self.assertEqual(ranges[1], (72, 75))
+        self.assertEqual(ranges[2], (144, 147))
+        self.assertEqual(ranges[3], (216, 219))
+        self.assertEqual(ranges[15], (1080, 1083))
+
     def test_small_compact(self):
         # 1 node / EP group / segment per stage.
         self._check_invariants(N=4, R=8, TP=1, PP=2, EP=8, CP=1, G=2)

--- a/dlrover/python/tests/test_rdzv_manager.py
+++ b/dlrover/python/tests/test_rdzv_manager.py
@@ -343,6 +343,30 @@ class ElasticTrainingRendezvousManagerTest(unittest.TestCase):
         finally:
             job_context.clear_job_nodes()
 
+    def test_join_rendezvous_validates_expected_local_world_size(self):
+        rdzv_manager = ElasticTrainingRendezvousManager()
+        rdzv_manager.update_rdzv_params(2, 2, 0.1, 1)
+        rdzv_manager.set_expected_local_world_size(8)
+
+        # a node reporting the expected nproc joins normally
+        rdzv_manager.join_rendezvous(0, 0, 8)
+        self.assertEqual(list(rdzv_manager._waiting_nodes.keys()), [0])
+
+        # a node reporting a different nproc fails fast with a clear
+        # error (e.g. --nproc_per_node mismatches the inferred
+        # ranks_per_node of the ep_pp_dp topology), leaving no state
+        with self.assertRaises(ValueError) as ctx:
+            rdzv_manager.join_rendezvous(1, 1, 4, "10.0.0.2")
+        self.assertIn("local_world_size=4", str(ctx.exception))
+        self.assertIn("ranks_per_node=8", str(ctx.exception))
+        self.assertEqual(list(rdzv_manager._waiting_nodes.keys()), [0])
+
+        # the failure is loud in the master log
+        with self.assertLogs("dlrover.logger", level="ERROR") as logs:
+            with self.assertRaises(ValueError):
+                rdzv_manager.join_rendezvous(1, 1, 4, "10.0.0.2")
+        self.assertIn("--nproc_per_node", " ".join(logs.output))
+
     def test_min_nodes_with_unit(self):
         rdzv_manager = ElasticTrainingRendezvousManager()
         min_nodes = 8


### PR DESCRIPTION
## Summary

  Follow-up to #1740, implementing the review-agreed remediation for the
  `ranks_per_node` inference issue: `ranks_per_node` is inferred from the
  requested GPU count at master startup, while the actual per-node process
  number comes from `dlrover-run --nproc_per_node` on the trainer side and
  only reaches the master when an agent joins the rendezvous (stored by
  `rdzv_manager` as `process_num`). This PR re-validates the two against
  each other at join time, so a misconfigured job fails fast instead of
  training with wrong rank boundaries.

  ## Changes

  - `RendezvousManager` carries an expected local world size, injected by
    `DistributedJobMaster` **only when the ep_pp_dp strategy is enabled**
    (`None` disables the check, so NetworkCheck rendezvous and non-ep_pp_dp
    jobs are untouched).
  - `join_rendezvous` re-validates each node's reported `local_world_size`
    **before mutating any state**: on mismatch it logs an ERROR with a fix
    hint and raises `ValueError`, so the job fails before the world freezes
    (e.g. 8 requested GPUs with `nproc_per_node=4`: startup validation
    passes with S=16 while the real S=8 makes EP groups cross segments).
  - `DistributedJobManager.get_expected_ranks_per_node()` exposes the
    validated R for the injection.

  ## Tests

  - `test_rdzv_manager`: a node with the expected nproc joins normally; a
    mismatching node raises with a clear message, leaves no waiting state,
    and the ERROR log carries the `--nproc_per_node` hint.
  - `test_node_group_strategy`: worker-level invariants on the 9216-card
    job (N=1152 = 9 segments × 128 nodes, R=8, PP=16, EP=32) — every
    segment holds exactly 128 workers on the same per-stage slot; every EP
    world (4 workers) and every PP world (the same 4-worker slot across
    all 16 stages, e.g. `ep_pp0 = 0-3, 72-75, ..., 1080-1083`) stays
    inside a single segment.
  - `test_job_manager`: `get_expected_ranks_per_node` returns the
    validated R only for ep_pp_dp.

  ## Notes

  - This branch is **stacked on #1740** (it uses `NodeGroupSchedule` from
    there), so the diff currently includes #1740's commits as well and
    will collapse to this commit's changes once #1740 merges.
  - Remaining agreed remediation will follow in separate PRs: an explicit
    `--ranks-per-node` master argument, and fixing the `gpu_num` parsing
    for limits-only / non-NVIDIA resources.