### PR TITLE
fix(xpu_timer): add missing f-string prefix to the missing-path message

### DIFF
--- a/xpu_timer/py_xpu_timer/py_xpu_timer/gen_trace_timeline.py
+++ b/xpu_timer/py_xpu_timer/py_xpu_timer/gen_trace_timeline.py
@@ -575,7 +575,7 @@ def main():
     timeline_dir = args.path
     files = Path(timeline_dir)
     if not files.exists():
-        print("path {timeline_dir} not exists")
+        print(f"path {timeline_dir} not exists")
         return
     generate_perfetto_trace(args)
     parse_timeline_stack(timeline_dir)


### PR DESCRIPTION
### What

In `xpu_timer/py_xpu_timer/py_xpu_timer/gen_trace_timeline.py`, the guard that
reports a non-existent timeline directory is missing its `f` prefix:

```python
timeline_dir = args.path
files = Path(timeline_dir)
if not files.exists():
    print("path {timeline_dir} not exists")   # <- no f
    return
```

So the user sees the literal placeholder instead of the path they passed:

```
path {timeline_dir} not exists
```

### Fix

Add the missing `f` prefix so the offending directory is shown. One-character
change, no logic touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
