### PR TITLE
Feat(master): pack ep_pp_dp soft groups into PP columns greedily

### DIFF
--- a/dlrover/python/master/resource/soft_group.py
+++ b/dlrover/python/master/resource/soft_group.py
@@ -207,12 +207,36 @@ def _ep_pp_dp_layout(schedule: SoftGroupSchedule) -> List[int]:
     """Compute (once per schedule) the full-world group sequence of the
     ``ep_pp_dp`` strategy: ``{rank_index: group_id}`` for ``k = 0..N-1``.
 
-    Each round takes one EP slot (``ep_workers`` consecutive pods) from
-    every non-exhausted group in ascending group-id order — "take
-    ep-size pods from a group, jump to the next group, and so on".
+    The layout packs whole EP slots into ep-pp COLUMNS. The world has
+    ``C = DP_nodes / ep_workers`` slot positions (columns); a column is
+    one slot position spanning ALL ``pp`` pipeline stages (``pp`` EP
+    slots, i.e. one Megatron PP column). Each column is filled by a
+    greedy: repeatedly take the group with the MOST remaining whole EP
+    slots (ties broken by the smallest group id) and place
+    ``min(remaining, column capacity)`` slots of it until the column is
+    full, then move to the next column.
+
+    Why the largest-remaining greedy (fragment-deferring FFD): a group
+    with at least ``pp`` remaining slots fills whole columns alone, so
+    its PP columns are intra-group — ZERO cross-segment PP hops. Only
+    residual fragments (``s_g % pp != 0`` leftover slots) share a
+    column with other fragments; one group switch inside a column is
+    exactly one cross-segment PP hop. Deferring fragments to the tail
+    lets them pair with each other, which reaches the theoretical
+    minimum number of mixed columns for nearly every input: the
+    odd-slot groups lower-bound the mixed columns and the greedy pairs
+    the residuals together ({3, 3, 2} with pp=2 packs as [aa][bb][cc][ab]
+    — one mixed column, while a descending chained fill pays two).
+
+    The column inventory is global (``pp * C * ep_workers`` slot-pods,
+    covered by ``sum(sizes)``), so unlike a per-stage rotation the
+    packing never starves a late stage: {g1: 6, g2: 2, g3: 2} with
+    pp=2 and 1-pod slots lays out fully, where a per-stage round robin
+    drains the small groups in stage 0 and cannot fill stage 1.
+
     Validation guarantees every size is a whole number of EP slots, so
-    the round robin consumes exactly all pods; the leftover sweep below
-    is a defensive fallback for schedules built bypassing validation.
+    the greedy covers exactly all pods; the crumb tail below is a
+    defensive fallback for schedules built bypassing validation.
     """
     with schedule._layout_lock:
         if schedule._ep_pp_dp_layout is not None:
@@ -220,36 +244,60 @@ def _ep_pp_dp_layout(schedule: SoftGroupSchedule) -> List[int]:
         sizes = schedule.sizes
         total = sum(sizes.values())
         slot = ep_group_workers(schedule)
-        remaining = {g: sizes[g] for g in sorted(sizes) if sizes[g] > 0}
+        slot = slot if slot > 0 else 1
+        # Whole EP slots remaining per group; sub-slot crumbs are kept
+        # apart for the defensive tail (empty for validated schedules).
+        remaining: Dict[int, int] = {}
+        crumbs: Dict[int, int] = {}
+        for group_id in sorted(sizes):
+            if sizes[group_id] > 0:
+                remaining[group_id] = sizes[group_id] // slot
+                crumbs[group_id] = sizes[group_id] % slot
+
+        model_parallel = schedule.tp * schedule.pp * schedule.cp
+        dp_nodes = total // model_parallel if model_parallel else total
+        # Number of slot positions per stage == the number of PP columns.
+        columns = dp_nodes // slot
+        pp = max(schedule.pp, 1)
+
+        # Greedy column packing: one column of pp slots at a time, every
+        # pick taking min(remaining of the largest group, capacity) slots.
+        col_slots: List[List[int]] = []
+        for _col in range(columns):
+            groups: List[int] = []
+            while len(groups) < pp and any(v > 0 for v in remaining.values()):
+                group_id = max(
+                    sorted(remaining.keys()),
+                    key=lambda k: (remaining[k], -k),
+                )
+                take = min(remaining[group_id], pp - len(groups))
+                groups.extend([group_id] * take)
+                remaining[group_id] -= take
+            col_slots.append(groups)
+
+        # Flatten the columns into the stage-major pod sequence: the
+        # s-th pipeline stage consumes the s-th slot of every column.
         layout: List[int] = []
