### PR TITLE
Feat(master): relax ep_pp_dp group ids to opaque identifiers

### DIFF
--- a/dlrover/python/master/resource/job.py
+++ b/dlrover/python/master/resource/job.py
@@ -124,14 +124,19 @@ def _resolve_stripe_group_id(
         seg      = DP_nodes / G            # nodes per segment per stage
         group(k) = (k % DP_nodes) // seg
 
-    The caller is responsible for having validated the topology via
+    The group ids are opaque identifiers: the computed 0-based stripe slot
+    maps to the group with the k-th smallest id, mirroring the ascending-id
+    segment order used by the contiguous strategy. Ids like ``{1, 2}`` or
+    ``{5, 9, 17}`` are therefore as valid as ``{0, 1}``. The caller is
+    responsible for having validated the topology via
     :func:`validate_topology`, which guarantees the divisions are integral
     and ``seg >= 1``.
     """
     g = len(group_affinity)
+    ordered_groups = sorted(group_affinity.keys())
     dp_nodes = schedule.num_nodes // (schedule.tp * schedule.pp * schedule.cp)
     seg = dp_nodes // g
-    return (rank_index % dp_nodes) // seg
+    return ordered_groups[(rank_index % dp_nodes) // seg]
 
 
 def resolve_group_id(
@@ -152,7 +157,8 @@ def resolve_group_id(
       :func:`_resolve_stripe_group_id` is used instead. This requires a
       validated topology (see :func:`validate_topology`); as the topology
       is fixed-size, the rank is asserted to be within
-      ``schedule.num_nodes``.
+      ``schedule.num_nodes``. Group ids are opaque: they only label the
+      segments, with the ascending id order fixing the segment order.
 
     Returns ``None`` when group affinity is not configured or the rank
     falls outside the declared worker range. For ``ep_pp_dp``, an
@@ -201,8 +207,11 @@ def validate_topology(
       - C: ``S % EP == 0`` (an EP group does not cross a segment, which also
             makes ``de`` divisible across the ``G`` segments);
       - D: ``N % G == 0`` and all ``group_affinity`` values are equal to
-            ``N/G`` (equal-size groups, the platform hard requirement), and
-            the group ids are exactly ``{0, 1, ..., G-1}``;
+            ``N/G`` (equal-size groups, the platform hard requirement).
+            The group ids are opaque identifiers — the ascending id order
+            defines the segment order (the k-th stripe slot maps to the
+            k-th smallest id), so e.g. ``{1: 4, 2: 4}`` is as valid as
+            ``{0: 4, 1: 4}``;
       - E: ``EP % R == 0`` (an EP group is composed of whole nodes);
       - implicit: ``dense_dp`` and ``dp_nodes`` are integral and ``seg >= 1``.
     """
@@ -289,7 +298,9 @@ def validate_topology(
             "group spans whole nodes."
         )
 
-    # Constraint D: equal-size groups, group ids == {0..G-1}, each == N/G.
+    # Constraint D: equal-size groups, each == N/G. Group ids are opaque
+    # identifiers (distinct keys of the dict); their ascending order fixes
+    # the segment order, so no 0-based contiguity is required.
     if n % g != 0:
         raise ValueError(
             "node-group-strategy=ep_pp_dp requires the worker node count "
@@ -302,12 +313,6 @@ def validate_topology(
         raise ValueError(
             "node-group-strategy=ep_pp_dp requires all group_affinity sizes "
             f"to be equal to N/G={expected_size}, got {equal_size}."
-        )
-    keys = sorted(group_affinity.keys())
-    if keys != list(range(g)):
-        raise ValueError(
-            "node-group-strategy=ep_pp_dp requires contiguous group ids "
-            f"{{0,1,...,{g - 1}}}, got {keys}."
         )
 
 

--- a/dlrover/python/tests/test_node_group_strategy.py
+++ b/dlrover/python/tests/test_node_group_strategy.py
@@ -248,12 +248,39 @@ class ValidateTopologyTest(unittest.TestCase):
         )
         self._assert_raises_msg(ga, sched, "N/G=6")
 
-    def test_non_contiguous_group_ids_fail(self):
-        ga = {0: 4, 1: 4, 3: 4}  # missing group id 2
+    def test_arbitrary_group_ids_accepted(self):
+        # Group ids are opaque: sparse/shifted ids are valid and the
+        # ascending id order defines the segment order. N=12, R=8, G=3,
+        # EP=8: dp_nodes=12, seg=4 -> slots 0/1/2 map to ids 0/1/3.
+        ga = {0: 4, 1: 4, 3: 4}  # missing group id 2, id 3 instead
         sched = _ep_pp_dp(
             tp=1, pp=1, ep=8, cp=1, num_nodes=12, ranks_per_node=8
         )
-        self._assert_raises_msg(ga, sched, "contiguous group ids")
+        validate_topology(ga, sched)
+        self.assertEqual(
+            [
+                resolve_group_id(ga, NodeType.WORKER, k, sched)
+                for k in range(12)
+            ],
+            [0] * 4 + [1] * 4 + [3] * 4,
+        )
+
+    def test_one_based_group_ids_stripe_like_zero_based(self):
+        # Production racks may be labeled from 1: {1: 4, 2: 4} must behave
+        # exactly like {0: 4, 1: 4} (N=8, R=8, PP=2, EP=16, G=2) — the ids
+        # only relabel the segments: ranks 0,1 -> 1; 2,3 -> 2; 4,5 -> 1;
+        # 6,7 -> 2 (PP/EP stay intra-segment, only DP crosses segments).
+        one_based = {1: 4, 2: 4}
+        zero_based = {0: 4, 1: 4}
+        sched = _ep_pp_dp(
+            tp=1, pp=2, ep=16, cp=1, num_nodes=8, ranks_per_node=8
+        )
+        validate_topology(one_based, sched)
+        for k in range(8):
+            self.assertEqual(
+                resolve_group_id(one_based, NodeType.WORKER, k, sched),
+                resolve_group_id(zero_based, NodeType.WORKER, k, sched) + 1,
+            )
 
 
 class StripeInvariantsTest(unittest.TestCase):


### PR DESCRIPTION
# Motivation

`--node-group-strategy=ep_pp_dp` rejected group-affinity dicts whose ids were not exactly `{0, ..., G-1}` (`"requires contiguous group ids {0,1,...,G-1}"`). Group ids are opaque identifiers — they flow straight into the `scheduling/rack-id` pod label, and racks may be numbered from 1, so valid configurations like `--group-affinity='{1:4, 2:4}'` failed master startup for no structural reason.

# Changes

- `_resolve_stripe_group_id` previously returned the raw **0-based stripe slot** as the group id, which only worked when ids happened to be `{0..G-1}` (that's what the dropped check was papering over). The slot is now mapped through `sorted(group_affinity.keys())`: the k-th stripe slot maps to the k-th smallest group id — the same ascending-id segment order the `contiguous` strategy already uses.
- `validate_topology` constraint D drops the `{0..G-1}` requirement. Equal-size groups (`N/G` each) remain mandatory — that is the platform hard requirement the stripe math relies on.
- Tests: `test_non_contiguous_group_ids_fail` replaced by two positive cases (`test_arbitrary_group_ids_accepted`, `test_one_based_group_ids_stripe_like_zero_based`).

# Compatibility

- With `{0: ..., 1: ...}` ids the mapping is **bit-identical** to before.
- `{1: 4, 2: 4}` now validates and stripes exactly like `{0: 4, 1: 4}`: with N=8, R=8, PP=2, EP=16 — ranks 0,1→1; 2,3→2; 4,5→1; 6,7→2 (EP/PP stay intra-segment, only DP crosses segments).

# Tests

- `test_node_group_strategy.py` + `test_args.py`: 30 passed
- `test_job_manager.py`: 5 failures pre-exist on master (verified on a clean tree via stash)