### PR TITLE
Feat(master): soft group affinity for unequal-size segment placement

### DIFF
--- a/dlrover/python/master/args.py
+++ b/dlrover/python/master/args.py
@@ -203,6 +203,29 @@ def _build_master_args_parser():
         help="Context-parallel size. Only consulted (and required to be 1) "
         "when --node-group-strategy=ep_pp_dp.",
     )
+    parser.add_argument(
+        "--soft-group-affinity",
+        "--soft_group_affinity",
+        default=None,
+        type=parse_group_affinity,
+        help="Unequal-size node group pod counts, e.g. "
+        '--soft-group-affinity="{0: 30, 1: 20}" means group 0 schedules '
+        "30 pods and group 1 schedules 20 pods. Unlike --group-affinity "
+        "the sizes may be heterogeneous, enabling --node-group-strategy "
+        "placement over uneven segments. The worker replicas must equal "
+        "the sum of all group sizes. Mutually exclusive with "
+        "--group-affinity.",
+    )
+    parser.add_argument(
+        "--no-group-failover",
+        "--no_group_failover",
+        action="store_true",
+        default=False,
+        help="With --soft-group-affinity: drop the node-group labels of "
+        "a relaunched (failover) worker pod so it can be scheduled onto "
+        "any segment. Defaults to false, i.e. the relaunch keeps its "
+        "group and follows the original segment affinity.",
+    )
     return parser
 
 

--- a/dlrover/python/master/main.py
+++ b/dlrover/python/master/main.py
@@ -93,6 +93,8 @@ def run(args):
     job_args.pipeline_model_parallel_size = args.pipeline_model_parallel_size
     job_args.expert_model_parallel_size = args.expert_model_parallel_size
     job_args.context_parallel_size = args.context_parallel_size
+    job_args.soft_group_affinity = args.soft_group_affinity
+    job_args.no_group_failover = args.no_group_failover
     if args.xpu_type.lower() == "ascend":
         job_args.xpu_type = Accelerators.ASCEND_NPU
     elif args.xpu_type.lower() == "nvidia":

--- a/dlrover/python/master/node/dist_job_manager.py
+++ b/dlrover/python/master/node/dist_job_manager.py
@@ -78,6 +78,10 @@ from dlrover.python.master.resource.job import (
     PSJobResourceOptimizer,
     validate_topology,
 )
+from dlrover.python.master.resource.soft_group import (
+    SoftGroupSchedule,
+    validate_soft_group_topology,
+)
 from dlrover.python.master.scaler.base_scaler import ScalePlan, Scaler
 from dlrover.python.master.scaler.factory import new_job_scaler
 from dlrover.python.master.watcher.base_watcher import NodeWatcher
@@ -135,6 +139,9 @@ class DistributedJobManager(JobManager):
             )
             node_restart_count[type] = node_args.restart_count
 
+        # _init_soft_group_affinity runs first so its mutual-exclusion
+        # check takes precedence over the legacy group-affinity errors.
+        self._init_soft_group_affinity(job_args)
         self._init_group_affinity(job_args)
 
         self._ps_is_critical = False
@@ -207,6 +214,12 @@ class DistributedJobManager(JobManager):
         self._scaler.set_node_group_schedule(
             self._job_resource.node_group_schedule
         )
+        # _init_soft_group_affinity (above) has already applied
+        # --soft-group-affinity; forward the soft schedule so the scaler
+        # labels newly created pods with the soft-resolved groups.
+        self._scaler.set_soft_group_schedule(
+            self._job_resource.soft_group_schedule
+        )
         self._init_training_node_manager()
         self._relaunched_groups: List[int] = []
         self._group_relaunch_count = 0
@@ -234,7 +247,11 @@ class DistributedJobManager(JobManager):
         )
         ep_pp_dp = strategy == NodeGroupStrategy.EP_PP_DP
         if not job_args.group_affinity:
-            if ep_pp_dp:
+            # --soft-group-affinity configures the groups its own way
+            # (unequal sizes); the legacy requirement below does not
+            # apply. Mutual exclusion is enforced by
+            # _init_soft_group_affinity.
+            if ep_pp_dp and not getattr(job_args, "soft_group_affinity", None):
                 raise ValueError(
                     "node-group-strategy=ep_pp_dp requires --group-affinity "
                     "to be set (groups == physical segments)."
@@ -298,12 +315,104 @@ class DistributedJobManager(JobManager):
                 len(job_args.group_affinity),
             )
 
+    def _init_soft_group_affinity(self, job_args: JobArgs):
+        """Validate and apply the ``--soft-group-affinity`` configuration.
+
+        Soft group affinity accepts UNEQUAL group sizes (the production
+        reality of uneven per-segment free resources) and is fully
+        isolated from the ``--group-affinity`` path: the schedule is
+        validated by :func:`validate_soft_group_topology`, attached to the
+        ``JobResource`` as ``soft_group_schedule``, and consumed by
+        ``init_job_node_meta`` and the scaler via
+        :func:`resolve_soft_group_id`. The two features are mutually
+        exclusive. The EP alignment (every group size must be a multiple
+        of the EP slot EP/R) is mandatory by default — the master fails
+        to start otherwise.
+
+        ``--no-group-failover`` is carried on the schedule and enforced
+        at the scaler exit (PodScaler.scale strips the node-group
+        labels from every relaunched node, whichever relaunch path —
+        single-node, job-level restart or group relaunch — produced
+        the plan) so the FO pod can be scheduled onto any segment.
+        """
+        if not job_args.soft_group_affinity:
+            return
+        if job_args.group_affinity:
+            raise ValueError(
+                "--soft-group-affinity cannot be combined with "
+                "--group-affinity: it replaces the equal-size static "
+                "mapping with an unequal-size soft mapping resolved at "
+                "pod creation time."
+            )
+        worker_resource = self._job_resource.node_group_resources.get(
+            NodeType.WORKER
+        )
+        if worker_resource is None:
+            raise ValueError(
+                "--soft-group-affinity requires a worker replica spec in "
+                "the job resource."
+            )
+        ranks_per_node = (
+            worker_resource.node_resource.gpu_num
+            if worker_resource.node_resource is not None
+            else 0
+        )
+        schedule = SoftGroupSchedule(
+            strategy=getattr(
+                job_args, "node_group_strategy", NodeGroupStrategy.CONTIGUOUS
+            ),
+            sizes=job_args.soft_group_affinity,
+            tp=getattr(job_args, "tensor_model_parallel_size", 1),
+            pp=getattr(job_args, "pipeline_model_parallel_size", 1),
+            ep=getattr(job_args, "expert_model_parallel_size", 1),
+            cp=getattr(job_args, "context_parallel_size", 1),
+            num_nodes=worker_resource.count,
+            ranks_per_node=ranks_per_node,
+            no_group_failover=job_args.no_group_failover,
+        )
+        # Validate BEFORE mutating the JobResource so a violation leaves
+        # the resource untouched and the master fails to start cleanly.
+        validate_soft_group_topology(schedule)
+
+        self._job_resource.soft_group_schedule = schedule
+        model_parallel = schedule.tp * schedule.pp * schedule.cp
+        dense_dp = (schedule.num_nodes * schedule.ranks_per_node) // (
+            model_parallel
+        )
+        ep_workers = (
+            schedule.ep // schedule.ranks_per_node
+            if schedule.ranks_per_node > 0
+            else 0
+        )
+        logger.info(
+            "Enable soft group affinity: %s (strategy=%s, tp=%d, pp=%d, "
+            "ep=%d, cp=%d, N=%d, R=%d, dp=%d, ep_workers=%d, "
+            "no_group_failover=%s): every group size is aligned to the "
+            "EP slot and workers are labeled with the soft-resolved "
+            "groups at pod creation.",
+            schedule.sizes,
+            schedule.strategy,
+            schedule.tp,
+            schedule.pp,
+            schedule.ep,
+            schedule.cp,
+            schedule.num_nodes,
+            schedule.ranks_per_node,
+            dense_dp // schedule.ep,
+            ep_workers,
+            schedule.no_group_failover,
+        )
+
     def get_expected_ranks_per_node(self) -> Optional[int]:
-        """Return the validated ``ranks_per_node`` of the ep_pp_dp topology
-        (or None when the strategy is not enabled) so other components can
-        re-validate it against the trainer-reported local_world_size."""
+        """Return the validated ``ranks_per_node`` of the ep_pp_dp or
+        soft-group topology (or None when neither is enabled) so other
+        components can re-validate it against the trainer-reported
+        local_world_size."""
         schedule = self._job_resource.node_group_schedule
         if schedule is None or schedule.strategy != NodeGroupStrategy.EP_PP_DP:
+            soft_schedule = self._job_resource.soft_group_schedule
+            if soft_schedule is not None:
+                return soft_schedule.ranks_per_node
             return None
         return schedule.ranks_per_node
 