+        for stage in range(pp):
+            for slot_groups in col_slots:
+                if stage < len(slot_groups):
+                    layout.extend([slot_groups[stage]] * slot)
 
-        # Round robin of whole EP slots: one slot per group per round.
-        progressed = True
-        while progressed:
-            progressed = False
-            for group_id in list(remaining.keys()):
-                if remaining[group_id] >= slot:
-                    layout.extend([group_id] * slot)
-                    remaining[group_id] -= slot
-                    progressed = True
-
-        # Defensive: complete with leftover pods, one per group per sweep.
-        # Unreachable for validated schedules (every size is a multiple
-        # of the EP slot).
-        if any(remaining.values()):
+        # Defensive crumb tail (bypassed validation only): append the
+        # sub-slot pods pod by pod in ascending group order.
+        missing = total - len(layout)
+        if missing > 0 and any(v > 0 for v in crumbs.values()):
             logger.warning(
-                "The ep_pp_dp soft group layout found leftover pods %s "
-                "outside whole EP slots (the schedule bypassed the EP "
-                "alignment validation); they are placed one per group per "
-                "sweep and their EP groups may straddle groups.",
-                {g: c for g, c in remaining.items() if c > 0},
+                "The ep_pp_dp soft group layout found %d sub-slot pod(s) "
+                "(the schedule bypassed the EP alignment validation); "
+                "they are appended pod by pod and their EP groups may "
+                "straddle.",
+                missing,
             )
-            while len(layout) < total and any(remaining.values()):
-                for group_id in list(remaining.keys()):
-                    if remaining[group_id] <= 0 or len(layout) >= total:
-                        continue
-                    layout.append(group_id)
-                    remaining[group_id] -= 1
+            for group_id in sorted(crumbs.keys()):
+                for _ in range(crumbs[group_id]):
+                    if len(layout) < total:
+                        layout.append(group_id)
 
         if len(layout) != total:
             raise ValueError(

--- a/dlrover/python/tests/test_soft_group.py
+++ b/dlrover/python/tests/test_soft_group.py
@@ -263,6 +263,300 @@ class ResolveSoftGroupIdTest(unittest.TestCase):
         )
         self.assertTrue(any("crossing groups" in log for log in logs.output))
 
