### PR TITLE
Feat(scheduler): add k8sClient.patch_images_to_pod for in-place image update

### DIFF
--- a/dlrover/python/scheduler/kubernetes.py
+++ b/dlrover/python/scheduler/kubernetes.py
@@ -294,6 +294,30 @@ class k8sClient(Singleton):
         )
 
     @retry_k8s_request
+    def patch_images_to_pod(self, name, images: Dict[str, str]):
+        """Patch images of named containers in a Pod.
+
+        The Pod is not recreated: the kubelet updates the container
+        image in place, so the Pod keeps its IP, labels and env.
+
+        Args:
+            name: str, the pod name.
+            images: dict, the key is the container name and the
+                value is the new image.
+        """
+        body = {
+            "spec": {
+                "containers": [
+                    {"name": container_name, "image": image}
+                    for container_name, image in images.items()
+                ]
+            }
+        }
+        return self.client.patch_namespaced_pod(
+            name=name, namespace=self._namespace, body=body
+        )
+
+    @retry_k8s_request
     def get_pod_annotation(self, name, key) -> str:
         """Get a specific annotation value of a Pod.
 

--- a/dlrover/python/tests/test_k8s.py
+++ b/dlrover/python/tests/test_k8s.py
@@ -225,6 +225,45 @@ class K8sClientTest(unittest.TestCase):
             "",
         )
 
+    def test_patch_images_to_pod(self):
+        k8s_client = k8sClient.singleton_instance("default")
+        k8s_client.client.patch_namespaced_pod = MagicMock(
+            return_value=client.V1Pod(
+                metadata=client.V1ObjectMeta(name="test-pod")
+            )
+        )
+        images = {
+            "main": "dlrover/trainer:v2",
+            "sidecar": "dlrover/sidecar:v3",
+        }
+        result = k8sClient.patch_images_to_pod(k8s_client, "test-pod", images)
+        self.assertEqual(result.metadata.name, "test-pod")
+        body = {
+            "spec": {
+                "containers": [
+                    {"name": "main", "image": "dlrover/trainer:v2"},
+                    {"name": "sidecar", "image": "dlrover/sidecar:v3"},
+                ]
+            }
+        }
+        k8s_client.client.patch_namespaced_pod.assert_called_once_with(
+            name="test-pod", namespace="default", body=body
+        )
+
+    @patch("dlrover.python.scheduler.kubernetes.time.sleep")
+    def test_patch_images_to_pod_failure(self, mock_sleep):
+        k8s_client = k8sClient.singleton_instance("default")
+        k8s_client.client.patch_namespaced_pod = MagicMock(
+            side_effect=client.rest.ApiException(
+                status=500, reason="Internal Server Error"
+            )
+        )
+        result = k8sClient.patch_images_to_pod(
+            k8s_client, "test-pod", {"main": "dlrover/trainer:v2"}
+        )
+        self.assertIsNone(result)
+        mock_sleep.assert_called()
+
     def test_delete_custom_resource_not_found(self):
         k8s_client = k8sClient.singleton_instance("default")
         k8s_client.api_instance = MagicMock()


### PR DESCRIPTION
## What

Add `k8sClient.patch_images_to_pod(name, images)` which patches the images
of named containers in a Pod via `patch_namespaced_pod`. The kubelet
updates the container in place, so the Pod keeps its name, IP, labels and
env.

## Why

The internal Ant master (dlrover-addon) watches the training job CRD.
When a user updates the worker image, the master first refreshes the
in-memory JobResource image (so later relaunch/scale-up also uses the new
image) and then patches every worker Pod's main container in place
instead of recreating the Pods. This upstream method is the k8s API
primitive that flow needs; it mirrors the existing
`patch_labels_to_pod` / `patch_annotations_to_pod` pattern
(`@retry_k8s_request` + `patch_namespaced_pod`).

## Implementation

- `patch_images_to_pod(name, images: Dict[str, str])`: the body only
  touches `spec.containers` images listed in the `images` mapping
  (container name -> image), so init containers and sidecars are left
  untouched.
- Unit tests in `test_k8s.py`: the success path asserts the exact patch
  body and namespace; the failure path asserts the retry-exhausted —>
  `None` behavior of `@retry_k8s_request`.