--- a/dlrover/python/master/resource/job.py
+++ b/dlrover/python/master/resource/job.py
@@ -30,6 +30,10 @@ from dlrover.python.common.global_context import Context
 from dlrover.python.common.log import default_logger as logger
 from dlrover.python.common.node import Node, NodeGroupResource, NodeResource
 from dlrover.python.common.serialize import JsonSerializable
+from dlrover.python.master.resource.soft_group import (
+    SoftGroupSchedule,
+    resolve_soft_group_id,
+)
 from dlrover.python.master.resource.brain_optimizer import (
     BrainResoureOptimizer,
 )
@@ -324,6 +328,11 @@ class JobResource(JsonSerializable):
         # i.e. ``CONTIGUOUS`` behavior; set to a NodeGroupSchedule(strategy=
         # ep_pp_dp, ...) when the ep_pp_dp strategy is enabled and validated.
         self.node_group_schedule: Optional[NodeGroupSchedule] = None
+        # Soft group schedule (--soft-group-affinity, unequal group sizes),
+        # fully isolated from group_affinity / node_group_schedule above
+        # and mutually exclusive with them. When set, init_job_node_meta
+        # resolves worker groups with resolve_soft_group_id.
+        self.soft_group_schedule: Optional[SoftGroupSchedule] = None
 
     def get_node_group_resource(self, node_type):
         return self.node_group_resources.get(node_type, None)
@@ -385,7 +394,20 @@ class JobResource(JsonSerializable):
             group_nodes: Dict[int, Node] = {}
             group_size = self._group_count()
             for i in range(group_resource.count):