+    def test_ep_pp_dp_unequal_sizes_per_stage_rotation(self):
+        # The ep_pp_dp rotation RESETS at every pipeline stage (virtual
+        # group) boundary instead of running globally: with sizes
+        # {1:4, 2:2, 3:2}, pp=2, ep_workers=2 the layout matches the
+        # requested segment placement — SG1 keeps its PP column
+        # intra-group (pods 0,1 <-> 4,5), and ONLY the odd-slot groups
+        # SG2/SG3 pair across stages (unavoidable with 1 slot each).
+        schedule = _soft(
+            strategy=NodeGroupStrategy.EP_PP_DP,
+            sizes={1: 4, 2: 2, 3: 2},
+            pp=2,
+            ep=16,
+        )
+        validate_soft_group_topology(schedule)
+        layout = [
+            resolve_soft_group_id(schedule, NodeType.WORKER, k)
+            for k in range(8)
+        ]
+        # stage 0 = [1,1, 2,2], stage 1 = [1,1, 3,3]
+        self.assertEqual(layout, [1, 1, 2, 2, 1, 1, 3, 3])
+        self.assertEqual([k for k in range(8) if layout[k] == 1], [0, 1, 4, 5])
+        self.assertEqual([k for k in range(8) if layout[k] == 2], [2, 3])
+        self.assertEqual([k for k in range(8) if layout[k] == 3], [6, 7])
+        # PP column alignment: same within-stage position maps to the
+        # same group except the odd-slot SG2/SG3 pair.
+        dp_nodes, pp = 4, 2
+        straddled = [
+            p
+            for p in range(dp_nodes)
+            if layout[p] != layout[pp * dp_nodes // 2 + p]
+        ]
+        self.assertEqual(straddled, [2, 3])
+        # All EP slots stay intra-group.
+        for start in range(0, 8, 2):
+            self.assertEqual(len(set(layout[start : start + 2])), 1)
+
+    def test_ep_pp_dp_greedy_column_packing_never_starves(self):
+        # {g1: 6, g2: 2, g3: 2} with 1-pod EP slots starves a per-stage
+        # round robin (the small groups drain in stage 0 and stage 1
+        # cannot be filled); the greedy column packing lays the world
+        # out fully: each pair of same-position slots forms a column
+        # owned by ONE group, so every PP column stays intra-group.
+        schedule = _soft(
+            strategy=NodeGroupStrategy.EP_PP_DP,
+            sizes={1: 6, 2: 2, 3: 2},
+            pp=2,
+            ep=8,
+        )
+        validate_soft_group_topology(schedule)
+        layout = [
+            resolve_soft_group_id(schedule, NodeType.WORKER, k)
+            for k in range(10)
+        ]
+        self.assertEqual(layout, [1, 1, 1, 2, 3, 1, 1, 1, 2, 3])
+        # columns: [1,1],[1,1],[1,1],[2,2],[3,3] -> column s-th slots
+        dp_nodes, pp = 5, 2
+        for position in range(dp_nodes):
+            self.assertEqual(
+                layout[position], layout[pp * 0 + dp_nodes + position]
+            )
+
+    def _check_scenario(
+        self,
+        sizes,
+        pp,
+        ep,
+        expected_layout,
+        mixed_columns,
+        ranks_per_node=8,
+    ):
+        """Assert a full ep_pp_dp scenario: the greedy column packing
+        produces exactly ``expected_layout`` (verified against the real
+        implementation), every group hosts its declared pod count, every
+        EP slot stays inside ONE group, and the number of PP columns
+        mixing two groups matches the theoretical minimum
+        (``ceil(odd_slot_groups / 2)`` plateaus) given by
+        ``mixed_columns`` (None skips the mixed-count assertion)."""
+        schedule = _soft(
+            strategy=NodeGroupStrategy.EP_PP_DP,
+            sizes=sizes,
+            pp=pp,
+            ep=ep,
+            ranks_per_node=ranks_per_node,
+        )
+        validate_soft_group_topology(schedule)
+        total = sum(sizes.values())
+        layout = [
+            resolve_soft_group_id(schedule, NodeType.WORKER, rank)
+            for rank in range(total)
+        ]
+        self.assertEqual(layout, expected_layout)
+        # every group keeps exactly its declared pod count
+        for group_id, size in sizes.items():
+            self.assertEqual(layout.count(group_id), size)
+        slot = ep // ranks_per_node
+        dp_nodes = total // pp
+        ep_groups = dp_nodes // slot
+        # every EP slot is single-group (never straddles a segment)
+        for stage in range(pp):
+            for de in range(ep_groups):
+                pods = [stage * dp_nodes + de * slot + i for i in range(slot)]
+                self.assertEqual(
+                    len({layout[p] for p in pods}),
+                    1,
+                    f"EP(s={stage}, de={de}) pods {pods} straddle",
+                )
+        if mixed_columns is None:
+            return
+        # compute the theoretical minimum of mixed PP columns
+        odd_slot_groups = sum(
+            1 for size in sizes.values() if (size // slot) % pp != 0
+        )
+        self.assertLessEqual(
+            mixed_columns,
+            (odd_slot_groups + 1) // 2,
+            "greedy column packing pays more mixed columns than the "
+            "pairing lower bound",
+        )
+        actual_mixed = 0
+        for de in range(ep_groups):
+            if any(
+                layout[stage * dp_nodes + de * slot]
+                != layout[(stage + 1) * dp_nodes + de * slot]
+                for stage in range(pp - 1)
+            ):
+                actual_mixed += 1
+        self.assertEqual(actual_mixed, mixed_columns)
+
+    def test_ep_pp_dp_scenario_matrix_legal(self):
+        # A spectrum of legal topologies: single group, equal sizes,
+        # unequal multiples of 4, pp=4, four segments, 1-pod slots...
+        # (expected layouts verified against the real implementation).
+        self._check_scenario(
+            sizes={7: 8},
+            pp=2,
+            ep=16,
+            expected_layout=[7] * 8,
+            mixed_columns=0,
+        )
+        self._check_scenario(
+            sizes={1: 2, 2: 2},
+            pp=2,
+            ep=8,
+            expected_layout=[1, 2, 1, 2],
+            mixed_columns=0,
+        )
+        self._check_scenario(
+            sizes={1: 8, 2: 8},
+            pp=2,
+            ep=16,
+            expected_layout=[1, 1, 2, 2, 1, 1, 2, 2, 1, 1, 2, 2, 1, 1, 2, 2],
+            mixed_columns=0,
+        )
+        self._check_scenario(
+            sizes={1: 8, 2: 4},
+            pp=2,
+            ep=16,
+            expected_layout=[1, 1, 1, 1, 2, 2, 1, 1, 1, 1, 2, 2],
+            mixed_columns=0,
+        )
+        self._check_scenario(
+            sizes={1: 8, 2: 4, 3: 4},
+            pp=4,
+            ep=8,
+            expected_layout=[1, 1, 2, 3, 1, 1, 2, 3, 1, 1, 2, 3, 1, 1, 2, 3],
+            mixed_columns=0,
+        )
+        self._check_scenario(
+            sizes={1: 2, 2: 2, 3: 2, 4: 2},
+            pp=2,
+            ep=8,
+            expected_layout=[1, 2, 3, 4, 1, 2, 3, 4],
+            mixed_columns=0,
+        )
+        self._check_scenario(
+            sizes={1: 12, 2: 8, 3: 8},
+            pp=2,
+            ep=16,
+            expected_layout=[
+                1,
+                1,
+                1,
+                1,
+                2,
+                2,
+                3,
+                3,
+                1,
+                1,
+                2,
+                2,
+                3,
+                3,
+                1,
+                1,
+                1,
+                1,
+                2,
+                2,
+                3,
+                3,
+                1,
+                1,
+                2,
+                2,
+                3,
+                3,
+            ],
+            mixed_columns=0,
+        )
+        # two odd-slot groups: the two residual EP slots pair in ONE
+        # mixed column (the theoretical minimum).
+        self._check_scenario(
+            sizes={1: 6, 2: 6, 3: 4},
+            pp=2,
+            ep=16,
+            expected_layout=[1, 1, 2, 2, 3, 3, 1, 1, 1, 1, 2, 2, 3, 3, 2, 2],
+            mixed_columns=1,
+        )
+        # the user-provided S2/S3 shapes
+        self._check_scenario(
+            sizes={1: 4, 2: 2, 3: 2},
+            pp=2,
+            ep=16,
+            expected_layout=[1, 1, 2, 2, 1, 1, 3, 3],
+            mixed_columns=1,
+        )
+        self._check_scenario(
+            sizes={1: 6, 2: 4, 3: 2},
+            pp=2,
+            ep=16,
+            expected_layout=[1, 1, 2, 2, 1, 1, 1, 1, 2, 2, 3, 3],
+            mixed_columns=1,
+        )
+        # the fragment-pairing minimum with 1-pod EP slots: the three
+        # whole columns and the two 1-slot residual fragments pair up
+        # in the last column — ONE mixed column (a descending chained
+        # fill pays two).
+        self._check_scenario(
+            sizes={1: 3, 2: 3, 3: 2},
+            pp=2,
+            ep=8,
+            expected_layout=[1, 2, 3, 1, 1, 2, 3, 2],
+            mixed_columns=1,
+        )
+        # the starvation counter-example with 1-pod slots: a per-stage
+        # round robin drains the small groups in stage 0; the greedy
+        # column packing lays the world out fully.
+        self._check_scenario(
+            sizes={1: 6, 2: 2, 3: 2},
+            pp=2,
+            ep=8,
+            expected_layout=[1, 1, 1, 2, 3, 1, 1, 1, 2, 3],
+            mixed_columns=0,
+        )
+
+    def test_ep_pp_dp_scenario_matrix_invalid(self):
+        # A spectrum of illegal topologies rejected by the start-up
+        # validation, each failing fast with its own message.
+        invalid_cases = [
+            # dense_dp = 10*8/2 = 40 not divisible by EP=16 (N must be
+            # a multiple of 4 for pp=2, ep=16, R=8)
+            ({1: 6, 2: 2, 3: 2}, 2, 16, "divisible by EP"),
+            # group 1 has 3 pods, not a multiple of the EP slot (2)
+            ({1: 3, 2: 3, 3: 2}, 2, 16, "ep_workers=2"),
+            # N=6 -> dense_dp=24 not divisible by EP=16
+            ({1: 4, 2: 2}, 2, 16, "divisible by EP"),
+        ]
+        for sizes, pp, ep, pattern in invalid_cases:
+            schedule = _soft(
+                strategy=NodeGroupStrategy.EP_PP_DP,
+                sizes=sizes,
+                pp=pp,
+                ep=ep,
+            )
+            with self.assertRaisesRegex(ValueError, pattern):
+                validate_soft_group_topology(schedule)
+        # EP=12 passes dense_dp divisibility (48 % 12 == 0) but is not
+        # a multiple of R=8: an EP slot would not consist of whole nodes
+        schedule = _soft(
+            strategy=NodeGroupStrategy.EP_PP_DP,
+            sizes={1: 6, 2: 6},
+            pp=2,
+            ep=12,
+        )
+        with self.assertRaisesRegex(
+            ValueError, "EP=12 to be divisible by ranks_per_node"
+        ):
+            validate_soft_group_topology(schedule)
+        # declared N mismatches the sum of sizes
+        schedule = _soft(sizes={1: 4, 2: 4}, pp=2, ep=16, num_nodes=7)
+        with self.assertRaisesRegex(ValueError, "sum to 8"):
+            validate_soft_group_topology(schedule)
+
     def test_ep_pp_dp_layout_built_once(self):
         schedule = _soft(
             strategy=NodeGroupStrategy.EP_PP_DP,


### PR DESCRIPTION
## What

Rework the `ep_pp_dp` soft-group layout (from #1743) into a **greedy EP-slot packing into PP columns**, replacing the per-stage round robin.

## Why

1. **Wrong packing on unequal sizes.** The per-stage round robin rotates groups independently inside every pipeline stage. With `pp=2`, sizes `{1: 4, 2: 2, 3: 2}`, `EP=16`, `R=8` this landed pods as `[1,1,2,2 | 1,1,2,2]` + `[3,3 …]` — actually `[1,1,2,2|3,3,1,1]` (group 3 hijacking position 0 of stage 1), producing **four cross-segment PP hops** (pods `0↔4, 1↔5, 2↔6, 3↔7` every pair crossed).
2. **Can fail outright on valid topologies.** `{g1: 6, g2: 2, g3: 2}` with `pp=2` and 1-pod EP slots passes every start-up check but the per-stage rotation drains the small groups inside stage 0 and stage 1 cannot be filled — a hard layout error.
3. **User-facing spec** (2026-09-10): treat the layout as EP-slot packing where **each pipeline stage's EP-pp column is a unit**, and greedily give the whole column to the group with the most remaining slots (ties by smallest id), filling column by column.

## How (algorithm)

```
columns C = DP_nodes / ep_workers (one slot position per stage)
column capacity = pp EP slots (each slot = ep_workers consecutive pods)
for col in 0..C-1:
    while column not full and any group has whole slots left:
        pick group with MOST remaining slots (tie: smallest id)
        place min(remaining, capacity) slots of it in this column
```

Properties:
- **A group with >= pp remaining slots occupies whole columns** → its PP column is intra-segment, **zero cross-segment PP hops**.
- **Residual fragments (`s_g % pp != 0`) pair up** in the tail columns (fragment-deferring FFD) → the number of mixed columns reaches the theoretical minimum ⌈odd-slot-groups / 2⌉ (verified per scenario: `{3,3,2}` pp=2 packs as `[aa][bb][cc][ab]` — ONE mixed column; a descending chained fill pays two).
- **Global inventory never starves a late stage**: the whole column budget `pp * C * ep_workers` is covered by `sum(sizes)` (any schedule passing the start-up validation is guaranteed to lay out fully), fixing bug (2).
- **Equal sizes degenerate to the previous rotation sequence** bit-for-bit — the #1745 opaque stripe parity and the 9216-card invariant tests still pass unchanged.
- EP invariants unchanged: every EP slot is single-group, every group hosts exactly its declared pod count.

## Tests (`test_soft_group.py`, now 25 cases)

- **Scenario matrix (legal, 12 entr cases)** — verified against the live implementation, each asserting: exact layout, per-group pod counts, EP slots single-segment, mixed-PP-columns = theoretical minimum:
  `{1:4,2:2,3:2}`→`SG1={0,1,4,5} SG2={2,3} SG3={6,7}` mixed=1、`{1:6,2:4,3:2}`（dp=3） mixed=1、`{1:6,2:6,3:4}` mixed=1、`{1:8,2:8}`/`{1:2,2:2}`/`{7:8}`（单组）/`{1:2,2:2,3:2,4:2}`（四段）/`{1:8,2:4}`/`{1:8,2:4,3:4}`（pp=4）/`{1:12,2:8,3:8}` mixed=0、碎片配对 `{1:3,2:3,3:2}` ep=8 mixed=1、饥饿反例 `{1:6,2:2,3:2}` ep=8 mixed=0。
- **Scenario matrix (in valid, 5 cases)** — each rejected start-up fast with its own message: `{1:6,2:2,3:2}`+ep16（dense_dp=40 不被 EP 整除）、`{1:3,2:3,3:2}`+ep16（3 不是 EP 槽 2 的倍数）、`{1:4,2:2}`+ep16（N=6 dense_dp=24）、`{1:6,2:6}`+ep12（EP=12 不被 R=8 整除）、`{1:4,2:4}`+N=7（sum 与 N 不匹配）。
- Retained from #1743: unequal per-stage layout, stripe parity (contiguous + opaque ids), 9216 invariants, leftover crumbs warning, layout caching.

## Verification

- `pytest dlrover/python/tests/test_soft_group.py test_node_group_strategy.py test_args.py` — **56 passed**
- `pytest dlrover/python/tests/test_pod_scaler.py` — **20 passed**
- pre-commit hooks (ruff, mypy, copyright) all pass
- Per-scenario `EP`/`PP`/`DP` group tables printed and verified (EP cross-segment = 0 in all legal cases, PP mixed-count = minimum, DP = whole stage, cross-segment by design)