-                group_id = self._resolve_group_id(node_type, i)
+                if self.soft_group_schedule is not None:
+                    # --soft-group-affinity: unequal-size groups resolved
+                    # by the isolated soft resolver instead of the
+                    # group_affinity helpers above.
+                    group_id = resolve_soft_group_id(
+                        self.soft_group_schedule, node_type, i
+                    )
+                    group_size = (
+                        len(self.soft_group_schedule.sizes)
+                        if group_id is not None
+                        else None
+                    )
+                else:
+                    group_id = self._resolve_group_id(node_type, i)
                 group_nodes[i] = Node(
                     node_type=node_type,
                     node_id=i,

--- a/dlrover/python/master/resource/soft_group.py
+++ b/dlrover/python/master/resource/soft_group.py
@@ -1,0 +1,315 @@
+# Copyright 2026 The DLRover Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import threading
+from typing import Dict, List, Optional
+
+from dlrover.python.common.constants import (
+    NodeGroupStrategy,
+    NodeType,
+)
+from dlrover.python.common.log import default_logger as logger
+
+
+class SoftGroupSchedule(object):
+    """Schedule of unequally-sized node groups (--soft-group-affinity).
+
+    Fully isolated from the plain ``--group-affinity`` path
+    (:class:`NodeGroupSchedule`/:func:`validate_topology`/
+    :func:`resolve_group_id` in ``dlrover.python.master.resource.job``):
+    a soft schedule declares a heterogeneous per-group pod count and
+    resolves every worker's group id at pod-creation time so the scaler
+    labels pods with ``scheduling/rack-group`` for segment-affinity
+    scheduling. There is deliberately NO equal-size constraint, but
+    EVERY group size must be a multiple of the EP slot
+    (``ep_workers = EP/R`` pods): this EP alignment is an unconditional
+    start-up requirement, not an option.
+
+    Args:
+        strategy: one of :class:`NodeGroupStrategy` (contiguous or
+            ep_pp_dp), consulted by :func:`resolve_soft_group_id`.
+        sizes: ``{group_id: pod count}``, e.g. ``{0: 30, 1: 20}``; the
+            keys are the node-group ids and can be any non-negative
+            integers (the fill order is ascending) and every count must
+            be a multiple of the EP slot.
+        tp / pp / ep / cp: Megatron parallel sizes. Only ``tp == 1`` and
+            ``cp == 1`` are supported today.
+        num_nodes: total number of worker nodes (``N``), must equal the
+            sum of ``sizes``.
+        ranks_per_node: number of ranks per worker node (``R``).
+        no_group_failover: when true (--no-group-failover), a relaunched
+            (FO) worker drops its node-group labels so it can be
+            scheduled onto any segment (see
+            DistributedJobManager._relaunch_node); when false (default)
+            the relaunch keeps the group labels and follows the
+            original segment affinity.
+    """
+
+    def __init__(
+        self,
+        strategy: str,
+        sizes: Dict[int, int],
+        tp: int = 1,
+        pp: int = 1,
+        ep: int = 1,
+        cp: int = 1,
+        num_nodes: int = 0,
+        ranks_per_node: int = 0,
+        no_group_failover: bool = False,
+    ):
+        self.strategy = strategy
+        self.sizes = sizes
+        self.tp = tp
+        self.pp = pp
+        self.ep = ep
+        self.cp = cp
+        self.num_nodes = num_nodes
+        self.ranks_per_node = ranks_per_node
+        self.no_group_failover = no_group_failover
+        # Laid-out {rank_index: group_id} for the ep_pp_dp strategy,
+        # built lazily by resolve_soft_group_id.
+        self._ep_pp_dp_layout: Optional[List[int]] = None
+        self._layout_lock = threading.Lock()
+
+
+def ep_group_workers(schedule: SoftGroupSchedule) -> int:
+    """Return the EP slot size in pods (``EP/R``, one EP communication
+    group of ``EP`` consecutive ranks). The caller must have validated
+    ``EP % R == 0`` (see validate_soft_group_topology)."""
+    if schedule.ranks_per_node <= 0:
+        return 0
+    return schedule.ep // schedule.ranks_per_node
+
+
+def validate_soft_group_topology(
+    schedule: Optional[SoftGroupSchedule],
+) -> None:
+    """Validate a soft group schedule (``--soft-group-affinity``).
+
+    Distinct from :func:`validate_topology`: there is no equal-size
+    constraint and no segment-count divisibility; raising ``ValueError``
+    leaves the schedule unapplied so the master fails to start cleanly.
+
+    Constraints (``N`` = #worker nodes, ``R`` = ranks/node, ``G`` =
+    ``len(sizes)``, ``model_parallel = TP*PP*CP``,
+    ``dense_dp = N*R/model_parallel``, ``ep_workers = EP/R``):
+
+      - ``sizes`` is non-empty with positive counts and non-negative keys;
+      - ``sum(sizes) == N``;
+      - scope: ``TP == 1`` and ``CP == 1``; ``PP > 0`` and ``EP > 0``;
+      - ``N % model_parallel == 0`` and ``dense_dp % EP == 0`` so the
+        data-parallel size ``dp = dense_dp/EP`` is an integral number;
+      - ``EP % R == 0`` (an EP slot is composed of whole nodes) and every
+        group size is a multiple of ``ep_workers`` — the EP alignment is
+        mandatory by default, no opt-in flag;
+      - when the strategy is ``ep_pp_dp``: additionally
+        ``DP_nodes % ep_workers == 0`` so every pipeline stage holds a
+        whole number of EP slots.
+    """
+    if schedule is None or not schedule.sizes:
+        return
+
+    sizes = schedule.sizes
+    tp, pp, ep, cp = schedule.tp, schedule.pp, schedule.ep, schedule.cp
+    n, r = schedule.num_nodes, schedule.ranks_per_node
+
+    total = sum(sizes.values())
+    if total != n:
+        raise ValueError(
+            "soft-group-affinity sizes sum to "
+            f"{total} pods, but the job declares N={n} worker replicas; "
+            "align --soft-group-affinity with the worker count."
+        )
+    if any(size <= 0 for size in sizes.values()):
+        raise ValueError(
+            f"soft-group-affinity group sizes must be positive, got {sizes}."
+        )
+    if any(key < 0 for key in sizes.keys()):
+        raise ValueError(
+            "soft-group-affinity group ids must be non-negative, got "
+            f"{sorted(sizes.keys())}."
+        )
+
+    if tp != 1:
+        raise ValueError(
+            "--soft-group-affinity currently requires TP=1 "
+            f"(got tp={tp}); TP>1 support is planned for a later phase."
+        )
+    if cp != 1:
+        raise ValueError(
+            "--soft-group-affinity currently requires CP=1 "
+            f"(got cp={cp}); CP>1 support is planned for a later phase."
+        )
+    if pp <= 0 or ep <= 0:
+        raise ValueError(
+            f"--soft-group-affinity requires pp={pp} and ep={ep} to be "
+            "positive."
+        )
+    if r <= 0:
+        raise ValueError(
+            "--soft-group-affinity requires ranks_per_node>0 "
+            f"(NodeResource.gpu_num), got {r}."
+        )
+
+    model_parallel = tp * pp * cp
+    if n % model_parallel != 0:
+        raise ValueError(
+            "--soft-group-affinity requires the worker node count N="
+            f"{n} to be divisible by TP*PP*CP={model_parallel}."
+        )
+    dense_dp = (n * r) // model_parallel
+    if dense_dp % ep != 0:
+        raise ValueError(
+            "--soft-group-affinity requires dense_dp="
+            f"{dense_dp} (N*R/(TP*PP*CP)) to be divisible by EP={ep} so "
+            "the data-parallel size dp=dense_dp/EP is an integer."
+        )
+
+    # EP alignment is the default, not an option: an EP slot must be
+    # well defined (EP % R == 0) and every group must be a whole number
+    # of EP slots, otherwise the master fails to start.
+    if ep % r != 0:
+        raise ValueError(
+            "--soft-group-affinity requires EP="
+            f"{ep} to be divisible by ranks_per_node R={r} so an EP "
+            "group (slot) is composed of whole nodes."
+        )
+    ep_workers = ep // r
+    for group_id, size in sizes.items():
+        if size % ep_workers != 0:
+            raise ValueError(
+                "--soft-group-affinity requires every group size to be a "
+                f"multiple of the EP slot (ep_workers={ep_workers}); "
+                f"group {group_id} has {size} pods."
+            )
+
+    if schedule.strategy == NodeGroupStrategy.EP_PP_DP:
+        dp_nodes = n // model_parallel
+        if dp_nodes % ep_workers != 0:
+            raise ValueError(
+                "--soft-group-affinity with node-group-strategy=ep_pp_dp "
+                f"requires DP_nodes={dp_nodes} (nodes per pipeline stage) "
+                f"to be divisible by ep_workers={ep_workers}."
+            )
+
+
+def _ep_pp_dp_layout(schedule: SoftGroupSchedule) -> List[int]:
+    """Compute (once per schedule) the full-world group sequence of the
+    ``ep_pp_dp`` strategy: ``{rank_index: group_id}`` for ``k = 0..N-1``.
+
+    Each round takes one EP slot (``ep_workers`` consecutive pods) from
+    every non-exhausted group in ascending group-id order — "take
+    ep-size pods from a group, jump to the next group, and so on".
+    Validation guarantees every size is a whole number of EP slots, so
+    the round robin consumes exactly all pods; the leftover sweep below
+    is a defensive fallback for schedules built bypassing validation.
+    """
+    with schedule._layout_lock:
+        if schedule._ep_pp_dp_layout is not None:
+            return schedule._ep_pp_dp_layout
+        sizes = schedule.sizes
+        total = sum(sizes.values())
+        slot = ep_group_workers(schedule)
+        remaining = {g: sizes[g] for g in sorted(sizes) if sizes[g] > 0}
+        layout: List[int] = []
+
+        # Round robin of whole EP slots: one slot per group per round.
+        progressed = True
+        while progressed:
+            progressed = False
+            for group_id in list(remaining.keys()):
+                if remaining[group_id] >= slot:
+                    layout.extend([group_id] * slot)
+                    remaining[group_id] -= slot
+                    progressed = True
+
+        # Defensive: complete with leftover pods, one per group per sweep.
+        # Unreachable for validated schedules (every size is a multiple
+        # of the EP slot).
+        if any(remaining.values()):
+            logger.warning(
+                "The ep_pp_dp soft group layout found leftover pods %s "
+                "outside whole EP slots (the schedule bypassed the EP "
+                "alignment validation); they are placed one per group per "
+                "sweep and their EP groups may straddle groups.",
+                {g: c for g, c in remaining.items() if c > 0},
+            )
+            while len(layout) < total and any(remaining.values()):
+                for group_id in list(remaining.keys()):
+                    if remaining[group_id] <= 0 or len(layout) >= total:
+                        continue
+                    layout.append(group_id)
+                    remaining[group_id] -= 1
+
+        if len(layout) != total:
+            raise ValueError(
+                "soft-group-affinity failed to lay out all worker pods; "
+                f"expected {total}, got {len(layout)}."
+            )
+
+        straddled = [
+            start
+            for start in range(0, total, slot)
+            if len(set(layout[start : start + slot])) > 1
+        ]
+        if straddled:
+            logger.warning(
+                "The ep_pp_dp soft group layout contains %d EP slot(s) "
+                "crossing groups (sizes %s), starting at pod %s.",
+                len(straddled),
+                sizes,
+                straddled[:5],
+            )
+        else:
+            logger.info(
+                "The ep_pp_dp soft group layout of sizes %s keeps every "
+                "EP slot inside one group.",
+                sizes,
+            )
+        schedule._ep_pp_dp_layout = layout
+        return layout
+
+
+def resolve_soft_group_id(
+    schedule: Optional[SoftGroupSchedule],
+    node_type: str,
+    rank_index: int,
+) -> Optional[int]:
+    """Resolve the soft node group id of a worker by its rank index.
+
+    - ``contiguous``: groups occupy cumulative contiguous rank ranges in
+      ascending group-id order (fill up one group then the next).
+    - ``ep_pp_dp``: the global round-robin EP-slot layout (see
+      :func:`_ep_pp_dp_layout`).
+
+    Returns ``None`` for non-worker nodes, when no soft schedule is set,
+    or when the rank falls beyond the declared world (e.g. a scale-up
+    beyond ``sum(sizes)``), leaving the pod unlabeled.
+    """
+    if schedule is None or not schedule.sizes:
+        return None
+    if node_type != NodeType.WORKER:
+        return None
+    total = sum(schedule.sizes.values())
+    if rank_index < 0 or rank_index >= total:
+        return None
+    if schedule.strategy == NodeGroupStrategy.EP_PP_DP:
+        return _ep_pp_dp_layout(schedule)[rank_index]
+
+    start = 0
+    for group_id in sorted(schedule.sizes.keys()):
+        size = schedule.sizes[group_id]
+        if start <= rank_index < start + size:
+            return group_id
+        start += size
+    return None

--- a/dlrover/python/master/scaler/base_scaler.py
+++ b/dlrover/python/master/scaler/base_scaler.py
@@ -108,3 +108,14 @@ class Scaler(metaclass=ABCMeta):
         base scaler agnostic of the schedule.
         """
         pass
+
+    def set_soft_group_schedule(self, soft_group_schedule):
+        """Set the soft group schedule (unequal-size node groups).
+
+        Scalers that compute the group id per created worker (e.g.
+        PodScaler, via ``resolve_soft_group_id``) can override this to
+        forward the ``--soft-group-affinity`` schedule so the workers
+        are labeled with the soft-resolved groups. The default no-op
+        keeps the base scaler agnostic of the schedule.
+        """
+        pass

--- a/dlrover/python/master/scaler/pod_scaler.py
+++ b/dlrover/python/master/scaler/pod_scaler.py
@@ -43,6 +43,10 @@ from dlrover.python.master.resource.job import (
     NodeGroupSchedule,
     resolve_group_id,
 )
+from dlrover.python.master.resource.soft_group import (
+    SoftGroupSchedule,
+    resolve_soft_group_id,
+)
 from dlrover.python.master.scaler.base_scaler import ScalePlan, Scaler
 from dlrover.python.scheduler.kubernetes import (
     NODE_SERVICE_PORTS,
@@ -128,6 +132,10 @@ class PodScaler(Scaler):
         # DistributedJobManager; consulted by resolve_group_id so the
         # ep_pp_dp stripe mapping is applied when labeling created pods.
         self._node_group_schedule: Optional[NodeGroupSchedule] = None
+        # Soft group schedule (--soft-group-affinity, unequal sizes)
+        # injected by DistributedJobManager; when set, newly created
+        # worker pods are labeled with the soft-resolved group.
+        self._soft_group_schedule: Optional[SoftGroupSchedule] = None
 
     def set_group_affinity(self, group_affinity):
         """Store the group affinity mapping for labeling created pods."""
@@ -138,6 +146,47 @@ class PodScaler(Scaler):
         resolve_group_id can apply the ep_pp_dp stripe mapping when
         labeling created worker pods."""
         self._node_group_schedule = node_group_schedule
+
+    def set_soft_group_schedule(self, soft_group_schedule):
+        """Store the soft group schedule (unequal-size node groups) so
+        resolve_soft_group_id labels newly created worker pods with
+        their soft-resolved group."""
+        self._soft_group_schedule = soft_group_schedule
+
+    def _strip_group_labels_for_no_group_failover(self, plan):
+        """With ``--soft-group-affinity --no-group-failover``, drop the
+        node-group fields of every relaunch node in the plan (the
+        ``generate_relaunch_node`` deepcopy carried them over) so the
+        recreated pod has no ``scheduling/rack-group`` label and can be
+        scheduled onto any segment instead of following the original
+        group affinity.
+
+        Called at the common exit of ALL relaunch paths (this scaler's
+        ``scale``): the single-node relaunch, the job-level ``restart``
+        and the group relaunch all hand their plans to ``scaler.scale``
+        here. The job context is kept in sync with the stripped state.
+
+        A no-op without a soft schedule or with --no-group-failover
+        disabled: the relaunch then keeps its group and the labels are
+        re-created as before.
+        """
+        if plan is None or not plan.launch_nodes:
+            return
+        soft_schedule = self._soft_group_schedule
+        if soft_schedule is None or not soft_schedule.no_group_failover:
+            return
+        for relaunched_node in plan.launch_nodes:
+            relaunched_node.group = None
+            relaunched_node.group_id = None
+            relaunched_node.group_size = None
+            self._job_context.update_job_node(relaunched_node)
+            logger.info(
+                "No-group failover: relaunch %s (rank %s) without its "
+                "node-group labels so it can be scheduled onto any "
+                "segment.",
+                relaunched_node.name,
+                relaunched_node.rank_index,
+            )
 
     def start(self):
         self._job = self._retry_to_get_job()
@@ -243,6 +292,12 @@ class PodScaler(Scaler):
             with_merge (bool, optional): If true, enable automatic plan merging.
                 Defaults to False.
         """
+
+        # Common exit of every relaunch plan (the single-node relaunch, the
+        # job-level restart and the group relaunch all funnel into
+        # scaler.scale): with --no-group-failover the relaunched nodes must
+        # carry no node-group information whatever path produced them.
+        self._strip_group_labels_for_no_group_failover(plan)
 
         with_merge = kwargs.pop("with_merge", False)
 
@@ -481,17 +536,32 @@ class PodScaler(Scaler):
         for i in range(up_num):
             node_id = max_pod_id + 1 + i
             task_id = cur_num + i
-            group_id = resolve_group_id(
-                self._group_affinity,
-                type,
-                task_id,
-                self._node_group_schedule,
-            )
-            group_size = (
-                len(self._group_affinity)
-                if group_id is not None and self._group_affinity
-                else None
-            )
+            if self._soft_group_schedule is not None:
+                # --soft-group-affinity takes precedence (it is mutually
+                # exclusive with --group-affinity anyway): label the pod
+                # with the soft-resolved group id.
+                group_id = resolve_soft_group_id(
+                    self._soft_group_schedule,
+                    type,
+                    task_id,
+                )
+                group_size = (
+                    len(self._soft_group_schedule.sizes)
+                    if group_id is not None
+                    else None
+                )
+            else:
+                group_id = resolve_group_id(
+                    self._group_affinity,
+                    type,
+                    task_id,
+                    self._node_group_schedule,
+                )
+                group_size = (
+                    len(self._group_affinity)
+                    if group_id is not None and self._group_affinity
+                    else None
+                )
             node = Node(
                 type,
                 node_id,

--- a/dlrover/python/scheduler/job.py
+++ b/dlrover/python/scheduler/job.py
@@ -121,6 +121,16 @@ class JobArgs(JsonSerializable):
         self.pipeline_model_parallel_size: int = 1
         self.expert_model_parallel_size: int = 1
         self.context_parallel_size: int = 1
+        # Unequal-size node group pod counts (--soft-group-affinity),
+        # fully isolated from group_affinity above and mutually exclusive
+        # with it. See SoftGroupSchedule / validate_soft_group_topology /
+        # resolve_soft_group_id in master.resource.soft_group. Every group
+        # size must be a multiple of the EP slot (EP/R pods) — the EP
+        # alignment is mandatory, not an option.
+        self.soft_group_affinity: Optional[Dict[int, int]] = None
+        # With soft_group_affinity: relaunch (FO) workers without their
+        # node-group labels so they can be scheduled onto any segment.
+        self.no_group_failover: bool = False
 
     @abstractmethod
     def initilize(self):

--- a/dlrover/python/tests/test_args.py
+++ b/dlrover/python/tests/test_args.py
@@ -135,6 +135,36 @@ class ArgsTest(unittest.TestCase):
         parsed_args = parse_master_args(original_args)
         self.assertEqual(parsed_args.group_affinity, {2: 3})
 
+    def test_parse_soft_group_args(self):
+        # defaults: no soft mapping, the failover flag off
+        parsed_args = parse_master_args(["--job_name", "test"])
+        self.assertIsNone(parsed_args.soft_group_affinity)
+        self.assertFalse(parsed_args.no_group_failover)
+
+        # soft group affinity reuses the dict parser (unequal sizes)
+        parsed_args = parse_master_args(
+            [
+                "--job_name",
+                "test",
+                "--soft-group-affinity={0: 30, 1: 20}",
+                "--no-group-failover",
+            ]
+        )
+        self.assertEqual(parsed_args.soft_group_affinity, {0: 30, 1: 20})
+        self.assertTrue(parsed_args.no_group_failover)
+
+        # the underscore aliases are also accepted
+        parsed_args = parse_master_args(
+            [
+                "--job_name",
+                "test",
+                "--soft_group_affinity={2: 3}",
+                "--no_group_failover",
+            ]
+        )
+        self.assertEqual(parsed_args.soft_group_affinity, {2: 3})
+        self.assertTrue(parsed_args.no_group_failover)
+
         # invalid mapping makes the parser exit with code 2
         original_args = [
             "--job_name",

--- a/dlrover/python/tests/test_job_manager.py
+++ b/dlrover/python/tests/test_job_manager.py
@@ -81,7 +81,9 @@ from dlrover.python.master.node.training_node import (
     update_nodes_priority,
 )
 from dlrover.python.master.resource.job import JobResource, NodeGroupSchedule
+from dlrover.python.master.resource.soft_group import SoftGroupSchedule
 from dlrover.python.master.scaler.base_scaler import ScalePlan
+from dlrover.python.master.scaler.pod_scaler import PodScaler
 from dlrover.python.master.watcher.base_watcher import Node
 from dlrover.python.scheduler.job import LocalJobArgs
 from dlrover.python.tests.test_utils import (
@@ -458,6 +460,280 @@ class DistributedJobManagerTest(unittest.TestCase):
         params.group_affinity = {0: 10, 1: 15}
         with self.assertRaisesRegex(ValueError, "requires worker replicas=25"):
             create_job_manager(params, PerfMonitor())
+
+    def _soft_group_args(self, **overrides):
+        args = dict(
+            group_affinity=None,
+            soft_group_affinity={0: 8, 1: 8},
+            node_group_strategy=NodeGroupStrategy.EP_PP_DP,
+            tensor_model_parallel_size=1,
+            pipeline_model_parallel_size=2,
+            expert_model_parallel_size=16,
+            context_parallel_size=1,
+            no_group_failover=False,
+        )
+        args.update(overrides)
+        return SimpleNamespace(**args)
+
+    def test_init_soft_group_affinity_ok(self):
+        # 16 workers, {0:8, 1:8}, PP=2, EP=16: unequal sizes are legal and
+        # both are multiples of the EP slot (ep_workers=2) as required by
+        # the default EP alignment.
+        manager = self._new_manager_with_worker_count(16, gpu_num=8)
+        manager._init_soft_group_affinity(
+            self._soft_group_args(no_group_failover=True)
+        )
+        schedule = manager._job_resource.soft_group_schedule
+        self.assertIsNotNone(schedule)
+        self.assertEqual(schedule.sizes, {0: 8, 1: 8})
+        self.assertEqual(
+            (schedule.tp, schedule.pp, schedule.ep, schedule.cp), (1, 2, 16, 1)
+        )
+        self.assertEqual(
+            (schedule.num_nodes, schedule.ranks_per_node), (16, 8)
+        )
+        self.assertTrue(schedule.no_group_failover)
+        self.assertIsNone(manager._job_resource.group_affinity)
+        self.assertIsNone(manager._job_resource.node_group_schedule)
+        self.assertEqual(manager.get_expected_ranks_per_node(), 8)
+
+    def test_init_soft_group_affinity_mutually_exclusive(self):
+        manager = self._new_manager_with_worker_count(16, gpu_num=8)
+        with self.assertRaisesRegex(
+            ValueError, "cannot be combined with --group-affinity"
+        ):
+            manager._init_soft_group_affinity(
+                self._soft_group_args(group_affinity={0: 8, 1: 8})
+            )
+        self.assertIsNone(manager._job_resource.soft_group_schedule)
+
+    def test_init_soft_group_affinity_sum_mismatch(self):
+        manager = self._new_manager_with_worker_count(15, gpu_num=8)
+        with self.assertRaisesRegex(ValueError, "sum to 16"):
+            manager._init_soft_group_affinity(self._soft_group_args())
+        self.assertIsNone(manager._job_resource.soft_group_schedule)
+
+    def test_init_soft_group_affinity_requires_worker_resource(self):
+        manager = self._new_manager_with_worker_count(None, gpu_num=8)
+        with self.assertRaisesRegex(ValueError, "worker replica spec"):
+            manager._init_soft_group_affinity(self._soft_group_args())
+        self.assertIsNone(manager._job_resource.soft_group_schedule)
+
+    def test_init_soft_group_invalid_leaves_resource_untouched(self):
+        # N=16, R=8, PP=2 -> dense_dp=64, not divisible by EP=12.
+        manager = self._new_manager_with_worker_count(16, gpu_num=8)
+        with self.assertRaisesRegex(ValueError, "divisible by EP"):
+            manager._init_soft_group_affinity(
+                self._soft_group_args(expert_model_parallel_size=12)
+            )
+        self.assertIsNone(manager._job_resource.soft_group_schedule)
+        self.assertIsNone(manager._job_resource.group_affinity)
+
+    def test_init_soft_group_disabled_without_mapping(self):
+        manager = self._new_manager_with_worker_count(16, gpu_num=8)
+        manager._init_soft_group_affinity(
+            self._soft_group_args(soft_group_affinity=None)
+        )
+        self.assertIsNone(manager._job_resource.soft_group_schedule)
+
+    def test_init_soft_group_via_job_manager_init(self):
+        params = MockK8sAllreduceJobArgs()
+        params.initilize(16)
+        params.soft_group_affinity = {0: 8, 1: 8}
+        params.node_group_strategy = NodeGroupStrategy.EP_PP_DP
+        params.pipeline_model_parallel_size = 2
+        params.expert_model_parallel_size = 16
+        params.no_group_failover = True
+        manager = create_job_manager(params, PerfMonitor())
+        schedule = manager._job_resource.soft_group_schedule
+        self.assertIsNotNone(schedule)
+        self.assertTrue(schedule.no_group_failover)
+        self.assertIsNone(manager._job_resource.group_affinity)
+        self.assertEqual(manager.get_expected_ranks_per_node(), 8)
+        # The constructor forwarded the schedule to the scaler (the
+        # mocked job scaler only exposes the no-op base setter; the
+        # PodScaler-side labeling is covered by test_pod_scaler).
+        self.assertTrue(callable(manager._scaler.set_soft_group_schedule))
+
+    def test_job_resource_soft_group_init_node_meta(self):
+        job = JobResource()
+        job.node_group_resources[NodeType.WORKER] = NodeGroupResource(
+            2, NodeResource(8, 10240)
+        )
+        job.soft_group_schedule = SoftGroupSchedule(
+            strategy=NodeGroupStrategy.CONTIGUOUS,
+            sizes={0: 1, 1: 1},
+            tp=1,
+            pp=2,
+            ep=8,
+            cp=1,
+            num_nodes=2,
+            ranks_per_node=8,
+        )
+        nodes = job.init_job_node_meta(1, get_service_fn, _get_node_name)
+        workers = nodes[NodeType.WORKER]
+        self.assertEqual(workers[0].group, 0)
+        self.assertEqual(workers[0].group_size, 2)
+        self.assertEqual(workers[0].group_id, 0)
+        self.assertEqual(workers[1].group, 1)
+        self.assertEqual(workers[1].group_size, 2)
+        self.assertEqual(workers[1].group_id, 1)
+
+    def _capture_soft_scaler(self, no_group_failover=True):
+        """A real PodScaler whose execution side (_scale) is stubbed to
+        capture the plan; set_soft_group_schedule stays intact so the
+        scale() common exit applies the real no-group-failover logic."""
+        scaler = PodScaler("ej", "default")
+        scaler.set_soft_group_schedule(
+            SoftGroupSchedule(
+                strategy=NodeGroupStrategy.CONTIGUOUS,
+                sizes={0: 2, 1: 2},
+                tp=1,
+                pp=2,
+                ep=8,
+                cp=1,
+                num_nodes=4,
+                ranks_per_node=8,
+                no_group_failover=no_group_failover,
+            )
+        )
+        captured = []
+        scaler._scale = lambda p: captured.append(p)
+        return scaler, captured
+
+    @staticmethod
+    def _grouped_worker_node(node_id=0, rank_index=1):
+        return Node(
+            NodeType.WORKER,
+            node_id,
+            NodeResource(4, 8192),
+            rank_index=rank_index,
+            name=f"ej-edljob-worker-{node_id}",
+            node_group=1,
+            node_group_size=2,
+            node_group_id=1,
+        )
+
+    def _assert_exception_free_event_report(self):
+        return SimpleNamespace(
+            report_node_relaunch=lambda old, new: None,
+        )
+
+    def _null_job_context(self, node=None):
+        return SimpleNamespace(
+            update_job_node=lambda n: None,
+            update_job_node_by_group=lambda n: None,
+        )
+
+    def test_relaunch_node_chain_strips_labels_via_scale_exit(self):
+        # Chain 1: _relaunch_node -> scaler.scale(with_merge=True). The
+        # strip now lives at the common scaler exit, not the manager.
+        scaler, captured = self._capture_soft_scaler(no_group_failover=True)
+        node = self._grouped_worker_node()
+        relaunched = node.generate_relaunch_node(2)
+        plan = ScalePlan()
+        plan.launch_nodes.append(relaunched)
+
+        manager = DistributedJobManager.__new__(DistributedJobManager)
+        manager._remove_exited_node = False
+        manager._event_reporter = self._assert_exception_free_event_report()
+        manager._set_ps_addrs_in_plan = lambda p: None
+        manager._job_context = self._null_job_context()
+        manager._worker_manager = SimpleNamespace(
+            relaunch_node=lambda n, remove: plan
+        )
+        manager._scaler = scaler
+        manager._relaunch_node(node)
+        # with_merge=True runs asynchronously; wait for the capture.
+        scaler._current_scaling.result()
+        self.assertEqual(len(captured), 1)
+        stashed = captured[0].launch_nodes[0]
+        self.assertIsNone(stashed.group)
+        self.assertIsNone(stashed.group_id)
+        self.assertIsNone(stashed.group_size)
+
+    def test_restart_chain_strips_labels_via_scale_exit(self):
+        # Chain 2: the job-level restart() (relaunch all workers)
+        # funnels into the same scaler exit.
+        scaler, captured = self._capture_soft_scaler(no_group_failover=True)
+        node = self._grouped_worker_node()
+        relaunched = node.generate_relaunch_node(2)
+        plan = ScalePlan()
+        plan.launch_nodes.append(relaunched)
+
+        manager = DistributedJobManager.__new__(DistributedJobManager)
+        manager._job_args = SimpleNamespace(
+            distribution_strategy=DistributionStrategy.ALLREDUCE
+        )
+        manager._job_resource = JobResource()
+        manager._job_resource.node_group_resources[NodeType.WORKER] = (
+            NodeGroupResource(1, NodeResource(1, 4096))
+        )
+        manager._job_context = SimpleNamespace(
+            job_nodes_by_type=lambda t: {0: node},
+            update_job_node=lambda n: None,
+            update_job_node_by_group=lambda n: None,
+        )
+        manager._worker_manager = SimpleNamespace(
+            relaunch_nodes=lambda nodes, remove: plan
+        )
+        manager._scaler = scaler
+
+        import dlrover.python.master.node.dist_job_manager as djm_module
+
+        old_ctx = djm_module.job_ctx
+        old_max = djm_module._dlrover_context.job_max_restart_count
+        djm_module.job_ctx = SimpleNamespace(inc_job_restart_count=lambda: 1)
+        djm_module._dlrover_context.job_max_restart_count = 10
+        try:
+            manager.restart()
+        finally:
+            djm_module.job_ctx = old_ctx
+            djm_module._dlrover_context.job_max_restart_count = old_max
+
+        # restart calls scaler.scale(plan): the sync, no-merge path.
+        self.assertEqual(len(captured), 1)
+        relaunched = captured[0].launch_nodes[0]
+        self.assertIsNone(relaunched.group)
+        self.assertIsNone(relaunched.group_id)
+        self.assertIsNone(relaunched.group_size)
+
+    def test_relaunch_node_group_chain_strips_labels_via_scale_exit(self):
+        # Chain 3: the group relaunch (migrating the group to a new
+        # group idx) also abandons group labels under --no-group-failover,
+        # whatever path generates the plan.
+        scaler, captured = self._capture_soft_scaler(no_group_failover=True)
+        node = self._grouped_worker_node()
+
+        def fake_relaunch_nodes(nodes, remove):
+            plan = ScalePlan()
+            for relaunched_node in nodes:
+                plan.launch_nodes.append(
+                    relaunched_node.generate_relaunch_node(
+                        10 + relaunched_node.id
+                    )
+                )
+            return plan
+
+        manager = DistributedJobManager.__new__(DistributedJobManager)
+        manager._job_context = SimpleNamespace(
+            next_group_idx=lambda: 7,
+            job_node_group=lambda group: {0: node},
+            update_job_node=lambda n: None,
+            update_job_node_by_group=lambda n: None,
+        )
+        manager._worker_manager = SimpleNamespace(
+            relaunch_nodes=fake_relaunch_nodes
+        )
+        manager._relaunched_groups = []
+        manager._group_relaunch_count = 0
+        manager._scaler = scaler
+
+        manager._relaunch_node_group(1)
+        relaunched = captured[0].launch_nodes[0]
+        self.assertIsNone(relaunched.group)
+        self.assertIsNone(relaunched.group_id)
+        self.assertIsNone(relaunched.group_size)
         job = JobResource()
         job.node_group_resources[NodeType.PS] = NodeGroupResource(
             3, NodeResource(8, 10240, priority="high")

--- a/dlrover/python/tests/test_pod_scaler.py
+++ b/dlrover/python/tests/test_pod_scaler.py
@@ -21,6 +21,7 @@ from unittest.mock import MagicMock
 
 from dlrover.python.common.constants import (
     DistributionStrategy,
+    NodeGroupStrategy,
     NodeStatus,
     NodeType,
     SchedulingLabel,
@@ -28,6 +29,7 @@ from dlrover.python.common.constants import (
 from dlrover.python.common.global_context import Context
 from dlrover.python.common.node import Node, NodeGroupResource, NodeResource
 from dlrover.python.master.resource.job import NodeGroupSchedule
+from dlrover.python.master.resource.soft_group import SoftGroupSchedule
 from dlrover.python.master.scaler.base_scaler import ScalePlan
 from dlrover.python.master.scaler.pod_scaler import PodScaler, new_tf_config
 from dlrover.python.tests.test_utils import mock_k8s_client
@@ -388,6 +390,169 @@ class PodScalerTest(unittest.TestCase):
         self.assertEqual(rank1.group, 1)
         self.assertEqual(rank1.group_size, 2)
         self.assertEqual(rank1.group_id, 1)
+
+    def test_scale_up_pods_with_soft_group_contiguous(self):
+        scaler = PodScaler("elasticjob-sample", "default")
+        scaler._distribution_strategy = DistributionStrategy.PS
+        scaler.set_soft_group_schedule(
+            SoftGroupSchedule(
+                strategy=NodeGroupStrategy.CONTIGUOUS,
+                sizes={0: 1, 1: 1},
+                tp=1,
+                pp=2,
+                ep=8,
+                cp=1,
+                num_nodes=2,
+                ranks_per_node=8,
+            )
+        )
+        resource = NodeResource(4, 8192)
+        scale_plan = ScalePlan()
+        scale_plan.node_group_resources = {
+            NodeType.WORKER: NodeGroupResource(2, resource),
+        }
+        scaler._scale_up_pods(NodeType.WORKER, scale_plan, [], 0)
+        self.assertEqual(len(scaler._create_node_queue), 2)
+        rank0 = scaler._create_node_queue[0]
+        rank1 = scaler._create_node_queue[1]
+        self.assertEqual(rank0.group, 0)
+        self.assertEqual(rank0.group_size, 2)
+        self.assertEqual(rank0.group_id, 0)
+        self.assertEqual(rank1.group, 1)
+        self.assertEqual(rank1.group_size, 2)
+        self.assertEqual(rank1.group_id, 1)
+
+    def test_scale_up_pods_with_soft_group_ep_pp_dp(self):
+        # N=4, R=8, PP=2, EP=8 -> ep_workers=1: one pod per group per
+        # round, so the layout alternates 0,1,0,1.
+        scaler = PodScaler("elasticjob-sample", "default")
+        scaler._distribution_strategy = DistributionStrategy.PS
+        scaler.set_soft_group_schedule(
+            SoftGroupSchedule(
+                strategy=NodeGroupStrategy.EP_PP_DP,
+                sizes={0: 2, 1: 2},
+                tp=1,
+                pp=2,
+                ep=8,
+                cp=1,
+                num_nodes=4,
+                ranks_per_node=8,
+            )
+        )
+        resource = NodeResource(4, 8192)
+        scale_plan = ScalePlan()
+        scale_plan.node_group_resources = {
+            NodeType.WORKER: NodeGroupResource(4, resource),
+        }
+        scaler._scale_up_pods(NodeType.WORKER, scale_plan, [], 0)
+        self.assertEqual(
+            [node.group for node in scaler._create_node_queue],
+            [0, 1, 0, 1],
+        )
+        for node in scaler._create_node_queue:
+            self.assertEqual(node.group_size, 2)
+            self.assertEqual(node.group_id, node.group)
+
+    def test_scale_up_pods_soft_group_takes_precedence(self):
+        # The manager enforces mutual exclusion, but the scaler also
+        # prefers the soft schedule when both are (mistakenly) set.
+        scaler = PodScaler("elasticjob-sample", "default")
+        scaler._distribution_strategy = DistributionStrategy.PS
+        scaler.set_group_affinity({0: 2})
+        scaler.set_soft_group_schedule(
+            SoftGroupSchedule(
+                strategy=NodeGroupStrategy.CONTIGUOUS,
+                sizes={0: 1, 1: 1},
+                tp=1,
+                pp=2,
+                ep=8,
+                cp=1,
+                num_nodes=2,
+                ranks_per_node=8,
+            )
+        )
+        resource = NodeResource(4, 8192)
+        scale_plan = ScalePlan()
+        scale_plan.node_group_resources = {
+            NodeType.WORKER: NodeGroupResource(2, resource),
+        }
+        scaler._scale_up_pods(NodeType.WORKER, scale_plan, [], 0)
+        self.assertEqual(
+            [node.group for node in scaler._create_node_queue], [0, 1]
+        )
+
+    def _make_grouped_relaunch_plan(self):
+        old_node = Node(
+            NodeType.WORKER,
+            0,
+            NodeResource(4, 8192),
+            rank_index=1,
+            name="ej-edljob-worker-0",
+            node_group=1,
+            node_group_size=2,
+            node_group_id=1,
+        )
+        relaunched = old_node.generate_relaunch_node(2)
+        plan = ScalePlan()
+        plan.launch_nodes.append(relaunched)
+        return old_node, plan
+
+    def test_scale_strips_group_labels_for_no_group_failover(self):
+        # scaler.scale is the common exit of every relaunch path: with
+        # --no-group-failover the launch nodes lose their group fields
+        # synchronously, before any execution, whatever produced the
+        # plan (generate_relaunch_node's deepcopy carried them over).
+        scaler = PodScaler("elasticjob-sample", "default")
+        scaler.set_soft_group_schedule(
+            SoftGroupSchedule(
+                strategy=NodeGroupStrategy.CONTIGUOUS,
+                sizes={0: 2, 1: 2},
+                tp=1,
+                pp=2,
+                ep=8,
+                cp=1,
+                num_nodes=4,
+                ranks_per_node=8,
+                no_group_failover=True,
+            )
+        )
+        _, plan = self._make_grouped_relaunch_plan()
+        captured = []
+        scaler._scale = lambda p: captured.append(p)
+        scaler.scale(plan)
+        self.assertEqual(len(captured), 1)
+        self.assertIs(captured[0], plan)
+        relaunched = captured[0].launch_nodes[0]
+        self.assertIsNone(relaunched.group)
+        self.assertIsNone(relaunched.group_id)
+        self.assertIsNone(relaunched.group_size)
+
+    def test_scale_keeps_group_labels_without_no_group_failover(self):
+        # Default (flag off) and without a soft schedule: the relaunch
+        # nodes keep their groups and the labels are created as before.
+        for schedule in (
+            SoftGroupSchedule(
+                strategy=NodeGroupStrategy.CONTIGUOUS,
+                sizes={0: 2, 1: 2},
+                tp=1,
+                pp=2,
+                ep=8,
+                cp=1,
+                num_nodes=4,
+                ranks_per_node=8,
+            ),
+            None,
+        ):
+            scaler = PodScaler("elasticjob-sample", "default")
+            scaler.set_soft_group_schedule(schedule)
+            _, plan = self._make_grouped_relaunch_plan()
+            captured = []
+            scaler._scale = lambda p: captured.append(p)
+            scaler.scale(plan)
+            relaunched = captured[0].launch_nodes[0]
+            self.assertEqual(relaunched.group, 1)
+            self.assertEqual(relaunched.group_id, 1)
+            self.assertEqual(relaunched.group_size, 2)
 
     def test_scale_up_pods_with_ep_pp_dp(self):
         """The ep_pp_dp schedule stripes nodes across groups so EP/PP stay

--- a/dlrover/python/tests/test_soft_group.py
+++ b/dlrover/python/tests/test_soft_group.py
@@ -1,0 +1,350 @@
+# Copyright 2026 The DLRover Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from dlrover.python.common.constants import NodeGroupStrategy, NodeType
+from dlrover.python.master.resource.job import (
+    NodeGroupSchedule,
+    resolve_group_id,
+    validate_topology,
+)
+from dlrover.python.master.resource.soft_group import (
+    SoftGroupSchedule,
+    resolve_soft_group_id,
+    validate_soft_group_topology,
+)
+
+
+def _soft(
+    strategy=NodeGroupStrategy.CONTIGUOUS,
+    sizes=None,
+    tp=1,
+    pp=1,
+    ep=1,
+    cp=1,
+    num_nodes=None,
+    ranks_per_node=8,
+    no_group_failover=False,
+):
+    if sizes is None:
+        sizes = {0: 1}
+    return SoftGroupSchedule(
+        strategy=strategy,
+        sizes=sizes,
+        tp=tp,
+        pp=pp,
+        ep=ep,
+        cp=cp,
+        num_nodes=(
+            num_nodes if num_nodes is not None else sum(sizes.values())
+        ),
+        ranks_per_node=ranks_per_node,
+        no_group_failover=no_group_failover,
+    )
+
+
+class SoftGroupScheduleTest(unittest.TestCase):
+    def test_carry_fields(self):
+        schedule = _soft(
+            strategy=NodeGroupStrategy.EP_PP_DP,
+            sizes={0: 30, 1: 20},
+            pp=2,
+            ep=40,
+            no_group_failover=True,
+        )
+        self.assertEqual(schedule.sizes, {0: 30, 1: 20})
+        self.assertEqual(
+            (schedule.tp, schedule.pp, schedule.ep, schedule.cp), (1, 2, 40, 1)
+        )
+        self.assertEqual(
+            (schedule.num_nodes, schedule.ranks_per_node), (50, 8)
+        )
+        self.assertTrue(schedule.no_group_failover)
+        self.assertIsNone(schedule._ep_pp_dp_layout)
+
+
+class ValidateSoftGroupTopologyTest(unittest.TestCase):
+    def test_none_or_empty_is_noop(self):
+        validate_soft_group_topology(None)
+        validate_soft_group_topology(_soft(sizes={}))
+
+    def test_ok_unequal(self):
+        # The whole point of the soft path: heterogeneous sizes are legal
+        # (EP slot = 1 pod with ep=8, R=8, so any size is aligned).
+        validate_soft_group_topology(_soft(sizes={0: 30, 1: 20}, pp=2, ep=8))
+
+    def test_ok_ep_slot_aligned(self):
+        # N=64, R=8, EP=16, PP=2 -> dense_dp=256, dp=16, ep_workers=2;
+        # every size is a multiple of 2. EP alignment is the default, no
+        # flag involved.
+        validate_soft_group_topology(
+            _soft(
+                strategy=NodeGroupStrategy.EP_PP_DP,
+                sizes={0: 32, 1: 32},
+                pp=2,
+                ep=16,
+            )
+        )
+        # {0:30, 1:20} with ep=40: dp=5 and ep_workers=5 divides both sizes.
+        validate_soft_group_topology(
+            _soft(
+                sizes={0: 30, 1: 20},
+                pp=2,
+                ep=40,
+            )
+        )
+
+    def test_sum_must_equal_num_nodes(self):
+        with self.assertRaisesRegex(ValueError, "sum to 50"):
+            validate_soft_group_topology(
+                _soft(sizes={0: 30, 1: 20}, num_nodes=49, pp=2, ep=8)
+            )
+
+    def test_positive_sizes_and_keys(self):
+        with self.assertRaisesRegex(ValueError, "positive"):
+            validate_soft_group_topology(_soft(sizes={0: 0, 1: 4}, pp=1, ep=1))
+        with self.assertRaisesRegex(ValueError, "non-negative"):
+            validate_soft_group_topology(
+                _soft(sizes={-1: 4, 0: 4}, pp=1, ep=1)
+            )
+
+    def test_tp_cp_scope(self):
+        with self.assertRaisesRegex(ValueError, "TP=1"):
+            validate_soft_group_topology(
+                _soft(sizes={0: 8, 1: 8}, tp=2, pp=2, ep=8)
+            )
+        with self.assertRaisesRegex(ValueError, "CP=1"):
+            validate_soft_group_topology(
+                _soft(sizes={0: 8, 1: 8}, cp=2, pp=2, ep=8)
+            )
+
+    def test_invalid_parallel_sizes(self):
+        with self.assertRaisesRegex(ValueError, "pp=0"):
+            validate_soft_group_topology(_soft(sizes={0: 8, 1: 8}, pp=0, ep=8))
+        with self.assertRaisesRegex(ValueError, "ep=0"):
+            validate_soft_group_topology(_soft(sizes={0: 8, 1: 8}, pp=2, ep=0))
+        with self.assertRaisesRegex(ValueError, "ranks_per_node"):
+            validate_soft_group_topology(
+                _soft(sizes={0: 8, 1: 8}, pp=2, ep=8, ranks_per_node=0)
+            )
+
+    def test_num_nodes_must_divide_model_parallel(self):
+        with self.assertRaisesRegex(ValueError, r"TP\*PP\*CP=3"):
+            validate_soft_group_topology(_soft(sizes={0: 8, 1: 8}, pp=3, ep=8))
+
+    def test_dp_must_be_integral(self):
+        # N=50, R=8, PP=2 -> dense_dp=200 is not divisible by EP=16:
+        # not even a valid Megatron shape (dp=12.5).
+        with self.assertRaisesRegex(ValueError, "divisible by EP"):
+            validate_soft_group_topology(
+                _soft(sizes={0: 30, 1: 20}, pp=2, ep=16)
+            )
+
+    def test_ep_pp_dp_requires_ep_multiple_of_r(self):
+        # N=24, R=8, PP=2 -> dense_dp=96 divides EP=12 (dp integral) but
+        # EP=12 is not a multiple of R=8, so an EP slot is not whole
+        # nodes.
+        with self.assertRaisesRegex(
+            ValueError, "EP=12 to be divisible by ranks_per_node"
+        ):
+            validate_soft_group_topology(
+                _soft(
+                    strategy=NodeGroupStrategy.EP_PP_DP,
+                    sizes={0: 12, 1: 12},
+                    pp=2,
+                    ep=12,
+                )
+            )
+
+    def test_alignment_is_default_not_optin(self):
+        # dense_dp=256 with pp=2, EP=16 -> dp integral and EP%R==0, but
+        # 31 is odd so the group is not a multiple of the EP slot
+        # (ep_workers=2). No flag exists to relax this: the master fails
+        # to start for BOTH strategies.
+        for strategy in (
+            NodeGroupStrategy.CONTIGUOUS,
+            NodeGroupStrategy.EP_PP_DP,
+        ):
+            with self.assertRaisesRegex(ValueError, "group 0 has 31"):
+                validate_soft_group_topology(
+                    _soft(
+                        strategy=strategy,
+                        sizes={0: 31, 1: 33},
+                        pp=2,
+                        ep=16,
+                    )
+                )
+
+    def test_alignment_requires_ep_multiple_of_r_even_contiguous(self):
+        # The EP slot must be well-defined regardless of the strategy:
+        # N=48, R=8, PP=2 -> dense_dp=192 divides EP=12, but EP=12 is
+        # not a multiple of R=8.
+        with self.assertRaisesRegex(ValueError, "EP=12 to be divisible"):
+            validate_soft_group_topology(
+                _soft(
+                    sizes={0: 33, 1: 15},
+                    pp=2,
+                    ep=12,
+                )
+            )
+
+
+class ResolveSoftGroupIdTest(unittest.TestCase):
+    def test_none_or_non_worker_returns_none(self):
+        self.assertIsNone(resolve_soft_group_id(None, NodeType.WORKER, 0))
+        self.assertIsNone(resolve_soft_group_id(_soft(sizes={}), "worker", 0))
+        schedule = _soft(sizes={0: 4, 1: 4})
+        self.assertIsNone(resolve_soft_group_id(schedule, "ps", 0))
+
+    def test_contiguous_unequal_sizes(self):
+        schedule = _soft(sizes={0: 30, 1: 20})
+        result = [
+            resolve_soft_group_id(schedule, NodeType.WORKER, rank)
+            for rank in (0, 29, 30, 49, 50)
+        ]
+        self.assertEqual(result, [0, 0, 1, 1, None])
+
+    def test_contiguous_uses_ascending_group_keys(self):
+        schedule = _soft(sizes={5: 2, 2: 3})
+        result = [
+            resolve_soft_group_id(schedule, NodeType.WORKER, rank)
+            for rank in range(5)
+        ]
+        self.assertEqual(result, [2, 2, 2, 5, 5])
+
+    def test_ep_pp_dp_equal_sizes_slot_round_robin(self):
+        # N=16, R=8, PP=2, EP=16 -> dp_nodes=8, ep_workers=2: one EP slot
+        # (2 pods) from every group per round.
+        schedule = _soft(
+            strategy=NodeGroupStrategy.EP_PP_DP,
+            sizes={0: 8, 1: 8},
+            pp=2,
+            ep=16,
+        )
+        self.assertEqual(
+            [
+                resolve_soft_group_id(schedule, NodeType.WORKER, rank)
+                for rank in range(16)
+            ],
+            [0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1],
+        )
+
+    def test_ep_pp_dp_leftover_pods_tolerated_with_warning(self):
+        # Defensive resolver behavior for a schedule that bypassed the
+        # (now mandatory) EP alignment validation: {0:9, 1:7} has 1+1
+        # leftover pods after the whole slots; they complete the layout
+        # pod-by-pod, so the final EP slot straddles both groups —
+        # reported with a WARNING, never a resolver failure.
+        schedule = _soft(
+            strategy=NodeGroupStrategy.EP_PP_DP,
+            sizes={0: 9, 1: 7},
+            pp=2,
+            ep=16,
+        )
+        with self.assertLogs("dlrover.logger", level="WARNING") as logs:
+            layout = [
+                resolve_soft_group_id(schedule, NodeType.WORKER, rank)
+                for rank in range(16)
+            ]
+        self.assertEqual(
+            layout,
+            [0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 0, 1],
+        )
+        self.assertTrue(any("crossing groups" in log for log in logs.output))
+
+    def test_ep_pp_dp_layout_built_once(self):
+        schedule = _soft(
+            strategy=NodeGroupStrategy.EP_PP_DP,
+            sizes={0: 8, 1: 8},
+            pp=2,
+            ep=16,
+        )
+        first = resolve_soft_group_id(schedule, NodeType.WORKER, 3)
+        layout = schedule._ep_pp_dp_layout
+        second = resolve_soft_group_id(schedule, NodeType.WORKER, 3)
+        self.assertEqual(first, second)
+        self.assertIs(layout, schedule._ep_pp_dp_layout)
+
+    def test_ep_pp_dp_equal_sizes_matches_stripe_formula(self):
+        # When every group holds exactly one EP slot per pipeline stage
+        # (size = PP*EP/R, i.e. N*R = PP*EP*G) the round-robin layout
+        # reproduces the static ep_pp_dp stripe formula exactly, for
+        # contiguous AND opaque (non 0-based, per #1745) group ids.
+        N, R, PP, EP, G = 16, 8, 2, 16, 4
+        for ga in (
+            {i: N // G for i in range(G)},  # contiguous ids {0,1,2,3}
+            {5: 4, 9: 4, 17: 4, 23: 4},  # opaque ids
+        ):
+            static = NodeGroupSchedule(
+                strategy=NodeGroupStrategy.EP_PP_DP,
+                tp=1,
+                pp=PP,
+                ep=EP,
+                cp=1,
+                num_nodes=N,
+                ranks_per_node=R,
+            )
+            validate_topology(ga, static)
+            schedule = _soft(
+                strategy=NodeGroupStrategy.EP_PP_DP,
+                sizes=ga,
+                pp=PP,
+                ep=EP,
+            )
+            self.assertEqual(
+                [
+                    resolve_soft_group_id(schedule, NodeType.WORKER, k)
+                    for k in range(N)
+                ],
+                [
+                    resolve_group_id(ga, NodeType.WORKER, k, static)
+                    for k in range(N)
+                ],
+            )
+
+    def test_ep_pp_dp_invariants_9216_equal_sizes(self):
+        # N=1152 = 9 segments x 128 workers, R=8, PP=16, EP=32:
+        # ep_workers=4, DP_nodes=72 (2 rounds over the 9 groups per
+        # stage). EP slots stay inside one group and the same
+        # within-stage position always maps to the same group.
+        N, R, PP, EP, G = 1152, 8, 16, 32, 9
+        schedule = _soft(
+            strategy=NodeGroupStrategy.EP_PP_DP,
+            sizes={g: N // G for g in range(G)},
+            pp=PP,
+            ep=EP,
+        )
+        layout = [
+            resolve_soft_group_id(schedule, NodeType.WORKER, rank)
+            for rank in range(N)
+        ]
+        dp_nodes, slot = N // PP, EP // R
+        for start in range(0, N, slot):
+            self.assertEqual(
+                len(set(layout[start : start + slot])),
+                1,
+                f"EP slot at [{start},{start + slot})",
+            )
+        for position in range(dp_nodes):
+            self.assertEqual(
+                len({layout[pp * dp_nodes + position] for pp in range(PP)}),
+                1,
+                f"PP column {position}",
+            )
+        sums = {g: layout.count(g) for g in range(G)}
+        self.assertEqual(sums, {g: N // G for g in range(G)})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

  Add `--soft-group-affinity` so a job can declare **unequally-sized** node groups, e.g. `--soft-group-affinity="{0: 30, 1: 20}"`. Workers get their group resolved at **pod-creation time** and labeled
  with `scheduling/rack-group` for segment-affinity scheduling, per `--node-group-strategy`:

  - `contiguous`: groups occupy cumulative contiguous rank ranges — fill one group, then the next; node_rank increments in order (the #1729 behavior generalized to arbitrary sizes).
  - `ep_pp_dp`: each group contributes one **EP slot** (`ep_workers = EP/R` consecutive pods, one EP communication group) per round, round-robin until the world is laid out — EP groups and PP columns stay
  intra-group, only the dense DP allreduce crosses groups.

  Two knobs total:

  | Flag | Default | Behavior |
  | --- | --- | --- |
  | *(EP alignment: built-in, not a flag)* | **always on** | `EP % R == 0` and every group size must be a multiple of `EP/R`, otherwise the master fails to start cleanly (fail-fast, no partial state) |
  | `--no-group-failover` | false | Default: a relaunched (FO) worker keeps its group labels (the `generate_relaunch_node` deepcopy already carries them — zero change to the relaunch flow). With the flag:
  the relaunch pod is recreated **without** group labels so it can be scheduled onto any segment, trading placement fidelity for FO success rate. |

  ## Why

  The legacy `--group-affinity` path (#1729) plus the ep_pp_dp schedule (#1740) force every group to be the same size (`validate_topology` constraint D) — production clusters rarely can satisfy this
  because free resources per segment are naturally uneven. The soft path accepts heterogeneous sizes while keeping the same labeling/scheduling mechanism.

  ## How

  - `master/resource/soft_group.py` (new, fully isolated): `SoftGroupSchedule`, `resolve_soft_group_id` (both strategies; the ep_pp_dp layout is built once and cached; a defensive leftover sweep covers
  schedules that bypassed validation), `validate_soft_group_topology` (sum(sizes)==N, TP=CP=1, dp integral so invalid Megatron shapes fail at master start, the mandatory EP alignment, and per-stage whole
  slots for ep_pp_dp). It never touches `validate_topology`/`resolve_group_id`, so the legacy path is regression-free; the two features are mutually exclusive.
  - `master/args.py` / `main.py` / `scheduler/job.py`: `--soft-group-affinity` (reuses the `parse_group_affinity` dict parser) and `--no-group-failover`.
  - `master/node/dist_job_manager.py`: `_init_soft_group_affinity` runs **before** `_init_group_affinity` so the mutual-exclusion error wins; it attaches the schedule to `JobResource.soft_group_schedule`
  and forwards it to the scaler (`set_soft_group_schedule`). `get_expected_ranks_per_node` also covers the soft schedule, so #1741's join-time `local_world_size == R` re-validation applies.
  `_strip_group_labels_for_no_group_failover` implements the FO strip on the relaunch plan.
  - `master/resource/job.py` (`init_job_node_meta`) and `master/scaler/pod_scaler.py` (`_scale_up_pods`) resolve worker groups with the soft resolver and stamp the labels (`group_size = len(sizes)`).
  - rdzv_manager / dist_master / net_topology are untouched — pure creation-time static mapping, no rendezvous change.

  Follow-up of #1729/#1740/#1741; sibling of the group-affinity feature, isolated from it.

  ## Tests

  - `test_soft_group.py` (new): group mapping for both strategies over unequal sizes; validation branches; default EP alignment rejected for **both** strategies; parity with the old stripe formula when
  every group holds one EP slot per stage (`size = PP*EP/R`); 9216-card invariants (EP slots and PP columns intra-group); leftover-path warning for bypassed validation.
  - `test_pod_scaler.py`: soft labeling, FO label strip/keep, soft precedence over the legacy mapping.
  - `test_job_manager.py`: init branches, mutual exclusion, alignment fail-fast leaving the resource untouched, FO strip unit test.
  - `test_args.py`: parsing both new flags (dash/underscore aliases).
  - Affected suites pass; pre-commit hooks (ruff check/format, mypy, copyright) pass.